### PR TITLE
Add SRAM macro PDN power connections for P&R

### DIFF
--- a/scripts/openlane2/mcu_soc_config.json
+++ b/scripts/openlane2/mcu_soc_config.json
@@ -13,6 +13,12 @@
     "PL_RESIZER_HOLD_SLACK_MARGIN": -0.5,
     "RUN_LINTER": false,
     "SYNTH_ELABORATE_ONLY": true,
+    "PDN_MACRO_CONNECTIONS": [
+        "soc\\.sram\\.mem\\.0\\.0 VPWR VGND vpwrp vgnd",
+        "soc\\.sram\\.mem\\.0\\.0 VPWR VGND vpwra vgnd",
+        "soc\\.sram\\.mem\\.0\\.0 VPWR VGND vpwrm vgnd",
+        "soc\\.sram\\.mem\\.0\\.0 VPWR VGND vpb vnb"
+    ],
     "MACROS": {
         "CF_SRAM_1024x32": {
             "instances": {


### PR DESCRIPTION
## Summary
- P&R completed routing but librelane exited with "6 critical disconnected pins found"
- The CF_SRAM_1024x32 macro has 6 power/ground pins that need explicit PDN mapping
- Added `PDN_MACRO_CONNECTIONS` config to map SRAM power pins to global VPWR/VGND

## Pin mapping
| SRAM Pin | Type | Global Net |
|----------|------|------------|
| vpwrp | POWER | VPWR |
| vpwra | POWER | VPWR |
| vpwrm | POWER | VPWR |
| vpb | POWER | VPWR |
| vgnd | GROUND | VGND |
| vnb | GROUND | VGND |

## Context
Run [22385725048](https://github.com/ChipFlow/Loom/actions/runs/22385725048) failed after 83 minutes with:
- `[PDN-0231] soc.sram.mem.0.0 is not connected to any power/ground nets`
- `[PDN-0189] Supply pin soc.sram.mem.0.0/vnb is not connected to any net` (and 5 similar)
- `6 critical disconnected pins found` → exit code 2