### PR TITLE
Fix SKY130 timing simulation CI path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,13 +248,13 @@ jobs:
           # that the netlist parses correctly and the simulator runs.
           #
           # To test with real timing values, run locally with:
-          # cargo run -r --bin timing_sim_cpu -- tests/timing_test/6_final.v \
+          # cargo run -r --bin timing_sim_cpu -- tests/timing_test/minimal_build/6_final.v \
           #   tests/timing_test/6_final_test_input.vcd --clock-period 25000 \
           #   --liberty path/to/sky130_fd_sc_hd__tt_025C_1v80.lib
 
           # Build command arguments (using default timing values)
           ARGS=(
-            tests/timing_test/6_final.v
+            tests/timing_test/minimal_build/6_final.v
             tests/timing_test/6_final_test_input.vcd
             --clock-period 25000
             --max-cycles 10


### PR DESCRIPTION
## Summary
- Fix incorrect netlist file path in SKY130 Timing Simulation CI job
- The workflow referenced `tests/timing_test/6_final.v` but the file is at `tests/timing_test/minimal_build/6_final.v`
- This caused the job to panic with "No such file or directory" on every CI run

## Test plan
- [ ] Verify SKY130 Timing Simulation CI job passes after this fix