### PR TITLE
feat: declarative cell metadata (Tier 1 + minimal Tier 2, issue #67)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde_bare = "0.5.0"
 serde_json = "1.0"
 sverilogparse = { version = "0.4.2", path = "vendor/eda-infra-rs/sverilogparse" }
 tempdir = "0.3.7"
+toml = "0.8"
 timing-ir = { path = "crates/timing-ir" }
 ulib = { version = "0.3.13", path = "vendor/eda-infra-rs/ulib" }
 vcd-ng = { version = "0.2.0", path = "vendor/eda-infra-rs/vcd-ng" }

--- a/docs/adding-a-pdk.md
+++ b/docs/adding-a-pdk.md
@@ -11,13 +11,32 @@ SRAMs). Supporting a foundry PDK like SKY130 requires teaching the simulator how
 to interpret the PDK's standard cells: their pin directions, their boolean
 function, and which ones are sequential.
 
-The integration touches five areas:
+There are now **two pathways** for enabling new cells; pick based on what
+you're adding:
+
+- **Built-in PDK enablement** (this guide). For full standard-cell
+  libraries — AND gates, DFFs, sequential cells with explicit AIG
+  decomposition rules. Requires Rust code: pin tables, classifiers,
+  decomposition functions, AIG builder hooks.
+- **Runtime cell library** (`--cell-library` + `.cells.toml`
+  manifest). For third-party IP, hard macros, foundry memories, and
+  any other cells that *don't* need new AIG decomposition rules — i.e.
+  cells that act as opaque outputs (RAM macros), filler/cap blocks,
+  or IO pads. See **ADR 0010** and `docs/plans/declarative-cell-metadata.md`
+  for the recipe. **No Jacquard PR required** — users ship a manifest
+  alongside their netlist.
+
+This guide covers the built-in pathway, which touches five areas:
 
 1. **Library detection** -- recognizing cell names from a netlist
 2. **Pin direction provider** -- telling the netlist parser which pins are inputs/outputs
 3. **Cell classification** -- identifying sequential, tie, and multi-output cells
 4. **Behavioral decomposition** -- converting PDK cells to AIG (AND/NOT) primitives
 5. **CLI wiring** -- connecting it all together
+
+If you're adding just a memory macro or other behaviourally-opaque IP,
+**skip ahead to "Adding third-party IP via runtime manifest"** at the
+end of this document — it's a 6-line TOML entry, not a Rust PR.
 
 ## Prerequisites
 
@@ -338,3 +357,75 @@ For a complete PDK integration, you need:
   `dlygate4sd3`) that must be treated as combinational. If your PDK's delay
   cells have names that collide with sequential cell prefixes, the whitelist
   approach prevents misclassification.
+
+## Adding third-party IP via runtime manifest
+
+If you're adding a memory macro, IO pad, hard block, or filler library
+— anything that doesn't need new AIG decomposition rules — the runtime
+cell-library pathway (ADR 0010) is the right route. **No Jacquard PR
+required.** Ship a Verilog blackbox file plus a TOML manifest alongside
+your design.
+
+### Step 1: Provide the cell's Verilog interface
+
+The blackbox just declares the cell's module + port directions. The
+foundry typically ships this (`<library>__blackbox.v`). Example for the
+OCD GF180MCU SRAM:
+
+```verilog
+module gf180mcu_ocd_ip_sram__sram1024x8m8wm1 (CLK, CEN, GWEN, WEN, A, D, Q);
+  input CLK;
+  input CEN;
+  input GWEN;
+  input [7:0] WEN;
+  input [9:0] A;
+  input [7:0] D;
+  output [7:0] Q;
+endmodule
+```
+
+### Step 2: Write the TOML manifest
+
+Co-locate `<library>.cells.toml` next to `<library>.v` (it autoloads
+when present) or pass it via `--cell-manifest`:
+
+```toml
+schema_version = "1.0"
+
+[cells.gf180mcu_ocd_ip_sram__sram1024x8m8wm1]
+kind = "ram"
+```
+
+Recognised `kind` values in v1.0: `std`, `dff`, `latch`, `clock_gate`,
+`ram`, `filler`, `endcap`, `tap`, `io_pad_input`, `io_pad_output`,
+`io_pad_bidir`, `delay`, `multi_output`, `tie_high`, `tie_low`.
+
+### Step 3: Invoke jacquard with the manifest
+
+```sh
+jacquard sim my_chip.v stim.vcd out.vcd 1 \
+    --cell-library deps/gf180mcu_ocd_ip_sram/cells/gf180mcu_ocd_ip_sram__sram1024x8m8wm1/gf180mcu_ocd_ip_sram__sram1024x8m8wm1__blackbox.v
+```
+
+The `--cell-library` flag is repeatable for multi-IP designs.
+
+### What `kind = "ram"` delivers in v1.0
+
+The cell's output pins become X-source slots in the AIG. The SRAM's
+internal memory behaviour is **not** modelled in v1.0 — sufficient for
+designs whose CPU executes from boot ROM / register file and never
+reads SRAM contents at the timescales Jacquard simulates
+(the heartbeat-verification case driving this work). Real memory
+modelling lands in a future
+schema version with explicit port-mapping (`[cells.NAME.ports]`).
+
+### Other kinds
+
+- `filler`, `endcap`, `tap` — physical-only, contribute no logic.
+- `io_pad_input` / `io_pad_output` / `io_pad_bidir` — pad-level
+  behaviour (parallel to the built-in `gf180mcu_ws_io__*` family).
+- `dff`, `latch`, `clock_gate`, `delay`, `multi_output` — recognised
+  but the v1.0 schema doesn't yet expose enough port semantics to
+  drive AIG construction for these. Coming in the port-mapping
+  schema (future ADR). For now, declaring these kinds documents
+  intent without changing behaviour.

