### PR TITLE
Improve netlist extraction with diagnostics

### DIFF
--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           sudo swapoff /swapfile 2>/dev/null || true
           sudo rm -f /swapfile
-          sudo fallocate -l 6G /swapfile
+          sudo fallocate -l 8G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile
           sudo swapon /swapfile
@@ -89,18 +89,34 @@ jobs:
           RUN_DIR=$(find designs/mcu_soc_sky130/build/runs -maxdepth 1 -name 'RUN_*' -type d | sort -r | head -1)
           echo "Using run directory: $RUN_DIR"
 
-          # Try final netlist first, fall back to last intermediate step netlist.
+          # Show directory structure for debugging
+          echo "=== Top-level directories ==="
+          ls -la "$RUN_DIR"/ 2>/dev/null || true
+          echo "=== All Verilog files ==="
+          find "$RUN_DIR" -name '*.v' 2>/dev/null | head -20 || true
+          echo "=== All SDF files ==="
+          find "$RUN_DIR" -name '*.sdf' 2>/dev/null | head -10 || true
+          echo "==="
+
+          # Try final netlist first, fall back to intermediate step output.
           # Librelane only populates final/ after all sign-off checks pass;
           # the antenna check crashes on SRAM LEF missing gate info, but the
-          # post-fill-insertion netlist is functionally identical for simulation.
+          # post-route netlist is functionally identical for simulation.
           if ls "$RUN_DIR"/final/nl/*.nl.v 1>/dev/null 2>&1; then
             echo "Using final netlist"
             cp "$RUN_DIR"/final/nl/*.nl.v tests/mcu_soc/data/6_final_raw.v
           else
-            echo "::warning::final/nl/ not found, using last intermediate netlist"
-            LAST_NL=$(find "$RUN_DIR" -path '*/final/*' -prune -o -name 'top.nl.v' -print | sort -r | head -1)
+            echo "::warning::final/nl/ not found, searching for intermediate netlist"
+            # Search broadly: .nl.v files, then top.v, then any .v in step dirs
+            LAST_NL=$(find "$RUN_DIR" -name '*.nl.v' 2>/dev/null | sort -r | head -1)
             if [ -z "$LAST_NL" ]; then
-              echo "::error::No netlist found in any P&R step. P&R failed before generating output."
+              LAST_NL=$(find "$RUN_DIR" -name 'top.v' 2>/dev/null | sort -r | head -1)
+            fi
+            if [ -z "$LAST_NL" ]; then
+              echo "::error::No netlist found in any P&R step."
+              echo "::error::P&R may have failed before generating output."
+              echo "All files in run dir:"
+              find "$RUN_DIR" -type f | head -50
               exit 1
             fi
             echo "Using intermediate netlist: $LAST_NL"
@@ -111,8 +127,7 @@ jobs:
           if ls "$RUN_DIR"/final/sdf/*.sdf 1>/dev/null 2>&1; then
             cp "$RUN_DIR"/final/sdf/*.sdf tests/mcu_soc/data/6_final.sdf
           else
-            # Fall back to intermediate SDF from parasitic extraction step
-            LAST_SDF=$(find "$RUN_DIR" -path '*/final/*' -prune -o -name '*.sdf' -print | sort -r | head -1)
+            LAST_SDF=$(find "$RUN_DIR" -name '*.sdf' 2>/dev/null | sort -r | head -1)
             [ -n "$LAST_SDF" ] && cp "$LAST_SDF" tests/mcu_soc/data/6_final.sdf || true
           fi
 


### PR DESCRIPTION
## Summary
- Adds directory listing diagnostics to understand P&R output structure when `final/` isn't populated
- Broadens intermediate netlist search: looks for any `*.nl.v` first, then `top.v`, instead of only `top.nl.v`
- Restores 8GB swap (6GB caused STA thrashing in run 22415611454)

The last rebuild run (22419976573) failed at the extract step because the intermediate netlist fallback searched only for `top.nl.v`, which doesn't exist in OpenLane2's step output directories. With diagnostics, we'll see the actual directory structure and find the correct file.

## Test plan
- [ ] Trigger rebuild workflow and verify extract step finds the netlist
- [ ] Verify directory listing output appears in logs for debugging