### PR TITLE
fix(aig): skip power pins during clock-buffer pin enumeration (#70)

### DIFF
--- a/src/aig.rs
+++ b/src/aig.rs
@@ -602,7 +602,20 @@ impl AIG {
 
             for ipin in netlistdb.cell2pin.iter_set(cellid) {
                 if netlistdb.pindirect[ipin] == Direction::I {
-                    match netlistdb.pinnames[ipin].1.as_str() {
+                    let ipin_name = netlistdb.pinnames[ipin].1.as_str();
+                    // Power / ground pins on the clock-buffer cell. Post-#64
+                    // these resolve to `Direction::I` (the power-pin
+                    // shortcut in `GF180MCULeafPins::direction_of`), but
+                    // they're physical supply connections — never a clock
+                    // source. Skipping here keeps the "multi-input ⇒ clock
+                    // gating" rule honest by ignoring them, the same way
+                    // the IO-pad control pins below are ignored. See #70.
+                    if matches!(variant, Some(PdkVariant::Gf180Mcu))
+                        && crate::gf180mcu_pdk::is_power_pin(ipin_name)
+                    {
+                        continue;
+                    }
+                    match ipin_name {
                         // AIGPDK / sky130 use `A`; GF180MCU buf/inv cells
                         // use `I`; GF180MCU input pads carry the clock
                         // on `PAD`.

--- a/src/gf180mcu.rs
+++ b/src/gf180mcu.rs
@@ -183,14 +183,10 @@ impl LeafPinProvider for GF180MCULeafPins {
         // `inout VDD, VSS;` on antenna) but build.rs only parses
         // `input`/`output` declarations, so the generated GF180MCU_PIN_TABLE
         // is missing them. The post-PnR netlist connects them explicitly,
-        // which otherwise panics on the first VDD lookup. Local
-        // apitronix-integration patch (2026-05-16) — file upstream once
-        // verified across enough cells.
-        if matches!(
-            pin_name.as_str(),
-            "VDD" | "VSS" | "VNW" | "VPW" | "VPB" | "VNB" | "VPWR" | "VGND"
-                | "DVDD" | "DVSS" | "AVDD" | "AVSS"
-        ) {
+        // which otherwise panics on the first VDD lookup. The name set
+        // lives in `gf180mcu_pdk::POWER_PIN_NAMES` so the clock-tracing
+        // pin-enumeration skip in aig.rs uses the same source of truth.
+        if crate::gf180mcu_pdk::is_power_pin(pin_name.as_str()) {
             // Direction enum in eda-infra-rs has no `Inout` variant
             // (I / O / Unknown only). Power pins are effectively inputs —
             // driven from the supply, never driven by the cell — so `I`
@@ -481,6 +477,47 @@ endmodule
         // Exact AIG-pin count varies with synthesis choices; just assert
         // construction succeeded and produced a non-empty AIG.
         assert!(aig.num_aigpins > 0, "AIG should have at least one pin");
+    }
+
+    #[test]
+    fn aig_clock_trace_skips_power_pins_on_clkbuf() {
+        // Regression for #70: post-#64, power pins on a clkbuf resolve to
+        // `Direction::I`, which made the clock-tracing pin-enumeration
+        // loop treat them as unrecognised signal inputs and panic with
+        // "input pin VDD unexpected for ck element ... multi-input cell
+        // ... clock gating need to be manually patched."
+        //
+        // Synthetic shape: a single DFF clocked through a clkbuf that
+        // has VDD / VSS wired (the real-world chip_top.pnl.v pattern).
+        // Without the fix the AIG::from_netlistdb call panics during
+        // clock tracing.
+        const VERILOG: &str = r#"
+module tiny(CLK_PAD, D, Q);
+  input CLK_PAD, D;
+  output Q;
+  wire CLK_INTERNAL, VDD, VSS, notifier;
+  // Clock buffer with realistic power-pin wiring.
+  gf180mcu_fd_sc_mcu9t5v0__clkbuf_8 CLKBUF_1 (
+      .I(CLK_PAD), .Z(CLK_INTERNAL), .VDD(VDD), .VSS(VSS), .VNW(VDD), .VPW(VSS)
+  );
+  gf180mcu_fd_sc_mcu7t5v0__dffq_1 DFF_1 (
+      .CLK(CLK_INTERNAL), .D(D), .Q(Q), .notifier(notifier)
+  );
+endmodule
+"#;
+        let nl = netlistdb::NetlistDB::from_sverilog_source(
+            VERILOG,
+            Some("tiny"),
+            &GF180MCULeafPins,
+        )
+        .expect("netlist parse");
+        // The actual test: this used to panic. After the fix, AIG
+        // construction completes without error.
+        let aig = crate::aig::AIG::from_netlistdb(&nl);
+        assert!(
+            aig.num_aigpins > 0,
+            "AIG should have at least one pin after clock tracing"
+        );
     }
 
     #[test]

--- a/src/gf180mcu_pdk.rs
+++ b/src/gf180mcu_pdk.rs
@@ -394,6 +394,29 @@ pub fn is_multi_output_cell(cell_type: &str) -> bool {
     matches!(cell_type, "addf" | "addh")
 }
 
+/// Power / ground pin name set used across the GF180MCU standard-cell
+/// and pad libraries, plus the wafer.space power-pad naming
+/// (`DVDD`/`DVSS`/`AVDD`/`AVSS`). Single source of truth for both
+/// pin-direction resolution (`GF180MCULeafPins::direction_of`) and
+/// the clock-tracing pin-enumeration skip in `aig.rs`. See PR #70
+/// for context on the latter: post-#64 these names resolve to
+/// `Direction::I`, so the clock-tracer's "any non-clock input pin
+/// ⇒ multi-input cell ⇒ clock gating" rule started tripping on
+/// every clkbuf cell that has wired power pins.
+pub const POWER_PIN_NAMES: &[&str] = &[
+    "VDD", "VSS", "VNW", "VPW", "VPB", "VNB", "VPWR", "VGND", "DVDD", "DVSS", "AVDD", "AVSS",
+];
+
+/// True if `name` is a power / ground pin per [`POWER_PIN_NAMES`].
+///
+/// Power pins are physical (supply) connections — they are never
+/// driven by, and do not drive, simulation logic. Callers should
+/// short-circuit them: resolve to `Direction::I` for the netlist
+/// reader, skip them during clock-path pin enumeration, etc.
+pub fn is_power_pin(name: &str) -> bool {
+    POWER_PIN_NAMES.contains(&name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Closes #70.

## Summary

Post-#64, GF180MCU power-pin names resolve to \`Direction::I\` via \`GF180MCULeafPins::direction_of\`'s short-circuit, so post-P&R netlists wire VDD/VSS/etc on every cell without panicking the netlist reader. But the AIG clock-tracing path enumerates all \`Direction::I\` pins of a clock-buffer cell and treats anything outside its recognised name set as unexpected signal input — triggering the \"multi-input cell ⇒ clock gating\" error path. Every gf180mcu clkbuf in a real chip_top tripped it.

Fix is name-keyed: skip power-pin names in the clock-trace enumeration loop, gated on \`variant == Some(PdkVariant::Gf180Mcu)\` so AIGPDK / SKY130 paths are unchanged. Real intentional clock gating still trips the existing check.

The power-pin name set moves from a duplicated \`matches!()\` block in \`gf180mcu.rs\` into a single \`POWER_PIN_NAMES\` const + \`is_power_pin()\` helper in \`gf180mcu_pdk.rs\`, used by both pin-direction resolution (#64's site) and the clock-trace skip (this PR's site).

## Test plan

- [x] New regression test \`aig_clock_trace_skips_power_pins_on_clkbuf\` in \`src/gf180mcu.rs\` — synthetic netlist with a DFF clocked through a clkbuf with VDD/VSS/VNW/VPW wired; \`AIG::from_netlistdb\` completes without panicking. Test wouldn't compile-pass without the fix.
- [x] Full lib test suite: 241 passed (was 240; +1 for the regression test)
- [x] Pre-existing \`netlist_db_parses_wired_chip_top_pad_ring\` (#64's test) stays green — power-pin direction resolution unchanged

## Notes

Also scrubs the stale \`apitronix-integration patch (2026-05-16)\` comment in \`gf180mcu.rs::direction_of\` (carried over from #64) per the confidentiality preference established earlier today.