### PR TITLE
Integrate gpu_sim co-simulation into loom cosim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,24 +437,24 @@ jobs:
             build_artifacts/6_final.v build_artifacts/result.gemparts \
             --top-module top
 
-      - name: Run GPU simulation with SDF timing (100K ticks)
+      - name: Run GPU co-simulation with SDF timing (100K ticks)
         timeout-minutes: 10
         run: |
-          cargo run --release --features metal --bin gpu_sim -- \
+          cargo run --release --features metal --bin loom -- cosim \
+            build_artifacts/6_final.v build_artifacts/result.gemparts \
             --config tests/mcu_soc/sim_config.json --top-module top \
             --sdf build_artifacts/6_final.sdf --sdf-corner typ \
             --max-cycles 100000 \
-            build_artifacts/6_final.v build_artifacts/result.gemparts \
-            2>&1 | tee gpu_sim_output.txt
+            2>&1 | tee cosim_output.txt
 
       - name: Verify UART boot output
         run: |
-          if grep -q "nyaa" gpu_sim_output.txt; then
+          if grep -q "nyaa" cosim_output.txt; then
             echo "MCU SoC booted successfully - UART output detected"
           else
             echo "ERROR: Expected UART output 'nyaa' not found"
             echo "--- Last 50 lines of simulation output ---"
-            tail -50 gpu_sim_output.txt
+            tail -50 cosim_output.txt
             exit 1
           fi
 
@@ -462,9 +462,9 @@ jobs:
         if: always()
         run: |
           {
-            echo "## MCU SoC Metal Simulation (with SDF timing)"
+            echo "## MCU SoC Metal Co-simulation (with SDF timing)"
             echo "\`\`\`"
-            tail -20 gpu_sim_output.txt
+            tail -20 cosim_output.txt
             echo "\`\`\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -474,7 +474,7 @@ jobs:
         with:
           name: mcu-soc-results
           path: |
-            gpu_sim_output.txt
+            cosim_output.txt
             tests/mcu_soc/sim_config.json
 
   # Build documentation (cargo doc + mdbook) and deploy to GitHub Pages

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,6 @@ required-features = ["cuda"]
 name = "metal_test"
 required-features = ["metal"]
 
-[[bin]]
-name = "gpu_sim"
-required-features = ["metal"]
-
 [dev-dependencies]
 criterion = "0.5"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,10 @@
 //! - [`testbench`] — Testbench configuration and VCD-driven simulation setup
 //! - [`display`] — Display/assertion support infrastructure
 
+#[cfg(feature = "metal")]
+#[macro_use]
+extern crate objc;
+
 pub mod aigpdk;
 
 pub mod sky130;

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -9,6 +9,8 @@
 //! - [`vcd_io`] — VCD input parsing and output writing utilities
 //! - [`setup`] — Design loading pipeline (netlist → AIG → script)
 
+#[cfg(feature = "metal")]
+pub mod cosim_metal;
 pub mod cpu_reference;
 pub mod setup;
 pub mod vcd_io;

--- a/src/sky130_pdk.rs
+++ b/src/sky130_pdk.rs
@@ -1375,9 +1375,10 @@ mod tests {
 
     #[test]
     fn test_parse_ha() {
-        let src =
-            std::fs::read_to_string("vendor/sky130_fd_sc_hd/cells/ha/sky130_fd_sc_hd__ha.functional.v")
-                .unwrap();
+        let src = std::fs::read_to_string(
+            "vendor/sky130_fd_sc_hd/cells/ha/sky130_fd_sc_hd__ha.functional.v",
+        )
+        .unwrap();
         let model = parse_functional_model(&src).unwrap();
         assert_eq!(model.module_name, "sky130_fd_sc_hd__ha");
         assert_eq!(model.inputs, vec!["A", "B"]);


### PR DESCRIPTION
## Summary

- Extract Metal co-simulation engine from `gpu_sim` binary into `src/sim/cosim_metal.rs` library module
- Replace `cmd_cosim` stub in `loom.rs` with thin wrapper calling `cosim_metal::run_cosim()`
- Design loading reuses `setup::load_design()` instead of duplicating it
- `DesignArgs` gains `clock_period_ps` for configurable SDF clock period
- CI updated to use `loom cosim` instead of `gpu_sim`
- `gpu_sim` binary removed

## Test plan

- [ ] CI lint job passes (formatting + clippy)
- [ ] CI mcu-soc-metal job passes with `loom cosim`
- [ ] `loom cosim --help` shows all expected flags
- [ ] Existing `loom sim` still works (unchanged code path)