### PR TITLE
Fix wrap_openframe.py: parenthesize OEB inversion for parser

### DIFF
--- a/scripts/wrap_openframe.py
+++ b/scripts/wrap_openframe.py
@@ -240,7 +240,7 @@ def generate_wrapper(mappings: dict, top_ports: list[dict]) -> str:
                 lines.append(f"  assign gpio_out[{gpio_idx}] = {io_port} ; // {port_name} output")
                 used_out_gpio.add(gpio_idx)
                 oe_port = f"\\io${port_name}$oe"
-                lines.append(f"  assign gpio_oeb[{gpio_idx}] = !{oe_port} ; // {port_name} OEB")
+                lines.append(f"  assign gpio_oeb[{gpio_idx}] = ~( {oe_port} ); // {port_name} OEB")
                 used_oeb_gpio.add(gpio_idx)
         else:
             # Multi-bit port
@@ -260,9 +260,9 @@ def generate_wrapper(mappings: dict, top_ports: list[dict]) -> str:
                     used_out_gpio.add(gpio_idx)
                     oe_port = f"\\io${port_name}$oe"
                     if individual_oe:
-                        lines.append(f"  assign gpio_oeb[{gpio_idx}] = ~{oe_port} [{bit}]; // {port_name}[{bit}] OEB")
+                        lines.append(f"  assign gpio_oeb[{gpio_idx}] = ~( {oe_port} [{bit}] ); // {port_name}[{bit}] OEB")
                     else:
-                        lines.append(f"  assign gpio_oeb[{gpio_idx}] = !{oe_port} ; // {port_name} OEB")
+                        lines.append(f"  assign gpio_oeb[{gpio_idx}] = ~( {oe_port} ); // {port_name} OEB")
                     used_oeb_gpio.add(gpio_idx)
     lines.append("")
 


### PR DESCRIPTION
## Summary
- Wraps OEB inversion operands in parentheses: `~( \io$name$oe )` instead of `~\io$name$oe`
- Loom's sverilog parser can't handle unary operators (`~`, `!`) immediately before backslash-escaped identifiers
- Adding parentheses makes the expression unambiguous for the parser

Fixes MCU SoC Metal Simulation CI failure on PR #44.

## Test plan
- [ ] CI passes (MCU SoC Metal Simulation uses the existing committed netlist, not the new wrapper)
- [ ] After merge, re-trigger rebuild to regenerate PR #44 with correct wrapper syntax