### PR TITLE
Increase P&R timeout to 240 min and swap to 6GB

### DIFF
--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -19,7 +19,7 @@ jobs:
   rebuild:
     name: Rebuild MCU SoC Test Data
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 240
     steps:
       - name: Free disk space
         run: |
@@ -31,7 +31,7 @@ jobs:
         run: |
           sudo swapoff /swapfile 2>/dev/null || true
           sudo rm -f /swapfile
-          sudo fallocate -l 8G /swapfile
+          sudo fallocate -l 6G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile


### PR DESCRIPTION
## Summary
- P&R timed out again at 120 min — with reduced swap (4GB), STA thrashes and runs slower
- Increase swap from 4GB to 6GB for better STA performance
- Increase timeout from 120 to 240 min to accommodate swap-based STA

## Context
Run [22415611454](https://github.com/ChipFlow/Loom/actions/runs/22415611454) timed out at 120 min. Previously with 8GB swap (PR #31), P&R completed in ~100 min but ran out of disk space. With 4GB swap (PR #35), there's enough disk space but STA is slower due to more swapping. 6GB swap is the compromise.

The GitHub free tier allows up to 360 min per job.