### PR TITLE
ci: rename cosim --max-cycles → --max-clock-edges (fixes #62)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,10 +620,11 @@ jobs:
       - name: Run GPU co-simulation (500K ticks)
         timeout-minutes: 30
         run: |
+          set -o pipefail
           cargo run --release --features metal --bin jacquard -- cosim \
             tests/mcu_soc/data/6_final.v \
             --config tests/mcu_soc/sim_config.json --top-module top \
-            --max-cycles 500000 \
+            --max-clock-edges 500000 \
             2>&1 | tee cosim_output.txt
 
       - name: Verify UART boot output
@@ -647,10 +648,11 @@ jobs:
       - name: Capture stimulus + timing VCD via cosim (10K ticks)
         timeout-minutes: 15
         run: |
+          set -o pipefail
           cargo run --release --features metal --bin jacquard -- cosim \
             tests/mcu_soc/data/6_final.v \
             --config tests/mcu_soc/sim_config.json --top-module top \
-            --max-cycles 10000 \
+            --max-clock-edges 10000 \
             --sdf tests/mcu_soc/data/6_final_stripped.sdf \
             --sdf-corner typ \
             --stimulus-vcd tests/mcu_soc/stimulus.vcd \
@@ -667,7 +669,7 @@ jobs:
             tests/mcu_soc/jacquard_replay_mcu.vcd \
             1 \
             --top-module top \
-            --max-cycles 10000 \
+            --max-clock-edges 10000 \
             2>&1 | tee metal_mcu_replay.txt
 
       - name: Report simulation results


### PR DESCRIPTION
## Summary

Fixes #62. Renames three workflow invocations of \`jacquard cosim/sim --max-cycles N\` to \`--max-clock-edges N\` (matching the renamed CLI flag) and adds \`set -o pipefail\` to the two cosim steps that lacked it so future failures surface immediately rather than greening through their \`tee\` pipelines.

## Test plan

- [ ] CI: \`MCU SoC Metal Simulation\` reaches \`Verify UART boot output\` with real firmware output (i.e. argv parse no longer fails the first cargo invocation).
- [ ] If "nyaa" still doesn't appear, the 500000/10000 numeric arguments may need adjusting — the rename may have changed semantics from cycles to edges (the field doc says one cycle = 2 edges). That's a follow-up; this PR's scope is the broken CLI invocation surfaced by #62.