### PR TITLE
Increase timeout to 180 min and restore 8GB swap

### DIFF
--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -19,7 +19,7 @@ jobs:
   rebuild:
     name: Rebuild MCU SoC Test Data
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     steps:
       - name: Free disk space
         run: |
@@ -31,7 +31,7 @@ jobs:
         run: |
           sudo swapoff /swapfile 2>/dev/null || true
           sudo rm -f /swapfile
-          sudo fallocate -l 4G /swapfile
+          sudo fallocate -l 8G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile


### PR DESCRIPTION
## Summary
- With 4GB swap, STA thrashes on disk causing timeout at 120 min
- Restore 8GB swap for faster STA (less thrashing)
- Increase timeout to 180 min to allow for sign-off checks
- Disk cleanup frees ~10GB so 8GB swap fits (14GB + 10GB freed - 8GB swap = ~16GB for build)

## Context
Run [22415611454](https://github.com/ChipFlow/Loom/actions/runs/22415611454) timed out at 120 min — P&R was still in STA/sign-off phase. With 8GB swap (run 22401763329), P&R completed in ~100 min but ran out of disk. Now with disk cleanup + 8GB swap, both constraints should be satisfied.