### PR TITLE
Fix synth script: read_ilang -> read_rtlil for Yosys 0.62+

### DIFF
--- a/scripts/openlane2/synth.ys
+++ b/scripts/openlane2/synth.ys
@@ -1,4 +1,4 @@
-read_ilang /design/mcu_soc_sky130.il
+read_rtlil /design/mcu_soc_sky130.il
 hierarchy -top top
 proc
 flatten


### PR DESCRIPTION
## Summary
- The librelane Docker image ships Yosys 0.62 which removed the deprecated `read_ilang` command
- Updated `scripts/openlane2/synth.ys` to use the current `read_rtlil` command

## Test plan
- [ ] Merge and re-trigger `mcu-soc-rebuild.yml` via workflow_dispatch
- [ ] Verify synthesis step passes