### PR TITLE
Allow P&R to continue past sign-off check failures

### DIFF
--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -66,6 +66,8 @@ jobs:
             yosys /design/synth.ys
 
       - name: Place and Route (librelane)
+        id: pnr
+        continue-on-error: true
         run: |
           docker run --rm \
             -v "$PWD/designs/mcu_soc_sky130/build:/design" \
@@ -80,6 +82,12 @@ jobs:
         run: |
           RUN_DIR=$(find designs/mcu_soc_sky130/build/runs -maxdepth 1 -name 'RUN_*' -type d | sort -r | head -1)
           echo "Using run directory: $RUN_DIR"
+
+          # Verify P&R produced a netlist (may exist even if sign-off checks failed)
+          if ! ls "$RUN_DIR"/final/nl/*.nl.v 1>/dev/null 2>&1; then
+            echo "::error::No post-P&R netlist found. P&R failed before generating output."
+            exit 1
+          fi
 
           # Post-P&R netlist (unpowered)
           cp "$RUN_DIR"/final/nl/*.nl.v tests/mcu_soc/data/6_final_raw.v

--- a/scripts/openlane2/mcu_soc_config.json
+++ b/scripts/openlane2/mcu_soc_config.json
@@ -39,9 +39,6 @@
         }
     },
     "meta": {
-        "version": 2,
-        "substituting_steps": {
-            "Odb.CheckDesignAntennaProperties": null
-        }
+        "version": 2
     }
 }


### PR DESCRIPTION
## Summary
- P&R completes routing + STA successfully, but crashes at final `Odb.CheckDesignAntennaProperties` sign-off step (SRAM LEF lacks antenna data)
- Use `continue-on-error: true` on the P&R step so the workflow proceeds
- Extract step verifies the netlist was actually generated before continuing
- Reverts the `substituting_steps` approach from PR #33 (requires full flow definition)

## Context
Run [22401763329](https://github.com/ChipFlow/Loom/actions/runs/22401763329) showed P&R completing routing + multi-corner STA but crashing at step 55 `odb-checkdesignantennaproperties` with `StopIteration`. The post-P&R netlist is written at step ~47 (`final/nl/`), well before the failing sign-off check.