### PR TITLE
Fix swap file creation in rebuild workflow

### DIFF
--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Create swap space
         run: |
+          sudo swapoff /swapfile 2>/dev/null || true
+          sudo rm -f /swapfile
           sudo fallocate -l 8G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile


### PR DESCRIPTION
## Summary
- `fallocate` fails with "Text file busy" because the GitHub runner already has a `/swapfile` in use
- Added `swapoff` and `rm` before creating the new 8GB swapfile

## Context
Run [22401387566](https://github.com/ChipFlow/Loom/actions/runs/22401387566) failed immediately at the swap creation step.