### PR TITLE
Remove remaining loom references and untrack .pdm-python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 __pycache__/
 *.pyc
 *.swp
+.pdm-python
 
 # Claude Code session data
 .claude/

--- a/.pdm-python
+++ b/.pdm-python
@@ -1,1 +1,0 @@
-/Users/roberttaylor/Code/ChipFlow/Loom/.venv/bin/python

--- a/designs/mcu_soc_sky130/.pdm-python
+++ b/designs/mcu_soc_sky130/.pdm-python
@@ -1,1 +1,0 @@
-/Users/roberttaylor/Code/ChipFlow/Loom/designs/mcu_soc_sky130/.venv/bin/python

--- a/scripts/compare_timing.py
+++ b/scripts/compare_timing.py
@@ -420,7 +420,7 @@ def main() -> int:
                         help="CVC stdout log with RESULT: lines")
     parser.add_argument("--cvc-vcd", type=Path, required=True,
                         help="CVC output VCD")
-    parser.add_argument("--jacquard-vcd", "--loom-vcd", type=Path, required=True,
+    parser.add_argument("--jacquard-vcd", type=Path, required=True,
                         help="Jacquard --timing-vcd output")
     parser.add_argument("--clock-period-ps", type=int, required=True,
                         help="Clock period in picoseconds")

--- a/tests/mcu_soc/cvc/compare_simulation.py
+++ b/tests/mcu_soc/cvc/compare_simulation.py
@@ -489,7 +489,7 @@ def main() -> None:
                 else:
                     skip_bits.add(int(part))
             i += 2
-        elif args[i] in ("--jacquard-timing-vcd", "--loom-timing-vcd") and i + 1 < len(args):
+        elif args[i] == "--jacquard-timing-vcd" and i + 1 < len(args):
             jacquard_timing_vcd = Path(args[i + 1])
             i += 2
         elif args[i] == "--cvc-timing-vcd" and i + 1 < len(args):

--- a/tests/timing_test/cvc/run_cvc.sh
+++ b/tests/timing_test/cvc/run_cvc.sh
@@ -58,16 +58,16 @@ if grep -q "RESULT: total_delay=" "$OUTPUT_DIR/cvc_output.log"; then
     CVC_TOTAL=$(grep "RESULT: total_delay=" "$OUTPUT_DIR/cvc_output.log" | sed 's/.*=//')
     CVC_CLK_TO_Q=$(grep "RESULT: clk_to_q=" "$OUTPUT_DIR/cvc_output.log" | sed 's/.*=//')
     CVC_CHAIN=$(grep "RESULT: chain_delay=" "$OUTPUT_DIR/cvc_output.log" | sed 's/.*=//')
-    LOOM_TOTAL=1323
+    JACQUARD_TOTAL=1323
     echo "CVC:  clk_to_q=${CVC_CLK_TO_Q}ps  chain=${CVC_CHAIN}ps  total=${CVC_TOTAL}ps"
-    echo "Jacquard: clk_to_q=350ps  chain=973ps  total=${LOOM_TOTAL}ps"
+    echo "Jacquard: clk_to_q=350ps  chain=973ps  total=${JACQUARD_TOTAL}ps"
     echo ""
 
     # Jacquard uses max(rise, fall) per cell — a conservative approximation since
     # the GPU kernel processes 32 packed signals and can't track per-signal
     # transition direction. CVC tracks actual rise/fall transitions.
     # Expected overestimate: 8 inverters × 10ps IOPATH + 8 wires × 1ps = 88ps.
-    DIFF=$((LOOM_TOTAL - CVC_TOTAL))
+    DIFF=$((JACQUARD_TOTAL - CVC_TOTAL))
     echo "Difference: ${DIFF}ps (Jacquard conservative overestimate)"
     if [ "$DIFF" -ge 0 ] && [ "$DIFF" -le 200 ]; then
         echo "PASS: Jacquard within expected conservative bound"


### PR DESCRIPTION
## Summary
- Remove backward-compat `--loom-vcd` and `--loom-timing-vcd` CLI aliases
- Rename `LOOM_TOTAL` shell variable to `JACQUARD_TOTAL`
- Remove `.pdm-python` files from tracking (stale local paths pointing at old `/ChipFlow/Loom/` directory)
- Add `.pdm-python` to `.gitignore`

Followup to #59.

## Test plan
- [ ] CI passes
- [ ] `grep -ri loom` only returns README.md literary reference