### PR TITLE
fix: bump sverilogparse to accept ANSI-style port lists (#69)

### DIFF
--- a/src/aig.rs
+++ b/src/aig.rs
@@ -3356,19 +3356,25 @@ mod xprop_tests {
         use sverilogparse::SVerilogRange;
 
         // Blackbox interface mirroring
-        // gf180mcu_ocd_ip_sram__sram1024x8m8wm1. Uses the
-        // module-header-only port list with separate declarations
-        // (sverilogparse's preferred shape — confirmed by the
-        // existing AIGPDK / SKY130 / GF180MCU vendored blackboxes).
+        // gf180mcu_ocd_ip_sram__sram1024x8m8wm1, verbatim from
+        // RTimothyEdwards/gf180mcu_ocd_ip_sram. Uses the ANSI-style
+        // port-list form that's dominant in modern third-party IP
+        // blackbox.v files — supported via the sverilogparse fix
+        // in ChipFlow/eda-infra-rs#1 (closes #69). Before that fix
+        // landed, this test had to be written in the older
+        // port-names-in-header + separate body declarations form
+        // as a workaround.
         const OCD_SRAM_BLACKBOX: &str = "\
-module gf180mcu_ocd_ip_sram__sram1024x8m8wm1 (CLK, CEN, GWEN, WEN, A, D, Q);
-  input CLK;
-  input CEN;
-  input GWEN;
-  input [7:0] WEN;
-  input [9:0] A;
-  input [7:0] D;
-  output [7:0] Q;
+(* blackbox *)
+module gf180mcu_ocd_ip_sram__sram1024x8m8wm1 (
+  input         CLK,
+  input         CEN,
+  input         GWEN,
+  input  [7:0]  WEN,
+  input  [9:0]  A,
+  input  [7:0]  D,
+  output [7:0]  Q
+);
 endmodule
 ";
 


### PR DESCRIPTION
Closes #69.

## Summary

Bumps \`vendor/eda-infra-rs\` to \`e4e3db0\`, which carries the sverilogparse parser extension landed in [ChipFlow/eda-infra-rs#1](https://github.com/ChipFlow/eda-infra-rs/pull/1) — accepts Verilog 2001 ANSI-style port declarations:

\`\`\`verilog
module foo (
  input         CLK,
  input  [7:0]  WEN,
  output [7:0]  Q
);
\`\`\`

The previous parser only handled Verilog 1995 (port-names-in-header + separate body-level \`input\`/\`output\` declarations), so the \`--cell-library\` pathway from #68 hit a parse error on the very first ANSI blackbox.v it tried to consume. Per ADR 0010 § Tier 1's "third-party IP blackbox.v files directly, no vendoring" promise, this was the dominant remaining blocker for downstream wafer.space tapeouts pointing \`--cell-library\` at upstream IP.

Implementation details on the parser side live in [eda-infra-rs#1](https://github.com/ChipFlow/eda-infra-rs/pull/1). Public API of \`sverilogparse\` is unchanged.

## Demonstrated end-to-end

Flips the P4 opaque-RAM integration test fixture (\`test_opaque_ram_end_to_end\` in \`src/aig.rs\`) from the workaround \"port-names-in-header + separate body declarations\" form back to the upstream ANSI form — verbatim from \`RTimothyEdwards/gf180mcu_ocd_ip_sram\`, including the \`(* blackbox *)\` attribute that triggered #69 alongside the ANSI ports.

\`\`\`verilog
(* blackbox *)
module gf180mcu_ocd_ip_sram__sram1024x8m8wm1 (
  input         CLK,
  input         CEN,
  input         GWEN,
  input  [7:0]  WEN,
  input  [9:0]  A,
  input  [7:0]  D,
  output [7:0]  Q
);
endmodule
\`\`\`

## Test plan

- [x] Full lib test suite: 241 passed (no regressions from the submodule bump or the fixture rewrite)
- [x] \`test_opaque_ram_end_to_end\` passes with the ANSI fixture — confirms the upstream parser fix is live in Jacquard's path
- [x] All other \`--cell-library\`-touching tests stay green (\`cell_library::tests::*\`, \`gf180mcu::tests::aig_clock_trace_skips_power_pins_on_clkbuf\`)

## Note for reviewers

The fixture rewrite is the only meaningful diff in \`src/aig.rs\` — adjacent surface (everything else around the test) is unchanged.