### PR TITLE
Increase rebuild workflow timeout to 120 minutes

### DIFF
--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -19,7 +19,7 @@ jobs:
   rebuild:
     name: Rebuild MCU SoC Test Data
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- P&R step timed out at 57 minutes during detailed routing (8th iteration, still making progress)
- Increased workflow timeout from 60 to 120 minutes to accommodate the full OpenROAD flow

## Context
Run [22383889332](https://github.com/ChipFlow/Loom/actions/runs/22383889332) was cancelled after hitting the 60-minute limit. The synthesis completed in ~8 minutes, but P&R needs significantly more time for this design size (4000x4000 die area, 25% utilization).