### PR TITLE
Add swap space for P&R rebuild workflow

### DIFF
--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -21,6 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
+      - name: Create swap space
+        run: |
+          sudo fallocate -l 8G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- P&R process is OOM-killed (exit 137) during multi-corner STA after routing completes
- GitHub runner has 7GB RAM, insufficient for OpenROAD's post-PnR STA across 9 timing corners
- Added 8GB swap file creation step before the build

## Context
Run [22397494687](https://github.com/ChipFlow/Loom/actions/runs/22397494687) was killed at exit code 137 during STA step 51 (`openroad-stapostpnr`). The routing itself completed successfully (~2.6GB memory), but multi-corner STA running in parallel exceeded available RAM.