### PR TITLE
Increase P&R rebuild timeout to 180 minutes

### DIFF
--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -19,7 +19,7 @@ jobs:
   rebuild:
     name: Rebuild MCU SoC Test Data
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     steps:
       - name: Free disk space
         run: |


### PR DESCRIPTION
## Summary
- P&R with swap enabled runs slower due to memory pressure
- 120 min timeout insufficient — run was cancelled at exactly 2h0m
- Bumped to 180 minutes

## Context
Run [22415611454](https://github.com/ChipFlow/Loom/actions/runs/22415611454) was cancelled after 2h0m18s. P&R was still running during the STA/sign-off phase which uses more memory (triggering swap).