### PR TITLE
Free disk space and reduce swap for P&R rebuild

### DIFF
--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -21,11 +21,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost
+          sudo apt-get clean
+          df -h /
+
       - name: Create swap space
         run: |
           sudo swapoff /swapfile 2>/dev/null || true
           sudo rm -f /swapfile
-          sudo fallocate -l 8G /swapfile
+          sudo fallocate -l 4G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile


### PR DESCRIPTION
## Summary
- Runner ran out of disk space during P&R: `No space left on device`
- Free ~10GB by removing unused .NET SDK, Android SDK, Haskell, and Boost directories
- Reduce swap from 8GB to 4GB (still enough for STA memory spike)

## Context
Run [22408219129](https://github.com/ChipFlow/Loom/actions/runs/22408219129) crashed with `System.IO.IOException: No space left on device`. The 8GB swap + ~2GB docker image + ~1GB PDK + P&R intermediate files exceeded the runner's ~14GB free disk space.