### PR TITLE
Update README and usage docs for ChipFlow fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,95 @@
-# Welcome to GEM
-GEM is an open-source RTL logic simulator with CUDA acceleration, developed and maintained by NVIDIA Research.
-GEM can deliver up to 5--40X speed-up compared to CPU-based leading RTL simulators.
-A summary of the work with paper can be found [here](https://research.nvidia.com/publication/2025-06_gem-gpu-accelerated-emulator-inspired-rtl-simulation).
+# Loom
 
-## Compile and Run Your Design with GEM
-GEM works in a way similar to an FPGA-based RTL emulator.
-It first synthesizes your design with a special and-inverter graph (AIG) process, and then map the synthesized gate-level netlist to a virtual manycore Boolean processor which can be emulated with CUDA-compatible GPUs.
+Loom is a GPU-accelerated RTL logic simulator. Like a Jacquard loom weaving patterns from punched cards, Loom maps gate-level netlists onto a virtual manycore Boolean processor and executes them on GPUs, delivering 5-40X speedup over CPU-based RTL simulators.
 
-The synthesis and mapping is slower than the compiling/elaboration process of CPU-based simulators. But it is a one-time cost and your design can be simulated under different testbenches without re-running the synthesis or mapping.
+Loom builds on the excellent [GEM](https://github.com/NVlabs/GEM) research by Zizheng Guo, Yanqing Zhang, Runsheng Wang, Yibo Lin, and Haoxing Ren at NVIDIA Research. [ChipFlow](https://chipflow.io) extends their work with:
 
-**See [usage.md](./usage.md) for usage documentation.**
+- **Metal backend** for Apple Silicon Macs (in addition to the original CUDA backend)
+- **Liberty timing support** - load real cell delays from Liberty files (e.g. SKY130) for timing analysis and CPU-based timing simulation. GPU timing-annotated simulation is on the roadmap (see below).
+- **Significant performance optimizations** to the partition mapping pipeline
+- **CI/CD** with automated testing across both backends
+
+### Roadmap: Timing Simulation
+
+The goal is GPU-accelerated gate-level simulation with real cell timing - a first for open source. Current status:
+
+| Component | Status |
+|-----------|--------|
+| Liberty file parsing | Done - loads SKY130 HD cell delays |
+| Gate delay computation | Done - per-AIG-pin delays from Liberty |
+| CPU timing simulation | WIP - basic arrival time propagation works, hold checking needs fixes |
+| GPU timing simulation | Not started - delay buffers not yet passed to GPU kernel |
+| SKY130 timing test suite | WIP - small test circuits in `tests/timing_test/sky130_timing/` |
+
+Next steps:
+1. Fix CPU timing sim hold violation false positives (zero-delay paths through AIG inverter collapse)
+2. Validate CPU timing against analytical expectations using SKY130 test circuits
+3. Pass `gate_delays` buffer to GPU kernel and implement delay accumulation in the shader
+4. Compare GPU timing results against validated CPU reference
+
+## Quick Start
+
+Requires the [Rust toolchain](https://rustup.rs/).
+
+```sh
+git clone https://github.com/ChipFlow/GEM.git
+cd GEM
+git submodule update --init --recursive
+```
+
+### Build (Metal - macOS)
+
+```sh
+cargo build -r --features metal --bin cut_map_interactive
+cargo build -r --features metal --bin metal_test
+```
+
+### Build (CUDA - Linux)
+
+Requires CUDA toolkit installed.
+
+```sh
+cargo build -r --features cuda --bin cut_map_interactive
+cargo build -r --features cuda --bin cuda_test
+```
+
+## Usage
+
+Loom operates in two phases:
+
+1. **Map** your synthesized gate-level netlist to a `.gemparts` file (one-time cost):
+
+```sh
+cargo run -r --features metal --bin cut_map_interactive -- design.gv design.gemparts
+```
+
+2. **Simulate** with a VCD input waveform:
+
+```sh
+# Metal (macOS) - use NUM_BLOCKS=1
+cargo run -r --features metal --bin metal_test -- design.gv design.gemparts input.vcd output.vcd 1
+
+# CUDA (Linux) - set NUM_BLOCKS to 2x your GPU's SM count
+cargo run -r --features cuda --bin cuda_test -- design.gv design.gemparts input.vcd output.vcd NUM_BLOCKS
+```
+
+**See [usage.md](./usage.md) for full documentation** including synthesis preparation, VCD scope handling, and troubleshooting.
+
+## Limitations
+
+- Only supports non-interactive testbenches (static VCD input waveforms)
+- Synchronous logic only (no latches or async sequential logic)
+- Clock gates must use the `CKLNQD` module from `aigpdk.v`
+
+## Benchmarks
+
+Pre-synthesized benchmark designs are in `benchmarks/dataset/` (git submodule). See [benchmarks/README.md](benchmarks/README.md) for instructions.
+
+Available designs: NVDLA, Rocket, Gemmini.
 
 ## Citation
-Please cite our paper if you find GEM useful.
+
+Loom builds on the GEM research. Please cite the original paper if you find this work useful.
 
 ``` bibtex
 @inproceedings{gem,
@@ -23,3 +100,7 @@ Please cite our paper if you find GEM useful.
  year = {2025}
 }
 ```
+
+## License
+
+See [LICENSE](./LICENSE) for details.

--- a/tests/timing_test/.gitignore
+++ b/tests/timing_test/.gitignore
@@ -17,3 +17,5 @@ gem_output*.vcd
 !dff_test.vcd
 !dff_test.gemparts
 !dff_test_synth.gv
+!sky130_timing/*.v
+!sky130_timing/*.vcd

--- a/tests/timing_test/sky130_timing/README.md
+++ b/tests/timing_test/sky130_timing/README.md
@@ -1,0 +1,56 @@
+# SKY130 Timing Test Suite
+
+Small test circuits using SKY130 HD standard cells with analytically
+verifiable timing properties. These serve as ground truth for validating
+Loom's timing simulation (both CPU and GPU paths).
+
+## Test Circuits
+
+### 1. `inv_chain.v` - Inverter Chain
+- **Circuit**: DFF -> 16 inverters (sky130_fd_sc_hd__inv_1) -> DFF
+- **Logic function**: Identity (even number of inversions)
+- **Expected combo delay**: 16 x inv_delay (from Liberty)
+- **Expected arrival at capture DFF**: clk_to_q + 16 x inv_delay
+- **Purpose**: Validates basic delay accumulation through a linear chain
+
+### 2. `logic_cone.v` - Convergent Logic Cone
+- **Circuit**: 4 DFFs -> tree of nand2/nor2/and2 gates -> DFF
+- **Logic function**: Specific Boolean function of 4 inputs
+- **Expected combo delay**: Critical path through deepest branch
+- **Purpose**: Validates max-of-inputs arrival time propagation
+
+### 3. `setup_violation.v` - Setup Time Violation
+- **Circuit**: Same as inv_chain but designed to violate setup at tight clock
+- **Expected**: TIMING PASSED at 10ns clock, TIMING FAILED at 1ns clock
+- **Purpose**: Validates setup/hold checking
+
+## Generating Reference Values
+
+The expected timing values are computed analytically from the SKY130 HD
+Liberty file (sky130_fd_sc_hd__tt_025C_1v80.lib). Key values at typical corner:
+
+| Parameter | Value (ps) |
+|-----------|-----------|
+| inv_1 tpd (rise) | ~28 |
+| inv_1 tpd (fall) | ~18 |
+| nand2_1 tpd | ~30-40 |
+| and2_1 tpd | ~50-60 |
+| dfxtp_1 clk->Q | ~310 |
+| dfxtp_1 setup | ~80 |
+| dfxtp_1 hold | ~-40 |
+
+Note: Actual values depend on load capacitance and input transition time.
+The defaults in `TimingLibrary::default_sky130()` are approximate.
+
+## Running
+
+```sh
+# Run with default SKY130 timing values
+cargo run -r --bin timing_sim_cpu -- tests/timing_test/sky130_timing/inv_chain.v \
+    tests/timing_test/sky130_timing/inv_chain.vcd --clock-period 10000
+
+# Run with real Liberty file (if available)
+cargo run -r --bin timing_sim_cpu -- tests/timing_test/sky130_timing/inv_chain.v \
+    tests/timing_test/sky130_timing/inv_chain.vcd --clock-period 10000 \
+    --liberty path/to/sky130_fd_sc_hd__tt_025C_1v80.lib
+```

--- a/tests/timing_test/sky130_timing/inv_chain.v
+++ b/tests/timing_test/sky130_timing/inv_chain.v
@@ -1,0 +1,48 @@
+/* SKY130 Timing Test 1: Inverter Chain
+ * dfxtp -> 16 x inv_1 -> dfxtp
+ *
+ * Expected combo delay (default SKY130): 16 x 50ps = 800ps
+ * Expected arrival at D2: clk_to_q(150ps) + 800ps = 950ps
+ * Min clock period: 950ps + setup(80ps) = 1030ps
+ */
+
+module inv_chain(CLK, D, Q);
+  input CLK;
+  wire CLK;
+  input D;
+  wire D;
+  output Q;
+  wire Q;
+  wire q1;
+  wire [15:0] c;
+
+  sky130_fd_sc_hd__dfxtp_1 dff_in (
+    .CLK(CLK),
+    .D(D),
+    .Q(q1)
+  );
+
+  sky130_fd_sc_hd__inv_1 i0  (.A(q1),    .Y(c[0]));
+  sky130_fd_sc_hd__inv_1 i1  (.A(c[0]),  .Y(c[1]));
+  sky130_fd_sc_hd__inv_1 i2  (.A(c[1]),  .Y(c[2]));
+  sky130_fd_sc_hd__inv_1 i3  (.A(c[2]),  .Y(c[3]));
+  sky130_fd_sc_hd__inv_1 i4  (.A(c[3]),  .Y(c[4]));
+  sky130_fd_sc_hd__inv_1 i5  (.A(c[4]),  .Y(c[5]));
+  sky130_fd_sc_hd__inv_1 i6  (.A(c[5]),  .Y(c[6]));
+  sky130_fd_sc_hd__inv_1 i7  (.A(c[6]),  .Y(c[7]));
+  sky130_fd_sc_hd__inv_1 i8  (.A(c[7]),  .Y(c[8]));
+  sky130_fd_sc_hd__inv_1 i9  (.A(c[8]),  .Y(c[9]));
+  sky130_fd_sc_hd__inv_1 i10 (.A(c[9]),  .Y(c[10]));
+  sky130_fd_sc_hd__inv_1 i11 (.A(c[10]), .Y(c[11]));
+  sky130_fd_sc_hd__inv_1 i12 (.A(c[11]), .Y(c[12]));
+  sky130_fd_sc_hd__inv_1 i13 (.A(c[12]), .Y(c[13]));
+  sky130_fd_sc_hd__inv_1 i14 (.A(c[13]), .Y(c[14]));
+  sky130_fd_sc_hd__inv_1 i15 (.A(c[14]), .Y(c[15]));
+
+  sky130_fd_sc_hd__dfxtp_1 dff_out (
+    .CLK(CLK),
+    .D(c[15]),
+    .Q(Q)
+  );
+
+endmodule

--- a/tests/timing_test/sky130_timing/inv_chain.vcd
+++ b/tests/timing_test/sky130_timing/inv_chain.vcd
@@ -1,0 +1,57 @@
+$date
+	Mon Feb 16 00:00:00 2026
+$end
+$version
+	Timing test VCD
+$end
+$timescale
+	1ps
+$end
+$scope module inv_chain $end
+$var wire 1 ! CLK $end
+$var wire 1 " D $end
+$var wire 1 # Q $end
+$upscope $end
+$enddefinitions $end
+#0
+$dumpvars
+0!
+0"
+x#
+$end
+#5000
+1!
+#10000
+0!
+#10001
+1"
+#15000
+1!
+#20000
+0!
+#25000
+1!
+#30000
+0!
+#30001
+0"
+#35000
+1!
+#40000
+0!
+#45000
+1!
+#50000
+0!
+#55000
+1!
+#60000
+0!
+#65000
+1!
+#70000
+0!
+#75000
+1!
+#80000
+0!

--- a/tests/timing_test/sky130_timing/logic_cone.v
+++ b/tests/timing_test/sky130_timing/logic_cone.v
@@ -1,0 +1,38 @@
+/* SKY130 Timing Test 2: Convergent Logic Cone
+ * 4 dfxtp -> tree of nand2/nor2/and2 -> dfxtp
+ *
+ * Critical path: a_q -> nand2 -> and2 -> nand2 -> inv (depth 4)
+ * Expected combo delay (default): 4 x 50ps = 200ps
+ * Expected arrival: 150ps + 200ps = 350ps
+ */
+
+module logic_cone(CLK, A, B, C, D_IN, Q);
+  input CLK;
+  wire CLK;
+  input A;
+  wire A;
+  input B;
+  wire B;
+  input C;
+  wire C;
+  input D_IN;
+  wire D_IN;
+  output Q;
+  wire Q;
+  wire a_q, b_q, c_q, d_q;
+  wire n1, n2, a1, n3, result;
+
+  sky130_fd_sc_hd__dfxtp_1 dff_a (.CLK(CLK), .D(A),    .Q(a_q));
+  sky130_fd_sc_hd__dfxtp_1 dff_b (.CLK(CLK), .D(B),    .Q(b_q));
+  sky130_fd_sc_hd__dfxtp_1 dff_c (.CLK(CLK), .D(C),    .Q(c_q));
+  sky130_fd_sc_hd__dfxtp_1 dff_d (.CLK(CLK), .D(D_IN), .Q(d_q));
+
+  sky130_fd_sc_hd__nand2_1 g1 (.A(a_q), .B(b_q), .Y(n1));
+  sky130_fd_sc_hd__nor2_1  g2 (.A(c_q), .B(d_q), .Y(n2));
+  sky130_fd_sc_hd__and2_1  g3 (.A(n1),  .B(n2),  .X(a1));
+  sky130_fd_sc_hd__nand2_1 g4 (.A(a1),  .B(a_q), .Y(n3));
+  sky130_fd_sc_hd__inv_1   g5 (.A(n3),  .Y(result));
+
+  sky130_fd_sc_hd__dfxtp_1 dff_out (.CLK(CLK), .D(result), .Q(Q));
+
+endmodule

--- a/tests/timing_test/sky130_timing/logic_cone.vcd
+++ b/tests/timing_test/sky130_timing/logic_cone.vcd
@@ -1,0 +1,62 @@
+$date
+	Mon Feb 16 00:00:00 2026
+$end
+$version
+	Timing test VCD
+$end
+$timescale
+	1ps
+$end
+$scope module logic_cone $end
+$var wire 1 ! CLK $end
+$var wire 1 " A $end
+$var wire 1 # B $end
+$var wire 1 $ C $end
+$var wire 1 % D_IN $end
+$var wire 1 & Q $end
+$upscope $end
+$enddefinitions $end
+#0
+$dumpvars
+0!
+0"
+0#
+0$
+0%
+x&
+$end
+#5000
+1!
+#10000
+0!
+#10001
+1"
+1#
+1$
+1%
+#15000
+1!
+#20000
+0!
+#25000
+1!
+#30000
+0!
+#30001
+0$
+0%
+#35000
+1!
+#40000
+0!
+#40001
+1$
+0"
+#45000
+1!
+#50000
+0!
+#55000
+1!
+#60000
+0!

--- a/usage.md
+++ b/usage.md
@@ -1,6 +1,6 @@
-# Getting Started to use GEM
+# Getting Started with Loom
 
-**Caveats**: currently GEM only supports non-interactive testbenches. This means the input to the circuit needs to be a static waveform (e.g., VCD). Registers and clock gates inside the circuit are allowed, but latches and other asynchronous sequential logics are currently unsupported.
+**Caveats**: Loom currently only supports non-interactive testbenches. This means the input to the circuit needs to be a static waveform (e.g., VCD). Registers and clock gates inside the circuit are allowed, but latches and other asynchronous sequential logics are currently unsupported.
 
 **Dataset**: Some (namely, netlists after AIG transformation in Steps 1-2 below, and reference VCDs) input data is available [here](https://drive.google.com/drive/folders/1M42vFoVZhG4ZjyD1hqYD0Hrw8F1rwNXd?usp=drive_link) .
 
@@ -35,11 +35,11 @@ memory_libmap -lib path/to/memlib_yosys.txt -logic-cost-rom 100 -logic-cost-ram 
 
 The `memory_libmap` command will output a list of RAMs it found and mapped.
 
-- If you see `$__RAMGEM_SYNC_`, it means the mapping is successful.
+- If you see `$__RAMGEM_SYNC_` (naming inherited from GEM), it means the mapping is successful.
 - If you see `$__RAMGEM_ASYNC_`, it means this RAM is found to have asynchronous READ port. You need to confirm if it is the case.
   - If it is a synchronous one but accidentally recognized as asynchronous, you might need to patch the RTL code to fix it. There might be multiple reasons it cannot be recognized as synchronous. For example, [when the read and write clocks are different](https://github.com/YosysHQ/yosys/issues/4521).
   - If it is indeed asynchronous, check its size. If its size is very small and affordable to be synthesized using registers and mux trees (which is *very* expensive for large RAM banks), you can remove the `$__RAMGEM_ASYNC_` block in `memlib_yosys.txt`, re-run Yosys to force the use of registers.
-- If you see `using FF mapping for memory`, it means the memory is recognized, but due to it being nonstandard (e.g., special global reset or nontrivial initialization), GEM will fall back to registers and mux trees. If the size of the memory is small, this is usually not an issue. Otherwise, you are advised to try other implementations.
+- If you see `using FF mapping for memory`, it means the memory is recognized, but due to it being nonstandard (e.g., special global reset or nontrivial initialization), Loom will fall back to registers and mux trees. If the size of the memory is small, this is usually not an issue. Otherwise, you are advised to try other implementations.
 
 After a successful mapping, use the following command to write out the mapped RTL as a single Verilog file.
 ``` tcl
@@ -50,7 +50,7 @@ Check the correctness of this step by simulating `memory_mapped.v` with your ref
 
 ## Step 2. Logic Synthesis
 This step maps all combinational and sequential logic into a special set of standard cells we defined in `aigpdk.lib`.
-The quality of synthesis is directly tied to GEM's final performance, so we suggest you use a commercial synthesis tool like DC. You can also use Yosys to complete this if you do not have access to a commercial synthesis tool.
+The quality of synthesis is directly tied to Loom's final performance, so we suggest you use a commercial synthesis tool like DC. You can also use Yosys to complete this if you do not have access to a commercial synthesis tool.
 
 Check the correctness of this step by simulating `gatelevel.gv` with your reference CPU simulator.
 
@@ -70,7 +70,7 @@ read_file -format db $target_library
 # elaborate TOP_MODULE
 # current_design TOP_MODULE
 
-# timing settings like create_clock ... are recommended. GEM benefits from timing-driven synthesis.
+# timing settings like create_clock ... are recommended. Loom benefits from timing-driven synthesis.
 
 compile_ultra -no_seq_output_inversion -no_autoungroup
 optimize_netlist -area
@@ -101,32 +101,42 @@ opt_clean -purge
 write_verilog gatelevel.gv
 ```
 
-## Step 3. Download and Compile GEM
-Make sure CUDA is installed on your Linux machine.
+## Step 3. Download and Compile Loom
 
-Download and install Rust toolchain. This is as simple as a one-liner in your terminal. We recommend [https://rustup.rs](https://rustup.rs/).
+Download and install the Rust toolchain. This is as simple as a one-liner in your terminal. We recommend [https://rustup.rs](https://rustup.rs/).
 
-Clone GEM along with its dependency.
+Clone Loom along with its dependencies.
 ``` sh
-git clone https://github.com/NVlabs/GEM.git
+git clone https://github.com/ChipFlow/GEM.git
 cd GEM
 git submodule update --init --recursive
 ```
 
-GEM comes with a `cut_map_interactive` command and a `cuda_test` command, that correspond to `compile` and `simulate` steps of a classical CPU simulator. See their help usage with the following command under `GEM`:
-``` sh
-cargo run -r --features cuda --bin cut_map_interactive -- --help
+Loom supports two GPU backends: **CUDA** (NVIDIA GPUs on Linux) and **Metal** (Apple Silicon Macs).
 
+Loom comes with a `cut_map_interactive` command and a simulator command (`cuda_test` or `metal_test`), that correspond to `compile` and `simulate` steps of a classical CPU simulator. See their help usage:
+
+``` sh
+# Metal (macOS)
+cargo run -r --features metal --bin cut_map_interactive -- --help
+cargo run -r --features metal --bin metal_test -- --help
+
+# CUDA (Linux, requires CUDA toolkit)
+cargo run -r --features cuda --bin cut_map_interactive -- --help
 cargo run -r --features cuda --bin cuda_test -- --help
 ```
 
-## Map the Design with GEM
-~~GEM depends on an external hypergraph partitioner binary. We recommend hmetis 2.0. You can download its binary and put it in a proper location.~~
-GEM no longer depends on an external hypergraph partitioner. We now compile and link to [mt-kahypar-sc](https://github.com/gzz2000/mt-kahypar-sc) automatically. This is experimental and if you encounter partitioning issue you can raise it to us.
+## Map the Design with Loom
+
+Loom compiles and links to [mt-kahypar-sc](https://github.com/gzz2000/mt-kahypar-sc) for hypergraph partitioning automatically.
 
 Run the following command to start the Boolean processor mapping.
 
 ``` sh
+# Metal (macOS)
+cargo run -r --features metal --bin cut_map_interactive -- path/to/gatelevel.gv path/to/result.gemparts
+
+# CUDA (Linux)
 cargo run -r --features cuda --bin cut_map_interactive -- path/to/gatelevel.gv path/to/result.gemparts
 ```
 
@@ -135,15 +145,32 @@ The mapped result will be stored in a binary file `result.gemparts`.
 If the mapping failed due to failure to partition deep circuits (which often shows as trying to partition a circuit with only 0 or 1 endpoints), try adding a `--level-split` option to force a stage split. For example `--level-split 30` or `--level-split 20,40`. If you used this, remember to add the same `--level-split` option when you simulate.
 
 ## Simulate the Design
-Run the following. Replace `NUM_BLOCKS` with twice the number of physical streaming multiprocessors (SMs) of your GPU.
+
+### Metal (macOS)
+
+Use `NUM_BLOCKS=1` for Metal.
+
+``` sh
+cargo run -r --features metal --bin metal_test -- path/to/gatelevel.gv path/to/result.gemparts path/to/input.vcd path/to/output.vcd 1
+```
+
+### CUDA (Linux)
+
+Replace `NUM_BLOCKS` with twice the number of physical streaming multiprocessors (SMs) of your GPU.
 
 ``` sh
 cargo run -r --features cuda --bin cuda_test -- path/to/gatelevel.gv path/to/result.gemparts path/to/input.vcd path/to/output.vcd NUM_BLOCKS
 ```
 
-**VCD Scope Handling**: GEM automatically detects the correct VCD scope containing your design's ports. In most cases, you don't need to specify `--input-vcd-scope`. If auto-detection fails or you need to override it, use:
+### VCD Scope Handling
+
+Loom automatically detects the correct VCD scope containing your design's ports. In most cases, you don't need to specify `--input-vcd-scope`. If auto-detection fails or you need to override it, use:
 
 ``` sh
+# Metal
+cargo run -r --features metal --bin metal_test -- path/to/gatelevel.gv path/to/result.gemparts path/to/input.vcd path/to/output.vcd 1 --input-vcd-scope "testbench/dut"
+
+# CUDA
 cargo run -r --features cuda --bin cuda_test -- path/to/gatelevel.gv path/to/result.gemparts path/to/input.vcd path/to/output.vcd NUM_BLOCKS --input-vcd-scope "testbench/dut"
 ```
 
@@ -151,4 +178,4 @@ Use slash separators (`/`) for hierarchical paths, not dots. See [docs/troublesh
 
 The simulated output ports value will be stored in `output.vcd`.
 
-**Caveat**: The actual GPU simulation runtime will also be outputted. You might see a long time before GPU enters due to reading and parsing `input.vcd`. You are recommended to develop your own pipeline to feed the input waveform into GEM CUDA kernels.
+**Caveat**: The actual GPU simulation runtime will also be outputted. You might see a long time before GPU enters due to reading and parsing `input.vcd`. You are recommended to develop your own pipeline to feed the input waveform into Loom's GPU kernels.


### PR DESCRIPTION
## Summary
- Rebrand README to reflect ChipFlow's fork of NVlabs/GEM
- Document Metal backend alongside CUDA throughout README and usage.md
- Update clone URLs from NVlabs/GEM to ChipFlow/GEM
- List fork additions: Metal support, SKY130 timing sim, performance optimizations, CI/CD

## Test plan
- [ ] Verify all links resolve correctly
- [ ] Confirm build commands work for both Metal and CUDA features