### PR TITLE
Fix wrap_openframe.py: use ~ instead of ! for OEB inversion

### DIFF
--- a/scripts/wrap_openframe.py
+++ b/scripts/wrap_openframe.py
@@ -240,7 +240,7 @@ def generate_wrapper(mappings: dict, top_ports: list[dict]) -> str:
                 lines.append(f"  assign gpio_out[{gpio_idx}] = {io_port} ; // {port_name} output")
                 used_out_gpio.add(gpio_idx)
                 oe_port = f"\\io${port_name}$oe"
-                lines.append(f"  assign gpio_oeb[{gpio_idx}] = !{oe_port} ; // {port_name} OEB")
+                lines.append(f"  assign gpio_oeb[{gpio_idx}] = ~{oe_port} ; // {port_name} OEB")
                 used_oeb_gpio.add(gpio_idx)
         else:
             # Multi-bit port
@@ -262,7 +262,7 @@ def generate_wrapper(mappings: dict, top_ports: list[dict]) -> str:
                     if individual_oe:
                         lines.append(f"  assign gpio_oeb[{gpio_idx}] = ~{oe_port} [{bit}]; // {port_name}[{bit}] OEB")
                     else:
-                        lines.append(f"  assign gpio_oeb[{gpio_idx}] = !{oe_port} ; // {port_name} OEB")
+                        lines.append(f"  assign gpio_oeb[{gpio_idx}] = ~{oe_port} ; // {port_name} OEB")
                     used_oeb_gpio.add(gpio_idx)
     lines.append("")
 


### PR DESCRIPTION
## Summary
- Changes `!` to `~` in OEB (output enable bar) assign statements
- Loom's sverilog parser can't handle `!\escaped_name` - the `!` immediately before a backslash-escaped identifier causes a parse error
- `~` (bitwise NOT) produces the same result as `!` (logical NOT) for single-bit signals

This fixes the MCU SoC Metal Simulation CI failure on PR #44 (auto/update-mcu-soc-data).

## Test plan
- [ ] Merge this, then rebuild will use the fixed wrapper
- [ ] MCU SoC Metal Simulation CI should pass with the new netlist