### PR TITLE
fix(aig): accept bi_24t bidir pads on the clock path (#75)

### DIFF
--- a/src/aig.rs
+++ b/src/aig.rs
@@ -599,12 +599,17 @@ impl AIG {
                     let ct = PdkVariant::Gf180Mcu.extract_cell_type(celltype);
                     let is_inv = matches!(ct, "inv" | "clkinv");
                     let is_buf = matches!(ct, "buf" | "clkbuf");
-                    // GF180MCU input pads on the clock path buffer PAD → Y, so
-                    // they're traceable just like a clkbuf. bi_24t is *not*
-                    // included: a bidir pad clocking the core would more likely
-                    // be a netlist bug than an intentional design — keep the
-                    // matching tight so it still errors.
-                    let is_io_pad_buf = matches!(ct, "in_c" | "in_s");
+                    // GF180MCU input + bidir pads on the clock path buffer
+                    // PAD → Y, so they're traceable just like a clkbuf.
+                    // `bi_24t` is included because the digital-sim
+                    // simplification (`Y = PAD`, see is_io_pad_cell in
+                    // gf180mcu_pdk.rs) makes its AIG shape identical to
+                    // in_c / in_s. Common case: JTAG TCK routed through a
+                    // bidirectional signal pad in templates that don't
+                    // dedicate input-only pads to the clock (e.g. the
+                    // wafer.space gf180mcu-project-template default). See
+                    // #75.
+                    let is_io_pad_buf = matches!(ct, "in_c" | "in_s" | "bi_24t");
                     let is_delay = matches!(ct, "dlya" | "dlyb" | "dlyc" | "dlyd");
                     (is_inv, is_buf, is_io_pad_buf, is_delay)
                 }
@@ -619,6 +624,17 @@ impl AIG {
                 return Err(pinid);
             }
 
+            // `bi_24t` on the clock path: only PAD is the clock input.
+            // The cell also exposes `A` and `OE` as Direction::I (the
+            // core-side tristate driver inputs), but those are
+            // discarded by `gf180mcu_postprocess`'s `Y = PAD`
+            // simplification, so they're not part of the clock cone.
+            // Without this guard, both PAD and A match the
+            // "A | I | PAD" arm below and whichever is enumerated
+            // last wins — wrong if A wins. See #75.
+            let is_gf180mcu_bi_24t = matches!(variant, Some(PdkVariant::Gf180Mcu))
+                && PdkVariant::Gf180Mcu.extract_cell_type(celltype) == "bi_24t";
+
             for ipin in netlistdb.cell2pin.iter_set(cellid) {
                 if netlistdb.pindirect[ipin] == Direction::I {
                     let ipin_name = netlistdb.pinnames[ipin].1.as_str();
@@ -632,6 +648,9 @@ impl AIG {
                     if matches!(variant, Some(PdkVariant::Gf180Mcu))
                         && crate::gf180mcu_pdk::is_power_pin(ipin_name)
                     {
+                        continue;
+                    }
+                    if is_gf180mcu_bi_24t && matches!(ipin_name, "A" | "OE") {
                         continue;
                     }
                     match ipin_name {

--- a/src/gf180mcu.rs
+++ b/src/gf180mcu.rs
@@ -564,6 +564,53 @@ endmodule
     }
 
     #[test]
+    fn aig_clock_trace_accepts_bi_24t_on_clock_path() {
+        // Regression for #75: bidirectional IO pads on the clock
+        // path. The wafer.space `gf180mcu-project-template` default
+        // routes JTAG TCK (and any other debug clock) through the
+        // standard `bi_24t` signal-pad slot rather than dedicating
+        // an input-only pad to it. `bi_24t` is digitally simplified
+        // to `Y = PAD` (see is_io_pad_cell in gf180mcu_pdk.rs), so
+        // the clock-trace shape is identical to in_c / in_s — but
+        // it has an extra wrinkle: `A` and `OE` are also
+        // Direction::I (the core-side tristate driver inputs that
+        // get discarded). The pin enumeration must pick `PAD` as
+        // the clock source, not `A`.
+        //
+        // Synthetic shape: a DFF clocked through bi_24t (PAD →
+        // Y → DFF.CLK), with A and OE wired to constants the way
+        // a no-tristate output-disable wiring would look.
+        const VERILOG: &str = r#"
+module tiny(TCK_PAD, D, Q);
+  inout TCK_PAD;
+  input D;
+  output Q;
+  wire CLK_CORE, VDD, VSS, notifier;
+  gf180mcu_fd_io__bi_24t TCK_PAD_INST (
+      .PAD(TCK_PAD), .Y(CLK_CORE), .A(1'b0), .OE(1'b0),
+      .IE(1'b1), .PU(1'b0), .PD(1'b0), .CS(1'b0), .SL(1'b0)
+  );
+  gf180mcu_fd_sc_mcu7t5v0__dffq_1 DFF_1 (
+      .CLK(CLK_CORE), .D(D), .Q(Q), .notifier(notifier)
+  );
+endmodule
+"#;
+        let nl = netlistdb::NetlistDB::from_sverilog_source(
+            VERILOG,
+            Some("tiny"),
+            &GF180MCULeafPins,
+        )
+        .expect("netlist parse");
+        // Used to panic in clock tracing — bi_24t wasn't on the
+        // is_io_pad_buf whitelist.
+        let aig = crate::aig::AIG::from_netlistdb(&nl);
+        assert!(
+            aig.num_aigpins > 0,
+            "AIG should have at least one pin after clock tracing through bi_24t"
+        );
+    }
+
+    #[test]
     fn netlist_db_parses_chip_top_pad_ring() {
         // Miniature GF180MCU chip-top: full pad ring around a trivial
         // core, covering every pad family that real post-P&R netlists


### PR DESCRIPTION
Closes #75.

## Summary

The wafer.space \`gf180mcu-project-template\` default routes JTAG TCK (and any other debug clock) through the standard \`bi_24t\` bidirectional signal-pad slot rather than dedicating an input-only pad to it. Pre-#75 the clock-trace recognition explicitly excluded \`bi_24t\` from \`is_io_pad_buf\` with a "more likely a bug than intentional" comment — accurate for chips with dedicated clock pads, wrong for the bidir-only template pad set.

The digital-sim simplification in \`gf180mcu_postprocess\` already maps \`bi_24t\` to \`Y = PAD\` (discarding the core-side \`A\` and \`OE\` tristate-driver inputs), so once past parse the AIG shape is identical to \`in_c\` / \`in_s\`. Just need to widen the whitelist + handle one pin-enumeration wrinkle.

## Changes

1. **Add \`bi_24t\` to \`is_io_pad_buf\`** match in the GF180MCU clock-buffer recognition.

2. **New \`is_gf180mcu_bi_24t\` guard in the pin enumeration loop.** \`bi_24t\` has BOTH \`PAD\` and \`A\` as \`Direction::I\` (the digital-sim simplification keeps the core-side inputs declared, just discards their semantic effect). Both pin names match the existing "A | I | PAD" arm, so without an explicit skip, whichever pin gets enumerated last wins — could pick \`A\` (the discarded tristate driver) instead of \`PAD\` (where the clock actually enters). Skip \`A\` and \`OE\` for bi_24t cells.

## Test plan

- [x] New regression test \`aig_clock_trace_accepts_bi_24t_on_clock_path\` in \`src/gf180mcu.rs\` — synthetic DFF clocked through a \`bi_24t\` (PAD → Y → DFF.CLK), with A/OE wired to constants. \`AIG::from_netlistdb\` completes without panicking.
- [x] Full lib test suite: 243 passed (was 242; +1 for the regression test)
- [x] Pre-existing \`aig_clock_trace_*\` regressions (#70 power pins, #74 delay cells) stay green