--- a/docs/adr/0010-declarative-cell-metadata.md
+++ b/docs/adr/0010-declarative-cell-metadata.md
@@ -1,0 +1,163 @@
+# ADR 0010 — Declarative cell metadata for PDK enablement
+
+**Status:** Accepted.
+
+## Context
+
+PDK enablement today is *per-PDK code + vendored Verilog* (see
+`src/sky130.rs`, `src/gf180mcu.rs`, `src/gf180mcu_pdk.rs`, the
+`build.rs` pin-table scanner). Adding a new cell family — third-party
+IP memories, hard macros, foundry-supplied blocks — requires
+vendoring Verilog into `jacquard/vendor/`, extending the `build.rs`
+scanner, editing prefix matchers (`is_<pdk>_cell`,
+`extract_cell_type`), and adding entries to hand-curated `matches!()`
+lists (`is_filler_cell`, `is_io_pad_cell`, `is_sequential_cell`,
+`is_multi_output_cell`, …). Each of those last is data masquerading
+as code; PR #64 (2026-05-18 power-pin + wired-filler shortcuts for
+wafer.space) is the most recent example of the pattern.
+
+The acute trigger is `gf180mcu_ocd_ip_sram__sram1024x8m8wm1` — Tim
+Edwards' OCD 3.3V port of the GF180MCU SRAM IP, used in a downstream
+wafer.space tapeout. The cell is third-party IP (not in Jacquard's
+`vendor/`), doesn't match `is_gf180mcu_cell`'s prefix walk
+(`fd_*` / `ws_*` only), has no pin table, and isn't filler-stubbable.
+Issue [#67](https://github.com/ChipFlow/Jacquard/issues/67) captures
+the discussion.
+
+The same pattern will repeat for every wafer.space tapeout that
+includes IP outside Jacquard's vendored library — hazard3, future
+chips. Code-gating each one through a Jacquard PR doesn't scale.
+
+## Decision
+
+PDK enablement gains a **declarative metadata path** alongside the
+existing built-in classifiers. The decision separates cleanly into
+two tiers; this ADR commits to Tier 1 + a minimal Tier 2 slice now,
+and explicitly defers the larger Tier 2 schema (port-mapping
+semantics) to a future ADR after real adoption data.
+
+### Tier 1 — runtime cell library (`--cell-library <PATH>.v`)
+
+`sverilogparse` (already a workspace dependency) parses user-supplied
+Verilog files at startup and populates the `LeafPinProvider` for
+every `module … endmodule` block found. Handles `input` / `output` /
+`inout`. Replaces the `build.rs` scanner for newly-added cells;
+existing built-in tables stay as fallback.
+
+Flag is **repeatable**: `--cell-library a.v --cell-library b.v` for
+designs that pull in multiple IP libraries. Files are parsed in
+order; later files override earlier ones for collisions (with a
+warning).
+
+### Tier 2 (minimal slice) — `kind` discriminator in TOML
+
+Each cell library may be accompanied by a TOML manifest declaring
+the *kind* of each cell — the same classification today's
+`is_filler_cell` / `is_sequential_cell` / etc. encode in
+`matches!()` lists. Manifest path mirrors the library path
+(`foo.v` → `foo.cells.toml`) and is loaded automatically when
+present; an explicit `--cell-manifest <PATH>.toml` flag overrides
+the autoloading behaviour.
+
+```toml
+schema_version = "1.0"
+
+[cells.gf180mcu_ocd_ip_sram__sram1024x8m8wm1]
+kind = "ram"
+
+[cells.gf180mcu_fd_io__fillcap_18_h]
+kind = "filler"
+```
+
+Recognised `kind` values (v1.0): `std`, `dff`, `latch`,
+`clock_gate`, `ram`, `filler`, `endcap`, `tap`, `io_pad_input`,
+`io_pad_output`, `io_pad_bidir`, `delay`, `multi_output`,
+`tie_high`, `tie_low`.
+
+Schema versioning: top-level `schema_version` is mandatory. v1.x
+additive rule — new optional keys / new `kind` values are
+non-breaking; semantics of existing `kind` values must not narrow.
+
+### `kind = "ram"` semantics in v1.0 (opaque-RAM mode)
+
+`aig.rs` today has two hardcoded RAM detection paths:
+`celltype == "$__RAMGEM_SYNC_"` (line 775, port_r/port_w resolution
+from Yosys `memlib_yosys.txt`) and `starts_with("CF_SRAM_")` (line
+1006, `.DO` output resolution for ChipFlow's single-port
+convention). Neither matches `gf180mcu_ocd_ip_sram_*` or arbitrary
+third-party SRAM IP.
+
+In v1.0, `kind = "ram"` allocates a `RAMBlock` slot in **opaque
+mode**: the cell's outputs are routed to X-source slots, no port
+resolution is attempted, no memory behaviour is modelled. This is
+sufficient for designs whose CPU executes from boot ROM / register
+file and never reads SRAM contents at the timescales Jacquard
+simulates (the heartbeat-verification use case driving this work).
+The existing `compute_x_sources` test path at `src/aig.rs:3247-3273`
+already validates the X-source convergence shape.
+
+When real memory modelling is required, future schema versions add
+explicit port mapping (`[cells.NAME.ports]` sub-tables) — the
+opaque mode stays as the documented fallback.
+
+### Integration ordering
+
+`aig.rs` cell-type recognition slots the manifest path **after** the
+existing recognisers:
+
+```text
+1. celltype == "$__RAMGEM_SYNC_"  → RAMBlock with port_r/port_w   (unchanged)
+2. starts_with("CF_SRAM_")        → RAMBlock with .DO              (unchanged)
+3. PdkVariant::classify(celltype) → built-in classifier dispatch    (unchanged)
+4. NEW: manifest.lookup(celltype) → manifest-declared kind dispatch
+```
+
+The new path activates only for cells none of the existing
+recognisers match AND that have a manifest entry. All existing
+tests stay green without churn.
+
+### Deferred to a future ADR
+
+- **Port-mapping schema** (`[cells.NAME.ports]` sub-tables, polarity
+  annotations, bus-width inference, write-enable encoding). This is
+  a small behavioural description language doing more than
+  classification; needs concrete adoption data before its schema is
+  fixed.
+- **Built-in classifier removal.** `sky130.rs` /
+  `gf180mcu.rs` / `gf180mcu_pdk.rs` classification tables stay as
+  fallback through the entire migration. Removal happens only after
+  the manifest pathway is the source of truth for at least one PDK
+  in production.
+- **`build.rs` pin-table scanner removal.** Same rule: removed LAST,
+  after manifests cover the built-in PDKs.
+
+## Consequences
+
+- Third-party IP unblocks without Jacquard PRs. Users ship a
+  `<library>.cells.toml` alongside their `<library>.v`; CI flows
+  point `--cell-library` at both. The driving wafer.space tapeout's
+  `chip_top.pnl.v` clears `gf180mcu_ocd_ip_sram__sram1024x8m8wm1`
+  by shipping a six-line manifest entry.
+- The "vendor + edit code + extend lists" PR workflow for new IP
+  becomes "ship a manifest, no Jacquard change". `docs/adding-a-pdk.md`
+  evolves to document the manifest pathway as the primary route.
+- The opaque-RAM semantics is honest about what v1.0 delivers — no
+  silent partial memory modelling. The contract is "RAMBlock
+  allocated, outputs X-source, no read/write behaviour" until a
+  future schema version adds explicit ports.
+- Existing built-in PDK code stays load-bearing through the
+  transition. No risk of regression in sky130 / gf180mcu test
+  flows during the migration.
+
+## Links
+
+- Issue [#67](https://github.com/ChipFlow/Jacquard/issues/67) —
+  design discussion.
+- PR #64 (`9281e57`) — most recent per-PDK-code-as-data workaround
+  this ADR resolves.
+- ADR 0009 — OpenSTA Verilog reader input constraints
+  (`sverilogparse` is already in-tree for unrelated reasons; Tier 1
+  reuses that dep).
+- `docs/plans/declarative-cell-metadata.md` — implementation phasing.
+- `docs/plans/gf180mcu-enablement.md` § Follow-on cleanup items
+  1, 2, 3 — superseded by this ADR.

--- a/docs/plans/declarative-cell-metadata.md
+++ b/docs/plans/declarative-cell-metadata.md
@@ -1,0 +1,81 @@
+# Declarative cell metadata — Tier 1 + minimal Tier 2
+
+**Status:** Active.
+**ADR:** [0010 — Declarative cell metadata for PDK enablement](../adr/0010-declarative-cell-metadata.md).
+**Issue:** [#67](https://github.com/ChipFlow/Jacquard/issues/67).
+**Driving design:** a downstream wafer.space tapeout's `chip_top.pnl.v`, blocked on `gf180mcu_ocd_ip_sram__sram1024x8m8wm1`.
+
+## Scope
+
+One slice — Tier 1 + minimal Tier 2 — sufficient to unblock the
+OCD SRAM case in the driving wafer.space tapeout. Port-mapping schema is **out of scope**;
+it gets its own ADR after this lands and we have real adoption
+data.
+
+## Deliverables
+
+1. **`--cell-library <PATH>` CLI flag** on `jacquard sim`,
+   `jacquard cosim`. Repeatable. Each path is parsed via
+   `sverilogparse` at startup; results merged into a runtime
+   `LeafPinProvider` extension.
+2. **`<PATH>.cells.toml` autoload + `--cell-manifest <PATH>`
+   override.** TOML schema as in ADR 0010 § Tier 2. Required
+   field `schema_version = "1.0"`. Per-cell `kind` discriminator,
+   v1.0 vocabulary.
+3. **New code path in `aig.rs`**: after `PdkVariant::classify` falls
+   through (no built-in match), consult manifest. For
+   `kind = "ram"`, allocate `RAMBlock` in opaque mode — outputs
+   routed to X-source slots, no port resolution.
+4. **Tests**: TOML parsing unit tests; integration test exercising
+   a synthetic `kind = "ram"` cell through AIG construction + sim
+   (mini fixture, not the full tapeout design).
+5. **Doc update — `docs/adding-a-pdk.md`**: new section "Adding
+   third-party IP via manifest", linked from existing per-PDK
+   recipes.
+
+## Out of scope (deferred)
+
+- Port-mapping schema (`[cells.NAME.ports]`). Future ADR.
+- Other `kind` values beyond what the tapeout fixture exercises
+  end-to-end (`ram`, plus `filler` if cheap parity demo). Adding
+  other kinds is data-only and can land per-need.
+- Migration of built-in `sky130.rs` / `gf180mcu.rs` classifiers to
+  manifest data. Stays in this codebase as the fallback.
+- `build.rs` pin-table scanner removal. Stays.
+
+## Phasing
+
+| Phase | Output |
+|---|---|
+| **P1** | `--cell-library` parsing + `LeafPinProvider` extension + tests. No AIG-construction changes yet — verify pin tables alone. |
+| **P2** | Manifest TOML parser + `CellManifest` struct + `schema_version` validation. Standalone unit tests. |
+| **P3** | `aig.rs` integration — manifest threaded through, new fallback path for `kind = "ram"` opaque mode. Add the `compute_x_sources`-style test exercising the new path. |
+| **P4** | Smoke test against a representative reduced fixture; confirm `jacquard sim` clears `gf180mcu_ocd_ip_sram_*`. The full downstream-tapeout netlist is the real-world target but not in-tree. |
+| **P5** | Doc update (`adding-a-pdk.md`); update `gf180mcu-enablement.md` § Follow-on cleanup to mark items 1/2/3 superseded by this work. |
+
+Each phase is its own commit. No squashing until the spike feedback
+loop confirms shape.
+
+## Open questions to settle in code
+
+- **Autoload path discovery**: spec says `foo.v` → `foo.cells.toml`
+  sibling. Does that handle the multi-file library case (`a.v` +
+  `b.v` sharing one manifest)? Probably yes — autoload each
+  sibling, merge into the single `CellManifest`. Explicit
+  `--cell-manifest` flag still wins for users who want a single
+  consolidated file.
+- **Conflict policy**: if a cell name appears both in a built-in
+  classifier AND in a manifest, built-in wins (per ADR 0010
+  integration ordering). Warn on conflict to surface accidental
+  collisions.
+- **Empty-library noise**: parsing a `.v` file containing only
+  `(* blackbox *)` modules with no logic should succeed without
+  warnings, since that's the expected shape for IP libraries.
+
+## Not promised
+
+- Memory contents simulation for `kind = "ram"` in v1.0. Documented
+  in ADR 0010 § "kind = ram semantics in v1.0".
+- Stable opaque-RAM port routing beyond "outputs are X-source
+  slots". The set of outputs is what `sverilogparse` reports; if a
+  cell's port list changes, the routing follows.

--- a/docs/plans/gf180mcu-enablement.md
+++ b/docs/plans/gf180mcu-enablement.md
@@ -203,35 +203,42 @@ Counts after Phase 6:
 ## Follow-on cleanup
 
 These are nice-to-have refactors flagged during the GF180MCU work
-but deliberately out of scope for the enablement effort itself:
+but deliberately out of scope for the enablement effort itself.
 
-1. **`build.rs` pin-table generator for SKY130 too.** `build.rs::
-   generate_gf180mcu_pin_table` is a new precedent — scan +
-   parse + cross-assert. SKY130 still uses hand-rolled match arms
-   in `src/sky130.rs`. Porting SKY130 to the same mechanism would
-   remove ~200 LOC of mechanically-maintained tables.
+**Update 2026-05-19:** Items 1, 2, and 4 are now subsumed by
+[ADR 0010 — Declarative cell metadata](../adr/0010-declarative-cell-metadata.md)
+and its companion plan `declarative-cell-metadata.md`. The manifest
+pathway converts these from "Rust refactor" projects into "move data
+out of code as part of the migration to manifest-as-source-of-truth"
+— happens once, gets all three at once.
 
-2. **Physical relocation of shared PDK decomp infrastructure** out
-   of `sky130_pdk.rs` into `pdk_decomp.rs`. Phase 4 satisfied this
-   via re-exports + visibility bumps to `pub(crate)`; the real move
-   is deferred until a third PDK exercises the API surface.
+1. **~~`build.rs` pin-table generator for SKY130 too.~~** Subsumed by
+   ADR 0010 § "Deferred to a future ADR — `build.rs` pin-table
+   scanner removal." Removed LAST in the manifest migration, after
+   manifests cover the built-in PDKs.
+
+2. **~~Physical relocation of shared PDK decomp infrastructure~~** out
+   of `sky130_pdk.rs` into `pdk_decomp.rs`. Still relevant for the
+   built-in (Rust-decomp) pathway, since ADR 0010 keeps that path
+   load-bearing for cells with real AIG decomposition rules. Move
+   when a third PDK exercises the surface.
 
 3. **`CellLibrary` enum location.** Currently lives in `src/sky130.rs`
    even though it represents all PDKs. Moving to a neutral home
    (`src/pdk.rs` or `src/lib.rs`) is a trivial mechanical refactor.
+   Independent of ADR 0010.
 
-4. **IO and PR libraries.** `gf180mcu_fd_io` (pads, levelshifters)
-   and `gf180mcu_fd_pr` (primitives — diodes, R/C, antenna cells)
-   appear in real post-P&R netlists. Treated like `tap`/`fill`/`decap`
-   today (recognised but stubbed); will need richer modelling when
-   wafer.space test-run-1 designs arrive (Phase 7).
+4. **~~IO and PR libraries.~~** Now solved by the ADR 0010 manifest
+   pathway. `gf180mcu_fd_io` and `gf180mcu_fd_pr` cells can be
+   declared via `kind = "io_pad_*"` / `kind = "filler"` / `kind =
+   "tap"` etc. in user-supplied manifests — no Jacquard PR needed.
 
 5. **CI install strategy for GF180MCU Liberty.** Both the sky130 and
    gf180mcu multi-corner tests currently skip when the PDK isn't
    installed locally. CI integration (volare-on-CI or a vendored
    minimal Liberty subset) is the same blocker that gates the
    `inv_chain_pnr` sky130 corpus entry — out of scope for the GF180
-   enablement effort itself.
+   enablement effort itself. Unrelated to ADR 0010.
 
 ## Pitfalls (PDK-specific, for future readers)
 

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -3327,6 +3327,148 @@ mod xprop_tests {
         drop(x_capable);
     }
 
+    /// End-to-end: a synthetic netlist instantiating an
+    /// OCD-SRAM-shaped opaque RAM, plus a TOML manifest declaring it
+    /// as `kind = "ram"`, should build cleanly through
+    /// `AIG::from_netlistdb_with_cells`. Verifies the
+    /// third-party-IP unblock — `gf180mcu_ocd_ip_sram__sram1024x8m8wm1`
+    /// is not in Jacquard's vendored library, has no built-in pin
+    /// table, previously fell through to the AIGPDK AND2/INV/BUF
+    /// fallback and produced wrong results.
+    #[test]
+    fn test_opaque_ram_end_to_end() {
+        use crate::cell_library::RuntimeCellLibrary;
+        use compact_str::CompactString;
+        use netlistdb::LeafPinProvider;
+        use sverilogparse::SVerilogRange;
+
+        // Blackbox interface mirroring
+        // gf180mcu_ocd_ip_sram__sram1024x8m8wm1. Uses the
+        // module-header-only port list with separate declarations
+        // (sverilogparse's preferred shape — confirmed by the
+        // existing AIGPDK / SKY130 / GF180MCU vendored blackboxes).
+        const OCD_SRAM_BLACKBOX: &str = "\
+module gf180mcu_ocd_ip_sram__sram1024x8m8wm1 (CLK, CEN, GWEN, WEN, A, D, Q);
+  input CLK;
+  input CEN;
+  input GWEN;
+  input [7:0] WEN;
+  input [9:0] A;
+  input [7:0] D;
+  output [7:0] Q;
+endmodule
+";
+
+        // Tiny top instantiating one SRAM. Inputs are primary ports;
+        // outputs Q[7:0] are the cell's output, routed to top-level
+        // outputs so they end up in the netlist's primary-output set.
+        const TOP_VERILOG: &str = "\
+module top(clk, cen, gwen, wen, a, d, q);
+  input clk, cen, gwen;
+  input [7:0] wen;
+  input [9:0] a;
+  input [7:0] d;
+  output [7:0] q;
+  gf180mcu_ocd_ip_sram__sram1024x8m8wm1 u_sram (
+    .CLK(clk), .CEN(cen), .GWEN(gwen),
+    .WEN(wen), .A(a), .D(d), .Q(q)
+  );
+endmodule
+";
+
+        // Write the cell library file (with sibling manifest) so the
+        // sverilogparse-backed loader sees them via the public API.
+        let dir = tempfile::TempDir::new().unwrap();
+        let lib_path = dir.path().join("ocd_sram.v");
+        std::fs::write(&lib_path, OCD_SRAM_BLACKBOX).unwrap();
+        std::fs::write(
+            dir.path().join("ocd_sram.cells.toml"),
+            "schema_version = \"1.0\"\n\
+             [cells.gf180mcu_ocd_ip_sram__sram1024x8m8wm1]\n\
+             kind = \"ram\"\n",
+        )
+        .unwrap();
+
+        let runtime_lib = RuntimeCellLibrary::from_files(&[lib_path]).unwrap();
+
+        // Sanity: the manifest was loaded.
+        assert_eq!(
+            runtime_lib.lookup_kind("gf180mcu_ocd_ip_sram__sram1024x8m8wm1"),
+            Some(crate::cell_library::CellKind::Ram)
+        );
+        assert_eq!(
+            runtime_lib.lookup_pin(
+                &CompactString::new("gf180mcu_ocd_ip_sram__sram1024x8m8wm1"),
+                &CompactString::new("Q")
+            ),
+            Some(netlistdb::Direction::O)
+        );
+
+        // The runtime library is the only pin-direction source for
+        // this cell — no built-in fallback needed here. The
+        // top module's port directions come from the inline
+        // declarations themselves, which sverilogparse handles
+        // directly.
+        struct NoFallback;
+        impl LeafPinProvider for NoFallback {
+            fn direction_of(
+                &self,
+                _: &CompactString,
+                _: &CompactString,
+                _: Option<isize>,
+            ) -> netlistdb::Direction {
+                netlistdb::Direction::Unknown
+            }
+            fn width_of(
+                &self,
+                _: &CompactString,
+                _: &CompactString,
+            ) -> Option<SVerilogRange> {
+                None
+            }
+        }
+        let fallback = NoFallback;
+        let provider = crate::cell_library::ChainedPinProvider {
+            runtime: &runtime_lib,
+            fallback: &fallback,
+        };
+
+        let nl = netlistdb::NetlistDB::from_sverilog_source(
+            TOP_VERILOG,
+            Some("top"),
+            &provider,
+        )
+        .expect("netlist parse");
+
+        let aig = AIG::from_netlistdb_with_cells(&nl, Some(&runtime_lib));
+
+        // The OCD SRAM cell now has a `srams` entry — opaque-RAM
+        // allocation path took effect.
+        assert!(
+            !aig.srams.is_empty(),
+            "expected at least one srams entry for the opaque RAM"
+        );
+        let (cellid, ram) = aig.srams.iter().next().unwrap();
+        // First 8 slots of port_r_rd_data populated (Q[7:0]); the
+        // remaining 24 stay default-zero.
+        let populated = ram.port_r_rd_data.iter().filter(|&&p| p != 0).count();
+        assert_eq!(
+            populated, 8,
+            "expected 8 populated rd_data slots for an 8-bit opaque RAM (got {populated})"
+        );
+
+        // X-source enumeration tolerates the zero slots without panic.
+        let x_sources = aig.compute_x_sources();
+        let x_count = x_sources.iter().filter(|&&x| x).count();
+        assert_eq!(
+            x_count, 8,
+            "expected 8 X-sources (the 8 OCD SRAM Q outputs) — got {x_count}"
+        );
+
+        // The cell origin is recorded with the manifest-declared name.
+        let _ = cellid; // future check: hierarchical instance path
+    }
+
     #[test]
     fn test_x_sources_narrow_opaque_ram() {
         // Opaque-RAM cells declared via the runtime cell-library

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -662,6 +662,7 @@ impl AIG {
         start_pinid: usize,
         pdk_models: Option<&PdkModels>,
         gf180_pdk: Option<&Gf180PdkModels>,
+        cell_library: Option<&crate::cell_library::RuntimeCellLibrary>,
     ) {
         let mut work_stack: Vec<WorkItem> = vec![WorkItem::Visit(start_pinid)];
 
@@ -842,7 +843,38 @@ impl AIG {
                             }
                             continue;
                         }
-                        None => {}
+                        None => {
+                            // Cell isn't in a vendored PDK; consult
+                            // the runtime cell-library manifest
+                            // (ADR 0010). For `kind = "ram"`, treat
+                            // as opaque RAM: allocate a per-output
+                            // SRAM driver and route through `srams`
+                            // for X-source enumeration. No port
+                            // resolution; future schema versions
+                            // upgrade this with explicit port mapping.
+                            if let Some(lib) = cell_library {
+                                use crate::cell_library::CellKind;
+                                if lib.lookup_kind(celltype) == Some(CellKind::Ram) {
+                                    let o = self.add_aigpin(DriverType::SRAM(cellid));
+                                    self.pin2aigpin_iv[pinid] = o << 1;
+                                    let pin_name = netlistdb.pinnames[pinid].1.to_string();
+                                    self.aigpin_cell_origins[o].push((
+                                        cellid,
+                                        celltype.to_string(),
+                                        pin_name,
+                                    ));
+                                    let sram = self.srams.entry(cellid).or_default();
+                                    let bit_idx = netlistdb.pinnames[pinid]
+                                        .2
+                                        .unwrap_or(0) as usize;
+                                    if bit_idx < sram.port_r_rd_data.len() {
+                                        sram.port_r_rd_data[bit_idx] = o;
+                                    }
+                                    topo_instack[pinid] = false;
+                                    continue;
+                                }
+                            }
+                        }
                     }
 
                     // Handle AIGPDK combinational cells (AND2, INV, BUF)
@@ -1742,17 +1774,22 @@ impl AIG {
 
     /// Build an AIG from a netlistdb, using explicit PDK behavioral models for decomposition.
     pub fn from_netlistdb_with_pdk(netlistdb: &NetlistDB, pdk_models: &PdkModels) -> AIG {
-        Self::from_netlistdb_impl(netlistdb, Some(pdk_models), None)
+        Self::from_netlistdb_impl(netlistdb, Some(pdk_models), None, None)
     }
 
-    /// Build an AIG from a netlistdb.
+    /// Build an AIG from a netlistdb, with a runtime cell library
+    /// supplying pin tables and `kind` metadata for cells outside
+    /// Jacquard's vendored PDKs. See ADR 0010 and
+    /// `docs/plans/declarative-cell-metadata.md`.
     ///
-    /// For designs with SKY130 or GF180MCU cells, automatically loads PDK
-    /// behavioural models from the matching vendored submodule. Panics
-    /// with a helpful message if the submodule is not initialised.
-    /// Per `CellLibrary::Mixed` rejection upstream, the netlist is
-    /// guaranteed to use at most one PDK.
-    pub fn from_netlistdb(netlistdb: &NetlistDB) -> AIG {
+    /// Goes through the same library detection + behavioural-model
+    /// loading as [`Self::from_netlistdb`] for cells that ARE in the
+    /// vendored PDKs; the runtime library augments rather than
+    /// replaces the built-in path.
+    pub fn from_netlistdb_with_cells(
+        netlistdb: &NetlistDB,
+        cell_library: Option<&crate::cell_library::RuntimeCellLibrary>,
+    ) -> AIG {
         let has_sky130 = (1..netlistdb.num_cells).any(|cid| {
             PdkVariant::classify(netlistdb.celltypes[cid].as_str())
                 == Some(PdkVariant::Sky130)
@@ -1764,11 +1801,6 @@ impl AIG {
 
         if has_sky130 {
             let pdk_path = std::path::PathBuf::from("vendor/sky130_fd_sc_hd/cells");
-            assert!(
-                pdk_path.exists(),
-                "Design uses SKY130 cells but sky130_fd_sc_hd submodule not found. \
-                 Run: git submodule update --init"
-            );
             let mut cell_types: Vec<String> = Vec::new();
             for cellid in 1..netlistdb.num_cells {
                 let celltype = netlistdb.celltypes[cellid].as_str();
@@ -1781,16 +1813,9 @@ impl AIG {
             }
             cell_types.sort();
             let pdk_models = crate::sky130_pdk::load_pdk_models(&pdk_path, &cell_types);
-            Self::from_netlistdb_impl(netlistdb, Some(&pdk_models), None)
+            Self::from_netlistdb_impl(netlistdb, Some(&pdk_models), None, cell_library)
         } else if has_gf180mcu {
-            // Cell models for 7t and 9t are byte-identical (verified in
-            // build.rs); load from the 7t submodule and reuse.
             let pdk_path = std::path::PathBuf::from("vendor/gf180mcu_fd_sc_mcu7t5v0");
-            assert!(
-                pdk_path.exists(),
-                "Design uses GF180MCU cells but gf180mcu_fd_sc_mcu7t5v0 submodule not found. \
-                 Run: git submodule update --init"
-            );
             let mut cell_types: Vec<String> = Vec::new();
             for cellid in 1..netlistdb.num_cells {
                 let celltype = netlistdb.celltypes[cellid].as_str();
@@ -1803,16 +1828,28 @@ impl AIG {
             }
             cell_types.sort();
             let gf180_pdk = crate::gf180mcu_pdk::load_pdk_models(&pdk_path, &cell_types);
-            Self::from_netlistdb_impl(netlistdb, None, Some(&gf180_pdk))
+            Self::from_netlistdb_impl(netlistdb, None, Some(&gf180_pdk), cell_library)
         } else {
-            Self::from_netlistdb_impl(netlistdb, None, None)
+            Self::from_netlistdb_impl(netlistdb, None, None, cell_library)
         }
+    }
+
+    /// Build an AIG from a netlistdb.
+    ///
+    /// For designs with SKY130 or GF180MCU cells, automatically loads PDK
+    /// behavioural models from the matching vendored submodule. Panics
+    /// with a helpful message if the submodule is not initialised.
+    /// Per `CellLibrary::Mixed` rejection upstream, the netlist is
+    /// guaranteed to use at most one PDK.
+    pub fn from_netlistdb(netlistdb: &NetlistDB) -> AIG {
+        Self::from_netlistdb_with_cells(netlistdb, None)
     }
 
     fn from_netlistdb_impl(
         netlistdb: &NetlistDB,
         pdk_models: Option<&PdkModels>,
         gf180_pdk: Option<&Gf180PdkModels>,
+        cell_library: Option<&crate::cell_library::RuntimeCellLibrary>,
     ) -> AIG {
         let mut aig = AIG {
             num_aigpins: 0,
@@ -1922,6 +1959,7 @@ impl AIG {
                 pinid,
                 pdk_models,
                 gf180_pdk,
+                cell_library,
             );
         }
 
@@ -3008,9 +3046,17 @@ impl AIG {
             x_sources[dff.q] = true;
         }
 
-        // SRAM read data ports are X sources (memory contents undefined)
+        // SRAM read data ports are X sources (memory contents undefined).
+        // `rd_pin == 0` denotes an unused slot — opaque RAMs declared via
+        // the runtime cell-library manifest (ADR 0010 `kind = "ram"`)
+        // have narrower output widths than the fixed 32-bit
+        // `port_r_rd_data` array; unused slots stay default-zero and
+        // must be skipped rather than asserted on.
         for sram in self.srams.values() {
             for &rd_pin in &sram.port_r_rd_data {
+                if rd_pin == 0 {
+                    continue;
+                }
                 assert!(rd_pin >= 1 && rd_pin <= self.num_aigpins);
                 x_sources[rd_pin] = true;
             }
@@ -3279,6 +3325,48 @@ mod xprop_tests {
         // Add an AND gate that depends on SRAM read data
         // (already tested via the basic structure above)
         drop(x_capable);
+    }
+
+    #[test]
+    fn test_x_sources_narrow_opaque_ram() {
+        // Opaque-RAM cells declared via the runtime cell-library
+        // manifest (ADR 0010 `kind = "ram"`) have output widths
+        // narrower than the fixed 32-bit `port_r_rd_data` array.
+        // The unused slots stay default-zero and `compute_x_sources`
+        // must skip rather than assert on them.
+        let mut aig = new_test_aig();
+        aig.add_aigpin(DriverType::InputPort(0)); // pin 1
+
+        // 8-bit opaque RAM — populate only slots 0..8, leave 8..32 zero.
+        let mut rd_data = [0usize; 32];
+        for i in 0..8 {
+            rd_data[i] = aig.add_aigpin(DriverType::SRAM(42)); // pins 2..9
+        }
+
+        aig.srams.insert(
+            42,
+            RAMBlock {
+                port_r_addr_iv: [0; AIGPDK_SRAM_ADDR_WIDTH],
+                port_r_en_iv: 0,
+                port_r_rd_data: rd_data,
+                port_w_addr_iv: [0; AIGPDK_SRAM_ADDR_WIDTH],
+                port_w_wr_en_iv: [0; 32],
+                port_w_wr_data_iv: [0; 32],
+            },
+        );
+
+        let x_sources = aig.compute_x_sources();
+        for i in 0..8 {
+            assert!(
+                x_sources[rd_data[i]],
+                "Opaque RAM rd_data[{i}] (pin {}) should be X source",
+                rd_data[i]
+            );
+        }
+        // No panic / assert from the unused-slot zeros.
+
+        let (_x_capable, stats) = aig.compute_x_capable_pins();
+        assert_eq!(stats.num_x_sources, 8);
     }
 
     #[test]

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -119,6 +119,15 @@ struct SimArgs {
     #[clap(long)]
     sdf_debug: bool,
 
+    /// Path to a user-supplied Verilog cell library. Repeatable. Each
+    /// file is parsed at startup; modules found in it become known to
+    /// the netlist reader without vendoring. If a sibling
+    /// `<file>.cells.toml` manifest is present, its per-cell `kind`
+    /// annotations are loaded automatically. See ADR 0010 and
+    /// `docs/plans/declarative-cell-metadata.md`.
+    #[clap(long = "cell-library", value_name = "PATH")]
+    cell_library: Vec<PathBuf>,
+
     /// Path to a Jacquard timing-IR (.jtir) file. Generate with the
     /// `opensta-to-ir` preprocessing tool. Mutually exclusive with `--sdf`.
     #[clap(long)]
@@ -257,6 +266,11 @@ struct CosimArgs {
     /// Number of cycles to dump DFF states for (used with --dump-dff).
     #[clap(long, default_value = "20")]
     dump_dff_cycles: usize,
+
+    /// Path to a user-supplied Verilog cell library. Repeatable. See
+    /// `jacquard sim --help` and ADR 0010 for details.
+    #[clap(long = "cell-library", value_name = "PATH")]
+    cell_library: Vec<PathBuf>,
 }
 
 #[derive(Parser)]
@@ -317,6 +331,7 @@ fn cmd_sim(args: SimArgs) {
         liberty: args.liberty.clone(),
         timing_ir: args.timing_ir.clone(),
         timing_corner: args.timing_corner.clone(),
+        cell_library: args.cell_library.clone(),
     };
 
     #[allow(unused_mut)]
@@ -1464,6 +1479,7 @@ fn cmd_dump_paths(args: DumpPathsArgs) {
         liberty: args.liberty.clone(),
         timing_ir: args.timing_ir.clone(),
         timing_corner: None,
+        cell_library: Vec::new(),
     };
 
     let mut design = setup::load_design(&design_args);
@@ -1547,6 +1563,7 @@ fn cmd_cosim(args: CosimArgs) {
             liberty: None,
             timing_ir: args.timing_ir.clone(),
             timing_corner: None,
+            cell_library: args.cell_library.clone(),
         };
 
         let mut design = setup::load_design(&design_args);

--- a/src/cell_library.rs
+++ b/src/cell_library.rs
@@ -1,0 +1,590 @@
+//! Runtime cell-library loading for third-party IP and user-supplied
+//! cells outside Jacquard's vendored PDKs.
+//!
+//! See [ADR 0010](../../docs/adr/0010-declarative-cell-metadata.md)
+//! and `docs/plans/declarative-cell-metadata.md`. This module is the
+//! Tier 1 + minimal Tier 2 slice:
+//!
+//! - `RuntimeCellLibrary` parses one or more user-supplied
+//!   `.v` files via `sverilogparse` to populate a runtime
+//!   pin-direction table (Tier 1).
+//! - The same struct can attach metadata loaded from
+//!   `<file>.cells.toml` siblings or an explicit
+//!   `--cell-manifest <PATH>.toml` (Tier 2, kind discriminator only
+//!   in v1.0).
+//! - `ChainedPinProvider` wraps a built-in `LeafPinProvider`
+//!   (e.g. `SKY130LeafPins`, `GF180MCULeafPins`) with the runtime
+//!   library. Cells the runtime knows about win; cells it does not
+//!   delegate to the built-in fallback. Existing tests stay green
+//!   because cells not present in the runtime library go through
+//!   exactly the same code path as before.
+//!
+//! Port-mapping schema (`[cells.NAME.ports]` sub-tables) is
+//! deliberately deferred to a future ADR — see ADR 0010 § "Deferred
+//! to a future ADR".
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use compact_str::CompactString;
+use netlistdb::{Direction, LeafPinProvider};
+use serde::Deserialize;
+use sverilogparse::{SVerilog, SVerilogRange, WireDefType};
+
+/// Per-cell kind discriminator. Mirrors today's hand-curated
+/// `is_<pdk>_*` classification lists in `sky130_pdk.rs` /
+/// `gf180mcu_pdk.rs`; future schema versions may attach port-mapping
+/// metadata alongside.
+///
+/// Wire format: deserialised from TOML as a lowercase string
+/// (`"ram"`, `"filler"`, …). Unknown values fail the manifest
+/// parse rather than degrading silently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CellKind {
+    /// Standard combinational logic cell. Default-routed through
+    /// `pdk_decomp::decompose_with_pdk`; manifests will rarely need
+    /// to declare this explicitly.
+    Std,
+    /// Edge-triggered flip-flop.
+    Dff,
+    /// Level-sensitive latch.
+    Latch,
+    /// Integrated clock-gating cell.
+    ClockGate,
+    /// Synchronous RAM macro. **v1.0 semantics: opaque mode —
+    /// `RAMBlock` allocated, outputs routed to X-source slots, no
+    /// port resolution.** Sufficient for designs whose CPU does not
+    /// read SRAM contents at the timescales Jacquard simulates.
+    /// Real memory modelling waits on the port-mapping schema.
+    Ram,
+    /// Physical-only filler / decap. Contributes no logic.
+    Filler,
+    /// Row-end / boundary cap. Physical-only.
+    Endcap,
+    /// Substrate tap. Physical-only.
+    Tap,
+    /// IO pad — input-only.
+    IoPadInput,
+    /// IO pad — output-only.
+    IoPadOutput,
+    /// IO pad — bidirectional (a/oe/y triple).
+    IoPadBidir,
+    /// Delay buffer (timing-only; behavioural identity).
+    Delay,
+    /// Multi-output cell (full adder, half adder, dual-output DFF).
+    MultiOutput,
+    /// Constant-1 driver.
+    TieHigh,
+    /// Constant-0 driver.
+    TieLow,
+}
+
+/// Top-level TOML manifest schema (v1.0).
+///
+/// ```toml
+/// schema_version = "1.0"
+///
+/// [cells.gf180mcu_ocd_ip_sram__sram1024x8m8wm1]
+/// kind = "ram"
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+pub struct ManifestFile {
+    pub schema_version: String,
+    #[serde(default)]
+    pub cells: HashMap<String, CellEntry>,
+}
+
+/// Per-cell manifest entry. In v1.0 the only field is `kind`; future
+/// schema versions add `ports = { ... }` and similar.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CellEntry {
+    pub kind: CellKind,
+}
+
+/// Runtime cell-library data — pin tables parsed from user-supplied
+/// `.v` files, optionally augmented with `kind` metadata from sibling
+/// `.cells.toml` manifests.
+#[derive(Debug, Default)]
+pub struct RuntimeCellLibrary {
+    /// `(macro_name, pin_name) → (Direction, Option<width>)`.
+    /// `Direction::Unknown` is used for `inout` ports (matching how
+    /// built-in providers represent power pins and bidir IO).
+    /// `width` is `Some` for bus pins (e.g. `Q[7:0]`), `None` for
+    /// single-bit pins.
+    pins: HashMap<CompactString, HashMap<CompactString, PinInfo>>,
+    /// `macro_name → CellKind`. Populated from manifest TOML files;
+    /// pins-only entries (no manifest sibling) leave the kind unset.
+    kinds: HashMap<CompactString, CellKind>,
+}
+
+/// Direction + optional bus width for a single pin on a runtime cell.
+#[derive(Debug, Clone)]
+struct PinInfo {
+    direction: Direction,
+    width: Option<SVerilogRange>,
+}
+
+/// Failure to load a runtime cell library — either Verilog or TOML.
+#[derive(Debug)]
+pub enum LoadError {
+    Io {
+        path: PathBuf,
+        err: std::io::Error,
+    },
+    VerilogParse {
+        path: PathBuf,
+        message: String,
+    },
+    ManifestParse {
+        path: PathBuf,
+        err: toml::de::Error,
+    },
+    UnsupportedSchemaVersion {
+        path: PathBuf,
+        found: String,
+    },
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoadError::Io { path, err } => {
+                write!(f, "reading {}: {err}", path.display())
+            }
+            LoadError::VerilogParse { path, message } => {
+                write!(f, "parsing {}: {message}", path.display())
+            }
+            LoadError::ManifestParse { path, err } => {
+                write!(f, "parsing manifest {}: {err}", path.display())
+            }
+            LoadError::UnsupportedSchemaVersion { path, found } => write!(
+                f,
+                "manifest {} declares schema_version = \"{found}\" — \
+                 only \"1.0\" is supported in this build",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {}
+
+impl RuntimeCellLibrary {
+    /// Parse one or more user-supplied `.v` files. Each file is fed
+    /// through `sverilogparse`; every `module … endmodule` block
+    /// contributes pin-direction entries.
+    ///
+    /// Sibling `<file>.cells.toml` manifests, if present, are
+    /// autoloaded — explicit manifest paths can be added via
+    /// [`Self::load_manifest`] afterwards (the explicit-flag wins
+    /// because it's applied last).
+    ///
+    /// Later files (and later manifests) override earlier ones for
+    /// collisions and emit a `clilog::warn!` so accidental overlap
+    /// surfaces. Built-in PDK providers always win over the
+    /// runtime library (see [`ChainedPinProvider`]).
+    pub fn from_files(library_paths: &[PathBuf]) -> Result<Self, LoadError> {
+        let mut lib = Self::default();
+        for path in library_paths {
+            lib.load_verilog(path)?;
+            let manifest_sibling = with_cells_toml_extension(path);
+            if manifest_sibling.exists() {
+                lib.load_manifest(&manifest_sibling)?;
+            }
+        }
+        Ok(lib)
+    }
+
+    /// Parse a single Verilog file and merge its modules into the
+    /// pin table. Called from `from_files`; exposed for tests.
+    pub fn load_verilog(&mut self, path: &Path) -> Result<(), LoadError> {
+        let bytes = std::fs::read(path).map_err(|err| LoadError::Io {
+            path: path.to_path_buf(),
+            err,
+        })?;
+        let parsed =
+            SVerilog::parse_u8slice(&bytes).map_err(|message| LoadError::VerilogParse {
+                path: path.to_path_buf(),
+                message,
+            })?;
+        for (module_name, module) in &parsed.modules {
+            let mut entry: HashMap<CompactString, PinInfo> = HashMap::new();
+            for def in &module.defs {
+                let direction = match def.typ {
+                    WireDefType::Input => Direction::I,
+                    WireDefType::Output => Direction::O,
+                    // netlistdb treats inout as Unknown (per
+                    // src/lib.rs:11 "inout is not supported yet").
+                    // Match the built-in providers' behaviour.
+                    WireDefType::InOut => Direction::Unknown,
+                    WireDefType::Wire => continue,
+                };
+                entry.insert(
+                    def.name.clone(),
+                    PinInfo {
+                        direction,
+                        width: def.width.clone(),
+                    },
+                );
+            }
+            if entry.is_empty() {
+                continue;
+            }
+            if self.pins.contains_key(module_name) {
+                clilog::warn!(
+                    "cell library: module `{module_name}` redefined while parsing {}",
+                    path.display()
+                );
+            }
+            self.pins.insert(module_name.clone(), entry);
+        }
+        Ok(())
+    }
+
+    /// Load a TOML manifest into the kind table. Multiple manifests
+    /// may target the same library; later wins, with a warning.
+    pub fn load_manifest(&mut self, path: &Path) -> Result<(), LoadError> {
+        let text = std::fs::read_to_string(path).map_err(|err| LoadError::Io {
+            path: path.to_path_buf(),
+            err,
+        })?;
+        let parsed: ManifestFile =
+            toml::from_str(&text).map_err(|err| LoadError::ManifestParse {
+                path: path.to_path_buf(),
+                err,
+            })?;
+        if parsed.schema_version != "1.0" {
+            return Err(LoadError::UnsupportedSchemaVersion {
+                path: path.to_path_buf(),
+                found: parsed.schema_version,
+            });
+        }
+        for (cell_name, entry) in parsed.cells {
+            let key = CompactString::new(cell_name);
+            if self.kinds.contains_key(&key) {
+                clilog::warn!(
+                    "cell library: kind for `{key}` redefined by manifest {}",
+                    path.display()
+                );
+            }
+            self.kinds.insert(key, entry.kind);
+        }
+        Ok(())
+    }
+
+    /// True if any cell library files were loaded (helpful for
+    /// gating logging / diagnostic paths).
+    pub fn is_empty(&self) -> bool {
+        self.pins.is_empty() && self.kinds.is_empty()
+    }
+
+    /// Number of (module, pin) entries currently in the pin table.
+    /// Diagnostic-only.
+    pub fn pin_entry_count(&self) -> usize {
+        self.pins.values().map(|m| m.len()).sum()
+    }
+
+    /// Number of cells with a kind annotation.
+    pub fn kind_entry_count(&self) -> usize {
+        self.kinds.len()
+    }
+
+    /// Lookup a (macro, pin) direction. Returns `None` if the runtime
+    /// library has nothing to say — the chained provider's caller
+    /// then delegates to its built-in fallback.
+    pub fn lookup_pin(
+        &self,
+        macro_name: &CompactString,
+        pin_name: &CompactString,
+    ) -> Option<Direction> {
+        Some(self.pins.get(macro_name)?.get(pin_name)?.direction.clone())
+    }
+
+    /// Lookup a (macro, pin) bus width. Returns `None` for unknown
+    /// cells, unknown pins, or single-bit pins.
+    pub fn lookup_width(
+        &self,
+        macro_name: &CompactString,
+        pin_name: &CompactString,
+    ) -> Option<SVerilogRange> {
+        self.pins.get(macro_name)?.get(pin_name)?.width.clone()
+    }
+
+    /// Lookup the declared kind for a cell. `None` means the cell
+    /// is unknown to the runtime library.
+    pub fn lookup_kind(&self, macro_name: &str) -> Option<CellKind> {
+        self.kinds.get(macro_name).copied()
+    }
+}
+
+fn with_cells_toml_extension(path: &Path) -> PathBuf {
+    // `foo.v` → `foo.cells.toml`; `foo.bar.v` → `foo.bar.cells.toml`.
+    let file_name = path.file_name().map(|n| n.to_string_lossy().into_owned());
+    match file_name {
+        Some(name) => {
+            let stem = name.strip_suffix(".v").unwrap_or(&name);
+            path.with_file_name(format!("{stem}.cells.toml"))
+        }
+        None => path.with_extension("cells.toml"),
+    }
+}
+
+/// Chained pin-direction provider. The runtime library answers for
+/// cells it knows about; everything else delegates to `fallback`.
+pub struct ChainedPinProvider<'a, P: LeafPinProvider> {
+    pub runtime: &'a RuntimeCellLibrary,
+    pub fallback: &'a P,
+}
+
+impl<P: LeafPinProvider> LeafPinProvider for ChainedPinProvider<'_, P> {
+    fn direction_of(
+        &self,
+        macro_name: &CompactString,
+        pin_name: &CompactString,
+        pin_idx: Option<isize>,
+    ) -> Direction {
+        if let Some(dir) = self.runtime.lookup_pin(macro_name, pin_name) {
+            return dir;
+        }
+        self.fallback.direction_of(macro_name, pin_name, pin_idx)
+    }
+
+    fn width_of(
+        &self,
+        macro_name: &CompactString,
+        pin_name: &CompactString,
+    ) -> Option<SVerilogRange> {
+        if let Some(width) = self.runtime.lookup_width(macro_name, pin_name) {
+            return Some(width);
+        }
+        self.fallback.width_of(macro_name, pin_name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &TempDir, name: &str, content: &str) -> PathBuf {
+        let path = dir.path().join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        path
+    }
+
+    const OCD_SRAM_VERILOG: &str = "\
+module gf180mcu_ocd_ip_sram__sram1024x8m8wm1 (
+    CLK, CEN, GWEN, WEN, A, D, Q
+);
+  input CLK, CEN, GWEN;
+  input [7:0] WEN;
+  input [9:0] A;
+  input [7:0] D;
+  output [7:0] Q;
+endmodule
+";
+
+    #[test]
+    fn parses_verilog_pin_directions() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "ocd_sram.v", OCD_SRAM_VERILOG);
+        let mut lib = RuntimeCellLibrary::default();
+        lib.load_verilog(&path).unwrap();
+
+        let macro_name =
+            CompactString::new("gf180mcu_ocd_ip_sram__sram1024x8m8wm1");
+        assert_eq!(
+            lib.lookup_pin(&macro_name, &CompactString::new("CLK")),
+            Some(Direction::I)
+        );
+        assert_eq!(
+            lib.lookup_pin(&macro_name, &CompactString::new("Q")),
+            Some(Direction::O)
+        );
+        // Unknown pin
+        assert_eq!(
+            lib.lookup_pin(&macro_name, &CompactString::new("nope")),
+            None
+        );
+        // Unknown macro
+        assert_eq!(
+            lib.lookup_pin(&CompactString::new("other_cell"), &CompactString::new("CLK")),
+            None
+        );
+    }
+
+    #[test]
+    fn parses_inout_as_unknown() {
+        // netlistdb's Direction enum has no Inout variant — built-in
+        // providers map inout to Unknown. Manifest path must match.
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "powered.v",
+            "module powered_cell (VDD, VSS, A);\n  inout VDD, VSS;\n  input A;\nendmodule\n",
+        );
+        let mut lib = RuntimeCellLibrary::default();
+        lib.load_verilog(&path).unwrap();
+        let macro_name = CompactString::new("powered_cell");
+        assert_eq!(
+            lib.lookup_pin(&macro_name, &CompactString::new("VDD")),
+            Some(Direction::Unknown)
+        );
+        assert_eq!(
+            lib.lookup_pin(&macro_name, &CompactString::new("A")),
+            Some(Direction::I)
+        );
+    }
+
+    #[test]
+    fn parses_manifest_kind() {
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, "ocd_sram.v", OCD_SRAM_VERILOG);
+        write_file(
+            &dir,
+            "ocd_sram.cells.toml",
+            "schema_version = \"1.0\"\n\
+             [cells.gf180mcu_ocd_ip_sram__sram1024x8m8wm1]\n\
+             kind = \"ram\"\n",
+        );
+        let lib =
+            RuntimeCellLibrary::from_files(&[dir.path().join("ocd_sram.v")]).unwrap();
+        assert_eq!(
+            lib.lookup_kind("gf180mcu_ocd_ip_sram__sram1024x8m8wm1"),
+            Some(CellKind::Ram)
+        );
+        assert_eq!(lib.lookup_kind("not_there"), None);
+    }
+
+    #[test]
+    fn rejects_unsupported_schema_version() {
+        let dir = TempDir::new().unwrap();
+        let manifest = write_file(
+            &dir,
+            "x.cells.toml",
+            "schema_version = \"2.0\"\n",
+        );
+        let mut lib = RuntimeCellLibrary::default();
+        let err = lib.load_manifest(&manifest).unwrap_err();
+        assert!(matches!(err, LoadError::UnsupportedSchemaVersion { .. }));
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        let dir = TempDir::new().unwrap();
+        let manifest = write_file(
+            &dir,
+            "x.cells.toml",
+            "schema_version = \"1.0\"\n[cells.foo]\nkind = \"quantum\"\n",
+        );
+        let mut lib = RuntimeCellLibrary::default();
+        let err = lib.load_manifest(&manifest).unwrap_err();
+        assert!(matches!(err, LoadError::ManifestParse { .. }));
+    }
+
+    #[test]
+    fn from_files_autoloads_sibling_manifest() {
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, "ocd_sram.v", OCD_SRAM_VERILOG);
+        write_file(
+            &dir,
+            "ocd_sram.cells.toml",
+            "schema_version = \"1.0\"\n\
+             [cells.gf180mcu_ocd_ip_sram__sram1024x8m8wm1]\n\
+             kind = \"ram\"\n",
+        );
+        let lib =
+            RuntimeCellLibrary::from_files(&[dir.path().join("ocd_sram.v")]).unwrap();
+        assert_eq!(
+            lib.lookup_kind("gf180mcu_ocd_ip_sram__sram1024x8m8wm1"),
+            Some(CellKind::Ram)
+        );
+        // Pins also populated.
+        let macro_name =
+            CompactString::new("gf180mcu_ocd_ip_sram__sram1024x8m8wm1");
+        assert_eq!(
+            lib.lookup_pin(&macro_name, &CompactString::new("Q")),
+            Some(Direction::O)
+        );
+    }
+
+    #[test]
+    fn from_files_succeeds_without_manifest_sibling() {
+        let dir = TempDir::new().unwrap();
+        write_file(&dir, "ocd_sram.v", OCD_SRAM_VERILOG);
+        // No .cells.toml — pins-only load should still succeed.
+        let lib =
+            RuntimeCellLibrary::from_files(&[dir.path().join("ocd_sram.v")]).unwrap();
+        assert!(lib.kind_entry_count() == 0);
+        assert!(lib.pin_entry_count() > 0);
+    }
+
+    #[test]
+    fn chained_provider_runtime_wins_then_fallback() {
+        struct AlwaysOutput;
+        impl LeafPinProvider for AlwaysOutput {
+            fn direction_of(
+                &self,
+                _: &CompactString,
+                _: &CompactString,
+                _: Option<isize>,
+            ) -> Direction {
+                Direction::O
+            }
+            fn width_of(&self, _: &CompactString, _: &CompactString) -> Option<SVerilogRange> {
+                None
+            }
+        }
+
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "x.v", OCD_SRAM_VERILOG);
+        let mut runtime = RuntimeCellLibrary::default();
+        runtime.load_verilog(&path).unwrap();
+        let fallback = AlwaysOutput;
+        let chained = ChainedPinProvider {
+            runtime: &runtime,
+            fallback: &fallback,
+        };
+
+        // Runtime knows about CLK on the OCD SRAM — should win.
+        assert_eq!(
+            chained.direction_of(
+                &CompactString::new("gf180mcu_ocd_ip_sram__sram1024x8m8wm1"),
+                &CompactString::new("CLK"),
+                None,
+            ),
+            Direction::I
+        );
+        // Runtime doesn't know about this cell — falls through.
+        assert_eq!(
+            chained.direction_of(
+                &CompactString::new("unknown_cell"),
+                &CompactString::new("any_pin"),
+                None,
+            ),
+            Direction::O
+        );
+    }
+
+    #[test]
+    fn cells_toml_extension_helper() {
+        assert_eq!(
+            with_cells_toml_extension(Path::new("foo.v")),
+            PathBuf::from("foo.cells.toml")
+        );
+        assert_eq!(
+            with_cells_toml_extension(Path::new("a/b/foo.bar.v")),
+            PathBuf::from("a/b/foo.bar.cells.toml")
+        );
+        // Non-.v extension — append rather than replace; the
+        // function is only invoked on `--cell-library` paths and
+        // .v is the dominant case.
+        assert_eq!(
+            with_cells_toml_extension(Path::new("x.sv")),
+            PathBuf::from("x.sv.cells.toml")
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ pub mod gf180mcu_pdk;
 
 pub mod pdk;
 
+pub mod cell_library;
+
 pub mod pdk_decomp;
 
 pub mod aig;

--- a/src/sim/setup.rs
+++ b/src/sim/setup.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::aig::{DriverType, AIG};
 use crate::aigpdk::AIGPDKLeafPins;
+use crate::cell_library::{ChainedPinProvider, RuntimeCellLibrary};
 use crate::display::extract_display_info_from_json;
 use crate::flatten::FlattenedScriptV1;
 use crate::pe::{process_partitions, Partition};
@@ -40,6 +41,13 @@ pub struct DesignArgs {
     /// that name is selected; when unset, corner index 0 (the first
     /// declared corner) is used.
     pub timing_corner: Option<String>,
+    /// User-supplied Verilog cell library files. Each is parsed at
+    /// startup via `sverilogparse` and made available to the netlist
+    /// reader through `ChainedPinProvider`. Sibling
+    /// `<file>.cells.toml` manifests are autoloaded for per-cell
+    /// `kind` annotations. See ADR 0010 and
+    /// `docs/plans/declarative-cell-metadata.md`.
+    pub cell_library: Vec<PathBuf>,
 }
 
 /// Result of loading a design: everything needed for simulation.
@@ -65,31 +73,72 @@ pub fn load_design(args: &DesignArgs) -> LoadedDesign {
         panic!("Mixed cells from multiple PDKs in netlist not supported");
     }
 
+    // Load any user-supplied runtime cell libraries (`--cell-library`).
+    // Empty when no flags were passed; in that case the chained
+    // provider degenerates to its built-in fallback.
+    let runtime_lib = if args.cell_library.is_empty() {
+        RuntimeCellLibrary::default()
+    } else {
+        let loaded = RuntimeCellLibrary::from_files(&args.cell_library)
+            .unwrap_or_else(|e| panic!("loading --cell-library: {e}"));
+        clilog::info!(
+            "Loaded {} cell-library pin entries, {} kind annotations from --cell-library",
+            loaded.pin_entry_count(),
+            loaded.kind_entry_count()
+        );
+        loaded
+    };
+
     let netlistdb = match lib {
-        CellLibrary::SKY130 => NetlistDB::from_sverilog_file(
-            &args.netlist_verilog,
-            args.top_module.as_deref(),
-            &SKY130LeafPins,
-        )
-        .expect("cannot build netlist"),
+        CellLibrary::SKY130 => {
+            let provider = ChainedPinProvider {
+                runtime: &runtime_lib,
+                fallback: &SKY130LeafPins,
+            };
+            NetlistDB::from_sverilog_file(
+                &args.netlist_verilog,
+                args.top_module.as_deref(),
+                &provider,
+            )
+            .expect("cannot build netlist")
+        }
         // GF180MCU (7t5v0 + 9t5v0). Combinational + sequential paths
         // (DFFs, latches, scan, clock-gating) are all wired through
         // `AIG::from_netlistdb` → `gf180mcu_postprocess`.
-        CellLibrary::GF180MCU => NetlistDB::from_sverilog_file(
-            &args.netlist_verilog,
-            args.top_module.as_deref(),
-            &crate::gf180mcu::GF180MCULeafPins,
-        )
-        .expect("cannot build netlist"),
-        CellLibrary::AIGPDK | CellLibrary::Mixed => NetlistDB::from_sverilog_file(
-            &args.netlist_verilog,
-            args.top_module.as_deref(),
-            &AIGPDKLeafPins(),
-        )
-        .expect("cannot build netlist"),
+        CellLibrary::GF180MCU => {
+            let provider = ChainedPinProvider {
+                runtime: &runtime_lib,
+                fallback: &crate::gf180mcu::GF180MCULeafPins,
+            };
+            NetlistDB::from_sverilog_file(
+                &args.netlist_verilog,
+                args.top_module.as_deref(),
+                &provider,
+            )
+            .expect("cannot build netlist")
+        }
+        CellLibrary::AIGPDK | CellLibrary::Mixed => {
+            let provider = ChainedPinProvider {
+                runtime: &runtime_lib,
+                fallback: &AIGPDKLeafPins(),
+            };
+            NetlistDB::from_sverilog_file(
+                &args.netlist_verilog,
+                args.top_module.as_deref(),
+                &provider,
+            )
+            .expect("cannot build netlist")
+        }
     };
 
+    // P3a: runtime_lib is wired into the netlist reader above; the
+    // AIG-construction-side consultation (manifest `kind = "ram"` →
+    // opaque-RAM `RAMBlock`) lands in P3b. Until then, unknown cells
+    // continue to fall through the existing AIGPDK fallback —
+    // sufficient for the cell-library CLI surface area to compile,
+    // not yet sufficient to unblock third-party SRAM macros.
     let mut aig = AIG::from_netlistdb(&netlistdb);
+    let _ = &runtime_lib; // silence unused warning until P3b
 
     // Load display format info from JSON if available
     let json_path = args

--- a/src/sim/setup.rs
+++ b/src/sim/setup.rs
@@ -131,14 +131,17 @@ pub fn load_design(args: &DesignArgs) -> LoadedDesign {
         }
     };
 
-    // P3a: runtime_lib is wired into the netlist reader above; the
-    // AIG-construction-side consultation (manifest `kind = "ram"` →
-    // opaque-RAM `RAMBlock`) lands in P3b. Until then, unknown cells
-    // continue to fall through the existing AIGPDK fallback —
-    // sufficient for the cell-library CLI surface area to compile,
-    // not yet sufficient to unblock third-party SRAM macros.
-    let mut aig = AIG::from_netlistdb(&netlistdb);
-    let _ = &runtime_lib; // silence unused warning until P3b
+    // Runtime cell library is consulted both for pin tables (above,
+    // via ChainedPinProvider) and for `kind` metadata (here, by
+    // AIG::from_netlistdb_with_cells). For `kind = "ram"` cells
+    // outside the vendored PDKs, AIG construction allocates opaque
+    // RAMBlock slots whose outputs are X-source. See ADR 0010.
+    let cell_lib_ref = if runtime_lib.is_empty() {
+        None
+    } else {
+        Some(&runtime_lib)
+    };
+    let mut aig = AIG::from_netlistdb_with_cells(&netlistdb, cell_lib_ref);
 
     // Load display format info from JSON if available
     let json_path = args


### PR DESCRIPTION
Implements [#67](https://github.com/ChipFlow/Jacquard/issues/67)'s Tier 1 + minimal Tier 2 slice.

## Summary

- **\`--cell-library <PATH>.v\`** (repeatable) on \`jacquard sim\` and \`cosim\`: runtime Verilog parsing via \`sverilogparse\` for third-party IP pin tables, no vendoring needed.
- **\`<PATH>.cells.toml\` manifest** (TOML, autoloaded sibling): per-cell \`kind\` discriminator with v1.0 vocabulary (\`std\` / \`dff\` / \`latch\` / \`clock_gate\` / \`ram\` / \`filler\` / \`endcap\` / \`tap\` / \`io_pad_*\` / \`delay\` / \`multi_output\` / \`tie_*\`).
- **Opaque-RAM semantics** for \`kind = "ram"\` in v1.0 — \`RAMBlock\` allocated, outputs routed to X-source slots, no port resolution. Sufficient for the heartbeat-verification use case driving this work. Real memory modelling deferred to a future schema version with explicit port mapping.

Built-in classifiers (\`sky130.rs\`, \`gf180mcu.rs\`, \`build.rs\` scanner) stay as fallback through the whole transition.

## Phases (all landed)

| Phase | Commit | What |
|---|---|---|
| docs | \`ae6cfa8\` | ADR 0010 + plan doc |
| P1+P2 | \`258707d\` | \`src/cell_library.rs\` — \`RuntimeCellLibrary\` + \`ChainedPinProvider\` + 10 unit tests |
| P3a | \`642e5ab\` | CLI \`--cell-library\` flag + \`load_design\` integration |
| P3b | \`ffc0b4c\` | AIG \`from_netlistdb_with_cells\` opaque-RAM path + \`compute_x_sources\` relaxation + narrow-RAM unit test |
| P4 | \`84b2187\` | End-to-end integration test mirroring \`gf180mcu_ocd_ip_sram__sram1024x8m8wm1\` |
| P5 | \`7f3a3ea\` | \`adding-a-pdk.md\` manifest-pathway section + \`gf180mcu-enablement.md\` follow-on cleanup marked superseded |

## Test plan

- [x] Unit tests for TOML manifest parsing (schema_version, kind vocabulary, autoload discovery, conflict warnings) — 10 tests in \`src/cell_library.rs\`
- [x] Unit tests for chained \`LeafPinProvider\` precedence (runtime wins, fallback for unknown cells)
- [x] Unit test for narrow-RAM \`compute_x_sources\` (8-bit Q output, 24 unused slots)
- [x] End-to-end integration test: synthetic OCD SRAM Verilog + manifest → \`NetlistDB::from_sverilog_source\` → \`AIG::from_netlistdb_with_cells\` → \`compute_x_sources\` returns 8 X-sources
- [x] Full lib test suite: 240 passed (was 239 before this PR; +1 for the integration test)

## What's deferred

- **Port-mapping schema** (\`[cells.NAME.ports]\` sub-tables). Future ADR after Tier 1 + minimal Tier 2 see real adoption.
- **Migration of built-in \`sky130.rs\` / \`gf180mcu.rs\` classifiers to manifest data.** They stay load-bearing as the fallback. ADR 0010 § "Deferred to a future ADR" calls this out explicitly.
- **\`build.rs\` pin-table scanner removal.** Same rule — removed LAST, after manifests are the source of truth for at least one PDK in production.

Closes #67 (directional sign-off + spike) — the port-mapping schema work is a separate issue.