### PR TITLE
fix(aig): accept delay cells on the clock path (#73)

### DIFF
--- a/src/aig.rs
+++ b/src/aig.rs
@@ -566,7 +566,24 @@ impl AIG {
             // identity. GF180MCU clock-path cells use input pin name `I` rather
             // than `A`; we accept both below.
             let variant = PdkVariant::classify(celltype);
-            let (is_inv, is_buf, is_io_pad_buf) = match variant {
+            // (is_inv, is_buf, is_io_pad_buf, is_delay).
+            //
+            // Delay cells (`dlya`/`dlyb`/`dlyc`/`dlyd` for GF180MCU;
+            // `dlygate*`/`dlymetal*` for SKY130) are functional identity
+            // buffers — single input, single output, no gating, no
+            // negation. The post-P&R OpenROAD hold-fixing pass routinely
+            // inserts them on clock fanout to repair tight hold paths.
+            // Treated like `is_buf` in the downstream propagation
+            // (current_pinid = pin_a, is_negedge unchanged). Kept
+            // separate from `is_buf` so timing-analysis paths can
+            // distinguish "identity buffer" from "identity buffer with
+            // a delay constant" if they need to. See #73.
+            //
+            // GF180MCU `hold` is **not** included — it's OpenROAD's
+            // data-path hold-fix cell, not expected on a clock fanout.
+            // If one does appear, that's likely a netlist bug worth
+            // surfacing rather than silently traversing.
+            let (is_inv, is_buf, is_io_pad_buf, is_delay) = match variant {
                 Some(PdkVariant::Sky130) => {
                     let ct = PdkVariant::Sky130.extract_cell_type(celltype);
                     let is_inv = ct.starts_with("inv") || ct.starts_with("clkinv");
@@ -575,7 +592,8 @@ impl AIG {
                         || ct.starts_with("clkdlybuf")
                         || ct.starts_with("lpflow_isobufsrc")
                         || ct.starts_with("lpflow_inputiso");
-                    (is_inv, is_buf, false)
+                    let is_delay = ct.starts_with("dlygate") || ct.starts_with("dlymetal");
+                    (is_inv, is_buf, false, is_delay)
                 }
                 Some(PdkVariant::Gf180Mcu) => {
                     let ct = PdkVariant::Gf180Mcu.extract_cell_type(celltype);
@@ -587,14 +605,15 @@ impl AIG {
                     // be a netlist bug than an intentional design — keep the
                     // matching tight so it still errors.
                     let is_io_pad_buf = matches!(ct, "in_c" | "in_s");
-                    (is_inv, is_buf, is_io_pad_buf)
+                    let is_delay = matches!(ct, "dlya" | "dlyb" | "dlyc" | "dlyd");
+                    (is_inv, is_buf, is_io_pad_buf, is_delay)
                 }
-                None => (celltype == "INV", celltype == "BUF", false),
+                None => (celltype == "INV", celltype == "BUF", false, false),
             };
 
-            if !is_inv && !is_buf && !is_io_pad_buf && celltype != "CKLNQD" {
+            if !is_inv && !is_buf && !is_io_pad_buf && !is_delay && celltype != "CKLNQD" {
                 clilog::error!(
-                    "cell type {} not supported on clock path. expecting only INV, BUF, or CKLNQD (or SKY130 / GF180MCU equivalents)",
+                    "cell type {} not supported on clock path. expecting only INV, BUF, CKLNQD, or a delay cell (or SKY130 / GF180MCU equivalents)",
                     celltype
                 );
                 return Err(pinid);
@@ -642,10 +661,12 @@ impl AIG {
                 assert_ne!(pin_a, usize::MAX);
                 current_pinid = pin_a;
                 current_is_negedge = !is_negedge;
-            } else if is_buf || is_io_pad_buf {
+            } else if is_buf || is_io_pad_buf || is_delay {
                 assert_ne!(pin_a, usize::MAX);
                 current_pinid = pin_a;
-                // is_negedge stays the same
+                // is_negedge stays the same. Delay cells (`dlya/b/c/d`,
+                // `dlygate*`, `dlymetal*`) propagate the clock through
+                // their delay constant just like a plain buffer — see #73.
             } else if celltype == "CKLNQD" {
                 assert_ne!(pin_cp, usize::MAX);
                 assert_ne!(pin_en, usize::MAX);

--- a/src/gf180mcu.rs
+++ b/src/gf180mcu.rs
@@ -521,6 +521,49 @@ endmodule
     }
 
     #[test]
+    fn aig_clock_trace_accepts_delay_cells_on_clock_path() {
+        // Regression for #73: OpenROAD's hold-fixing pass inserts
+        // `dlyd_*` / `dlya_*` / `dlyb_*` / `dlyc_*` delay cells on
+        // clock fanout to repair tight hold paths. These are
+        // functionally identity buffers (I → Z, no negation, no
+        // gating) so clock tracing should pass through them the
+        // same way it passes through `clkbuf` / `buf` cells.
+        // Before the fix the clock-tracer rejected the cell type
+        // and panicked with "multi-input cell ⇒ clock gating".
+        //
+        // Synthetic shape: a DFF clocked through `clkbuf → dlyd → DFF`
+        // (OpenROAD's typical hold-fix-on-clock-fanout pattern).
+        const VERILOG: &str = r#"
+module tiny(CLK_PAD, D, Q);
+  input CLK_PAD, D;
+  output Q;
+  wire CLK_BUF, CLK_DLY, VDD, VSS, notifier;
+  gf180mcu_fd_sc_mcu9t5v0__clkbuf_8 CLKBUF_1 (
+      .I(CLK_PAD), .Z(CLK_BUF), .VDD(VDD), .VSS(VSS), .VNW(VDD), .VPW(VSS)
+  );
+  gf180mcu_fd_sc_mcu9t5v0__dlyd_1 DLY_1 (
+      .I(CLK_BUF), .Z(CLK_DLY), .VDD(VDD), .VSS(VSS), .VNW(VDD), .VPW(VSS)
+  );
+  gf180mcu_fd_sc_mcu7t5v0__dffq_1 DFF_1 (
+      .CLK(CLK_DLY), .D(D), .Q(Q), .notifier(notifier)
+  );
+endmodule
+"#;
+        let nl = netlistdb::NetlistDB::from_sverilog_source(
+            VERILOG,
+            Some("tiny"),
+            &GF180MCULeafPins,
+        )
+        .expect("netlist parse");
+        // Used to panic in clock tracing on the dlyd_1 cell.
+        let aig = crate::aig::AIG::from_netlistdb(&nl);
+        assert!(
+            aig.num_aigpins > 0,
+            "AIG should have at least one pin after clock tracing through dlyd"
+        );
+    }
+
+    #[test]
     fn netlist_db_parses_chip_top_pad_ring() {
         // Miniature GF180MCU chip-top: full pad ring around a trivial
         // core, covering every pad family that real post-P&R netlists


### PR DESCRIPTION
Closes #73.

## Summary

OpenROAD's hold-fixing pass routinely inserts delay cells on clock fanout to repair tight hold paths. Functionally they're identity buffers (single input, single output, no negation, no gating) — but the clock-trace recognition in \`src/aig.rs\` only accepted \`inv\` / \`buf\` / \`io_pad_buf\` / \`CKLNQD\`, so the tracer panicked with "multi-input cell ⇒ clock gating" on the first hold-fix delay it walked through.

Per the issue's option (2): add \`is_delay\` as a fourth element of the recognition tuple so timing-analysis paths can still distinguish "identity buffer" from "identity buffer with a delay constant" if they need to. Treat it like \`is_buf\` in the propagation step.

## Recognised families

- **GF180MCU**: \`dlya\` / \`dlyb\` / \`dlyc\` / \`dlyd\` (exhaustive matches against the \`is_delay_cell\` list in \`gf180mcu_pdk.rs:369\`, minus \`hold\`).
- **SKY130**: \`dlygate*\` / \`dlymetal*\` (prefix match consistent with the existing SKY130 buf / inv recognition).

\`hold\` is **not** included — it's OpenROAD's *data-path* hold-fix cell and shouldn't appear on clock fanout in a well-formed netlist. If one does, the existing error path still fires so the bug surfaces rather than silently traversing.

## Test plan

- [x] Regression test: \`aig_clock_trace_accepts_delay_cells_on_clock_path\` in \`src/gf180mcu.rs\` — synthetic DFF clocked through \`clkbuf → dlyd_1 → DFF\` (OpenROAD's typical hold-fix-on-clock-fanout pattern). \`AIG::from_netlistdb\` completes without panicking.
- [x] Full lib test suite: 242 passed (was 241; +1 for the regression test)
- [x] Pre-existing \`aig_clock_trace_skips_power_pins_on_clkbuf\` (#70 regression) stays green — the new \`is_delay\` arm doesn't affect the power-pin skip logic