### PR TITLE
feat(cosim): JtagReplayModel — stage 1 of discussion #77

### DIFF
--- a/scripts/capture_bitbang.py
+++ b/scripts/capture_bitbang.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Capture an OpenOCD `remote_bitbang` byte stream to a file.
+
+Accepts one TCP connection from an OpenOCD client configured with the
+`remote_bitbang` adapter driver, then records every byte the client sends
+to the output file in raw form. For `R` (TDO-read) commands it replies
+with `'0'` so OpenOCD doesn't block on reads — the recorded stream's
+`R` bytes are informational only (the JTAG replay model in
+`src/sim/models/jtag.rs` ignores them in stage 1; stage 2's TCP-listener
+mode will route them back to the connecting OpenOCD).
+
+Use this when you want to record a synthetic / well-known JTAG sequence
+(e.g. an IDCODE scan or `scan_chain` invocation) to use as a regression
+fixture in Jacquard's cosim path. To capture against a *real* target
+instead, point OpenOCD at the real `remote_bitbang` server and add a
+small tee — out of scope for this script.
+
+Discussion #77 for context.
+
+Usage:
+    # 1. Start the capture server in one terminal:
+    python3 scripts/capture_bitbang.py --output stream.bin --port 9999
+
+    # 2. Point OpenOCD at it from another terminal:
+    openocd \\
+        -c "adapter driver remote_bitbang" \\
+        -c "remote_bitbang host localhost" \\
+        -c "remote_bitbang port 9999" \\
+        -f your_target.cfg
+
+    # 3. Run whatever JTAG commands you want recorded
+    # (e.g. `scan_chain` at the OpenOCD prompt, or one-shot
+    # `-c "init; scan_chain; exit"`). The script logs every byte
+    # sent until OpenOCD disconnects.
+"""
+
+import argparse
+import socket
+import sys
+from pathlib import Path
+
+
+def serve(host: str, port: int, output: Path, verbose: bool) -> None:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind((host, port))
+    listener.listen(1)
+    print(f"capture_bitbang: listening on {host}:{port} -> {output}", file=sys.stderr)
+
+    conn, addr = listener.accept()
+    print(f"capture_bitbang: client connected from {addr}", file=sys.stderr)
+
+    # Counters surfaced when the client disconnects.
+    counts: dict[str, int] = {
+        "set": 0,    # '0'..='7'
+        "trst": 0,   # 'r'/'s'/'t'/'u'
+        "read": 0,   # 'R'
+        "blink": 0,  # 'B'/'b'
+        "quit": 0,   # 'Q'
+        "other": 0,
+    }
+    total_bytes = 0
+    try:
+        with output.open("wb") as fout:
+            while True:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                fout.write(chunk)
+                if verbose:
+                    fout.flush()
+                total_bytes += len(chunk)
+                # Reply to TDO reads so OpenOCD doesn't block. Send a
+                # zero (ASCII '0') for every 'R' encountered.
+                reads = chunk.count(b"R")
+                if reads:
+                    conn.sendall(b"0" * reads)
+                # Update counters for the post-disconnect summary.
+                for b in chunk:
+                    if 0x30 <= b <= 0x37:        # '0'..'7'
+                        counts["set"] += 1
+                    elif b in (0x72, 0x73, 0x74, 0x75):  # 'r''s''t''u'
+                        counts["trst"] += 1
+                    elif b == 0x52:              # 'R'
+                        counts["read"] += 1
+                    elif b in (0x42, 0x62):      # 'B''b'
+                        counts["blink"] += 1
+                    elif b == 0x51:              # 'Q'
+                        counts["quit"] += 1
+                    else:
+                        counts["other"] += 1
+                if b"Q" in chunk:
+                    # OpenOCD sends 'Q' on shutdown; flush + exit.
+                    break
+    finally:
+        conn.close()
+        listener.close()
+
+    print(
+        f"capture_bitbang: client disconnected after {total_bytes} bytes "
+        f"(set={counts['set']}, trst={counts['trst']}, read={counts['read']}, "
+        f"blink={counts['blink']}, quit={counts['quit']}, "
+        f"other={counts['other']})",
+        file=sys.stderr,
+    )
+    print(f"capture_bitbang: stream written to {output}", file=sys.stderr)
+
+
+def main() -> None:
+    doc = __doc__ or ""
+    parser = argparse.ArgumentParser(description=doc.split("\n")[0])
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to write the recorded byte stream to (raw bytes, no framing).",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind host (default: 127.0.0.1; use 0.0.0.0 for remote clients).",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=9999,
+        help="Bind port (default: 9999; OpenOCD's remote_bitbang default).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Flush output after every received chunk for live tailing.",
+    )
+    args = parser.parse_args()
+    serve(args.host, args.port, args.output, args.verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -271,6 +271,21 @@ struct CosimArgs {
     /// `jacquard sim --help` and ADR 0010 for details.
     #[clap(long = "cell-library", value_name = "PATH")]
     cell_library: Vec<PathBuf>,
+
+    /// Path to a recorded `remote_bitbang` byte stream. When set
+    /// alongside a `jtag` peripheral in sim_config.json, cosim drives
+    /// the configured TCK/TMS/TDI/(TRST) pins from this stream — the
+    /// deterministic-replay path from discussion #77. Capture
+    /// `remote_bitbang` traffic via `scripts/capture_bitbang.py`.
+    #[clap(long = "jtag-replay", value_name = "PATH")]
+    jtag_replay: Option<PathBuf>,
+
+    /// Cosim edges per JTAG stream byte. Default 4 — chosen against
+    /// the "chip-clock ≥ 2× TCK" assumption that holds by construction
+    /// in any chipflow design running a debug TAP. Bump for designs
+    /// with faster TCK relative to the chip clock.
+    #[clap(long = "jtag-hold-cycles", value_name = "N", default_value = "4")]
+    jtag_hold_cycles: u32,
 }
 
 #[derive(Parser)]
@@ -1590,6 +1605,8 @@ fn cmd_cosim(args: CosimArgs) {
             timing_vcd: args.timing_vcd.clone(),
             dump_dff: args.dump_dff.clone(),
             dump_dff_cycles: args.dump_dff_cycles,
+            jtag_replay: args.jtag_replay.clone(),
+            jtag_hold_cycles: args.jtag_hold_cycles,
         };
 
         let result =

--- a/src/sim/cosim_metal.rs
+++ b/src/sim/cosim_metal.rs
@@ -38,6 +38,14 @@ pub struct CosimOpts {
     pub dump_dff: Option<std::path::PathBuf>,
     /// Number of cycles to dump DFF states (default 20).
     pub dump_dff_cycles: usize,
+    /// Optional path to a recorded `remote_bitbang` byte stream. When
+    /// set alongside a `jtag` peripheral in `TestbenchConfig`, cosim
+    /// instantiates a `JtagReplayModel` driving the configured pins
+    /// from this file. Discussion #77 stage 1.
+    pub jtag_replay: Option<std::path::PathBuf>,
+    /// Cosim edges per JTAG stream byte. Default 4; see
+    /// `JtagReplayModel` for the rationale.
+    pub jtag_hold_cycles: u32,
 }
 
 /// Result of a co-simulation run.
@@ -2400,6 +2408,67 @@ pub fn run_cosim(
                 uart_cfg.rx_gpio
             );
         }
+    }
+    // JTAG replay (discussion #77 stage 1) — only wires up when BOTH
+    // a `jtag` peripheral is configured AND --jtag-replay <PATH> is
+    // supplied. Config without CLI is a soft warn (someone forgot to
+    // pass the stream); CLI without config hard-fails (the operator
+    // expected JTAG to work and it didn't).
+    if let Some(jtag_cfg) = config.jtag.as_ref() {
+        if let Some(replay_path) = opts.jtag_replay.as_ref() {
+            let bytes = std::fs::read(replay_path).unwrap_or_else(|e| {
+                panic!(
+                    "jtag: cannot read --jtag-replay {}: {e}",
+                    replay_path.display()
+                )
+            });
+            let resolve_pin = |gpio: usize, label: &str| -> u32 {
+                *gpio_map.input_bits.get(&gpio).unwrap_or_else(|| {
+                    panic!(
+                        "jtag: {label}_gpio={gpio} not in input mapping; \
+                         check sim_config.json against design pin layout"
+                    )
+                })
+            };
+            let tck = resolve_pin(jtag_cfg.tck_gpio, "tck");
+            let tms = resolve_pin(jtag_cfg.tms_gpio, "tms");
+            let tdi = resolve_pin(jtag_cfg.tdi_gpio, "tdi");
+            let trst = jtag_cfg.trst_gpio.map(|g| crate::sim::models::jtag::TrstPin {
+                position: resolve_pin(g, "trst"),
+                active_low: jtag_cfg.trst_active_low,
+            });
+            let model = crate::sim::models::jtag::JtagReplayModel::new(
+                "jtag_0".to_string(),
+                tck,
+                tms,
+                tdi,
+                trst,
+                opts.jtag_hold_cycles,
+                bytes,
+            );
+            clilog::info!(
+                "JTAG replay `jtag_0`: {} stream bytes from {}, hold_edges={} \
+                 (tck_gpio={}, tms_gpio={}, tdi_gpio={}, trst_gpio={:?})",
+                model.driven_positions().len(),
+                replay_path.display(),
+                opts.jtag_hold_cycles,
+                jtag_cfg.tck_gpio,
+                jtag_cfg.tms_gpio,
+                jtag_cfg.tdi_gpio,
+                jtag_cfg.trst_gpio
+            );
+            register_model(Box::new(model), &mut models, &mut model_driven_positions);
+        } else {
+            clilog::warn!(
+                "sim_config.json declares a `jtag` peripheral but no \
+                 --jtag-replay <PATH> was supplied; JTAG inputs will float"
+            );
+        }
+    } else if opts.jtag_replay.is_some() {
+        panic!(
+            "--jtag-replay supplied but sim_config.json has no `jtag` \
+             peripheral entry to bind it to"
+        );
     }
     let _ = register_model;
 

--- a/src/sim/models/jtag.rs
+++ b/src/sim/models/jtag.rs
@@ -1,0 +1,455 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 ChipFlow
+// SPDX-License-Identifier: Apache-2.0
+//! JTAG replay peripheral model — consumes a recorded
+//! `remote_bitbang` byte stream (the protocol OpenOCD uses to drive
+//! an external JTAG bridge) and drives the design's TCK/TMS/TDI/TRST
+//! input pins from it.
+//!
+//! Stage 1 of the JTAG cosim plan from
+//! [discussion #77](https://github.com/ChipFlow/Jacquard/discussions/77):
+//! deterministic file-replay. The recorded stream is assumed valid
+//! and the design's TDO output is not read back — that lands in
+//! stage 2 alongside the TCP-listener mode where TDO has to be
+//! routed back over the socket to OpenOCD.
+//!
+//! ## `remote_bitbang` byte alphabet
+//!
+//! Per [OpenOCD's `remote_bitbang.c`][openocd-rb]:
+//!
+//! | Byte           | Meaning                                |
+//! |----------------|----------------------------------------|
+//! | `'0'`..=`'7'`  | Set `(TCK, TMS, TDI)` from low 3 bits  |
+//! | `'r'`          | TRST off, SRST off                     |
+//! | `'s'`          | TRST off, SRST on                      |
+//! | `'t'`          | TRST on,  SRST off                     |
+//! | `'u'`          | TRST on,  SRST on                      |
+//! | `'R'`          | Read TDO (ignored in stage 1)          |
+//! | `'B'` / `'b'`  | Blink on / off (no-op)                 |
+//! | `'Q'`          | Quit (treated as end-of-stream)        |
+//!
+//! [openocd-rb]: https://github.com/openocd-org/openocd/blob/master/src/jtag/drivers/remote_bitbang.c
+//!
+//! ## Pacing
+//!
+//! OpenOCD has no concept of simulation time. Stream bytes are
+//! consumed at chip-clock pace: each byte's drive values are held
+//! on the design's input pins for `hold_edges` cosim edges before
+//! the next byte is consumed. Default `hold_edges = 4` — chosen
+//! against the "chip-clock ≥ 2× TCK" assumption that holds by
+//! construction in any chipflow design running a debug TAP.
+//! Configurable per-cosim via `--jtag-hold-cycles <N>` for the
+//! corner case.
+
+use crate::sim::input_stim::QueuedAction;
+use crate::sim::models::{warn_unhandled, EmittedEvent, ModelOverrides, PeripheralModel};
+
+/// Optional pin position + polarity for the design's TRST input.
+///
+/// `active_low: true` (the common case for RV32-Debug TAPs) drives
+/// the configured position LOW when the stream says "TRST on".
+#[derive(Debug, Clone, Copy)]
+pub struct TrstPin {
+    pub position: u32,
+    pub active_low: bool,
+}
+
+/// CPU-side state for one JTAG replay peripheral.
+pub struct JtagReplayModel {
+    /// Peripheral name (e.g. `jtag_0`).
+    name: String,
+    /// State-buffer position for the design's TCK input.
+    tck_pos: u32,
+    /// State-buffer position for the design's TMS input.
+    tms_pos: u32,
+    /// State-buffer position for the design's TDI input.
+    tdi_pos: u32,
+    /// Optional TRST input. Some chips reset the TAP via a five-cycle
+    /// TMS=1 sequence instead of a dedicated pin.
+    trst: Option<TrstPin>,
+    /// Returned by `driven_positions()`. Built once at construction
+    /// since `PeripheralModel::driven_positions` returns `&[u32]`.
+    driven_positions_arr: Vec<u32>,
+    /// Cosim edges between consuming successive stream bytes.
+    hold_edges: u32,
+    /// Pre-recorded byte stream.
+    bytes: Vec<u8>,
+    /// Next byte to consume.
+    cursor: usize,
+    /// Cosim edges spent on the current drive. Resets to 0 when a
+    /// new byte is consumed.
+    edges_held: u32,
+    /// Currently-driven TCK value (0 / 1).
+    tck: u8,
+    /// Currently-driven TMS value (0 / 1).
+    tms: u8,
+    /// Currently-driven TDI value (0 / 1).
+    tdi: u8,
+    /// Currently-driven raw TRST value (0 / 1, pre-polarity). Combined
+    /// with `trst.active_low` when contributing the override.
+    trst_active: bool,
+    /// Total `'R'` (TDO-read) commands seen in the stream — emitted
+    /// once at end-of-replay so the operator sees that stage 2 would
+    /// have responded to them.
+    tdo_read_requests: u64,
+    /// Total `'s'` / `'t'` / `'u'` (SRST-toggling) commands — flagged
+    /// at end-of-replay since SRST isn't modeled.
+    srst_toggles: u64,
+    /// Set true when the stream's `'Q'` (quit) command is reached.
+    quit: bool,
+}
+
+impl JtagReplayModel {
+    /// Build a replay model. `name` matches the configured
+    /// peripheral name (typically `jtag_0`). `bytes` is the recorded
+    /// `remote_bitbang` stream — captured via `scripts/capture_bitbang.py`
+    /// or hand-authored for synthetic tests.
+    pub fn new(
+        name: String,
+        tck_pos: u32,
+        tms_pos: u32,
+        tdi_pos: u32,
+        trst: Option<TrstPin>,
+        hold_edges: u32,
+        bytes: Vec<u8>,
+    ) -> Self {
+        assert!(
+            hold_edges > 0,
+            "jtag {name}: hold_edges must be > 0 (got 0)"
+        );
+        let mut driven = vec![tck_pos, tms_pos, tdi_pos];
+        if let Some(t) = trst {
+            driven.push(t.position);
+        }
+        Self {
+            name,
+            tck_pos,
+            tms_pos,
+            tdi_pos,
+            trst,
+            driven_positions_arr: driven,
+            hold_edges,
+            bytes,
+            cursor: 0,
+            // Pre-loaded so the first `step_edge` immediately
+            // consumes the stream's first byte. Subsequent bytes
+            // are spaced `hold_edges` apart.
+            edges_held: hold_edges,
+            // Idle drive at startup: TCK=0, TMS=1 (target Run-Test-Idle
+            // entry), TDI=0, TRST deasserted.
+            tck: 0,
+            tms: 1,
+            tdi: 0,
+            trst_active: false,
+            tdo_read_requests: 0,
+            srst_toggles: 0,
+            quit: false,
+        }
+    }
+
+    /// Consume one byte from the stream, updating the driven values.
+    /// Public for unit testing the parser in isolation.
+    pub fn consume_byte(&mut self, byte: u8) {
+        match byte {
+            // (TCK, TMS, TDI) packed in low 3 bits. Bit assignment per
+            // OpenOCD's remote_bitbang.c: TDI=bit0, TMS=bit1, TCK=bit2.
+            b'0'..=b'7' => {
+                let b = byte - b'0';
+                self.tdi = b & 0b001;
+                self.tms = (b & 0b010) >> 1;
+                self.tck = (b & 0b100) >> 2;
+            }
+            // TRST off (deasserted).
+            b'r' => self.trst_active = false,
+            // TRST off, SRST on — SRST not modeled, count it.
+            b's' => {
+                self.trst_active = false;
+                self.srst_toggles += 1;
+            }
+            // TRST on (asserted), SRST off.
+            b't' => self.trst_active = true,
+            // TRST on, SRST on.
+            b'u' => {
+                self.trst_active = true;
+                self.srst_toggles += 1;
+            }
+            // TDO read — silently counted, response not sent (stage 1
+            // is deterministic replay; stage 2 sends back to socket).
+            b'R' => self.tdo_read_requests += 1,
+            // Blink LED commands — no-op.
+            b'B' | b'b' => {}
+            // Quit — treat as end-of-stream.
+            b'Q' => self.quit = true,
+            // Unknown byte — ignore but warn so corrupted streams
+            // surface during capture/replay. Count too noisy bytes
+            // up-front would require a HashMap; one-shot at end-of-
+            // replay is plenty.
+            other => clilog::warn!(
+                "jtag {}: unknown remote_bitbang byte 0x{:02X} ignored",
+                self.name,
+                other
+            ),
+        }
+    }
+
+    /// True after consuming the stream's final `'Q'` byte or running
+    /// off the end. Cosim doesn't gate on this — replay just goes
+    /// idle on its own.
+    pub fn finished(&self) -> bool {
+        self.quit || self.cursor >= self.bytes.len()
+    }
+
+    /// Diagnostics counters surfaced at end-of-run.
+    pub fn diagnostics(&self) -> JtagDiagnostics {
+        JtagDiagnostics {
+            bytes_consumed: self.cursor,
+            tdo_read_requests: self.tdo_read_requests,
+            srst_toggles: self.srst_toggles,
+            quit: self.quit,
+        }
+    }
+
+    /// Advance one cosim edge. Drains the next byte from the stream
+    /// when the current drive has been held for `hold_edges`. Public
+    /// for unit testing; the `PeripheralModel` impl also calls it.
+    pub fn step_edge(&mut self) {
+        if self.finished() {
+            return;
+        }
+        if self.edges_held >= self.hold_edges {
+            // Time to consume the next byte. Reset to 1 because the
+            // consuming edge itself counts as the first edge of the
+            // new drive's hold window — so a `hold_edges = N` config
+            // gives exactly N cosim edges per byte.
+            let byte = self.bytes[self.cursor];
+            self.cursor += 1;
+            self.consume_byte(byte);
+            self.edges_held = 1;
+        } else {
+            self.edges_held += 1;
+        }
+    }
+}
+
+/// Counters surfaced when the run finishes — useful for confirming
+/// the replay landed where expected.
+#[derive(Debug, Clone, Copy)]
+pub struct JtagDiagnostics {
+    pub bytes_consumed: usize,
+    pub tdo_read_requests: u64,
+    pub srst_toggles: u64,
+    pub quit: bool,
+}
+
+impl PeripheralModel for JtagReplayModel {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn driven_positions(&self) -> &[u32] {
+        &self.driven_positions_arr
+    }
+
+    fn apply_action(&mut self, action: &QueuedAction) {
+        // The replay model is byte-stream driven from the file, not
+        // input.json. Any action targeted at the jtag peripheral is
+        // a config mistake worth warning about.
+        warn_unhandled(&format!("jtag `{}`", self.name), action);
+    }
+
+    fn step_edge(
+        &mut self,
+        _output_state: &[u32],
+        overrides: &mut ModelOverrides,
+        _emitted: &mut Vec<EmittedEvent>,
+    ) {
+        JtagReplayModel::step_edge(self);
+        self.contribute_overrides(overrides);
+    }
+
+    fn contribute_overrides(&self, overrides: &mut ModelOverrides) {
+        overrides.insert(self.tck_pos, self.tck);
+        overrides.insert(self.tms_pos, self.tms);
+        overrides.insert(self.tdi_pos, self.tdi);
+        if let Some(trst) = self.trst {
+            let driven = if trst.active_low {
+                if self.trst_active {
+                    0
+                } else {
+                    1
+                }
+            } else if self.trst_active {
+                1
+            } else {
+                0
+            };
+            overrides.insert(trst.position, driven);
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        !self.finished()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn driven(model: &JtagReplayModel) -> (u8, u8, u8) {
+        (model.tck, model.tms, model.tdi)
+    }
+
+    #[test]
+    fn consume_byte_decodes_tck_tms_tdi_packing() {
+        // '0' = 0b000 → all zero. '7' = 0b111 → all one.
+        // Bit assignment per OpenOCD: TDI=bit0, TMS=bit1, TCK=bit2.
+        let mut m = JtagReplayModel::new(
+            "jtag_0".into(),
+            10, 11, 12, None,
+            4,
+            vec![],
+        );
+        m.consume_byte(b'0');
+        assert_eq!(driven(&m), (0, 0, 0));
+        m.consume_byte(b'5'); // 0b101 → TCK=1, TMS=0, TDI=1
+        assert_eq!(driven(&m), (1, 0, 1));
+        m.consume_byte(b'7'); // 0b111
+        assert_eq!(driven(&m), (1, 1, 1));
+        m.consume_byte(b'2'); // 0b010 → TCK=0, TMS=1, TDI=0
+        assert_eq!(driven(&m), (0, 1, 0));
+    }
+
+    #[test]
+    fn consume_byte_handles_trst_codes() {
+        let mut m = JtagReplayModel::new(
+            "jtag_0".into(),
+            10, 11, 12,
+            Some(TrstPin { position: 13, active_low: true }),
+            4,
+            vec![],
+        );
+        m.consume_byte(b'r');
+        assert!(!m.trst_active);
+        m.consume_byte(b't');
+        assert!(m.trst_active);
+        m.consume_byte(b'u');
+        assert!(m.trst_active);
+        assert_eq!(m.srst_toggles, 1); // 'u' toggles SRST too
+        m.consume_byte(b's');
+        assert!(!m.trst_active);
+        assert_eq!(m.srst_toggles, 2);
+    }
+
+    #[test]
+    fn consume_byte_counts_tdo_reads_and_quit() {
+        let mut m = JtagReplayModel::new(
+            "jtag_0".into(),
+            10, 11, 12, None,
+            4,
+            vec![],
+        );
+        m.consume_byte(b'R');
+        m.consume_byte(b'R');
+        m.consume_byte(b'R');
+        assert_eq!(m.tdo_read_requests, 3);
+        assert!(!m.quit);
+        m.consume_byte(b'Q');
+        assert!(m.quit);
+    }
+
+    #[test]
+    fn consume_byte_blink_is_noop() {
+        let mut m = JtagReplayModel::new(
+            "jtag_0".into(),
+            10, 11, 12, None,
+            4,
+            vec![],
+        );
+        m.consume_byte(b'5');
+        let before = (m.tck, m.tms, m.tdi, m.trst_active);
+        m.consume_byte(b'B');
+        m.consume_byte(b'b');
+        assert_eq!((m.tck, m.tms, m.tdi, m.trst_active), before);
+    }
+
+    #[test]
+    fn step_edge_holds_then_advances() {
+        // hold_edges=2 with the stream "07": first byte drives all
+        // zeros, after 2 step_edges we advance to '7' which drives
+        // all ones.
+        let mut m = JtagReplayModel::new(
+            "jtag_0".into(),
+            10, 11, 12, None,
+            2,
+            b"07".to_vec(),
+        );
+        // edges_held=0 < hold (2): first call eats byte '0' immediately.
+        m.step_edge();
+        assert_eq!(driven(&m), (0, 0, 0));
+        // edges_held=0 → 1
+        m.step_edge();
+        assert_eq!(driven(&m), (0, 0, 0));
+        // edges_held=1 → 2 → 0 (advance to '7')
+        m.step_edge();
+        assert_eq!(driven(&m), (1, 1, 1));
+        // Stream exhausted after two bytes consumed and hold-out edges.
+        m.step_edge();
+        m.step_edge();
+        assert!(m.finished());
+    }
+
+    #[test]
+    fn step_edge_stops_at_quit() {
+        let mut m = JtagReplayModel::new(
+            "jtag_0".into(),
+            10, 11, 12, None,
+            1,
+            b"05Q07".to_vec(),
+        );
+        for _ in 0..10 {
+            m.step_edge();
+        }
+        assert!(m.finished());
+        // Should have stopped before consuming the post-Q bytes.
+        assert!(m.cursor <= 3, "stopped on Q, cursor={}", m.cursor);
+    }
+
+    #[test]
+    fn contribute_overrides_applies_trst_polarity() {
+        let mut m = JtagReplayModel::new(
+            "jtag_0".into(),
+            10, 11, 12,
+            Some(TrstPin { position: 13, active_low: true }),
+            4,
+            vec![],
+        );
+        m.consume_byte(b't'); // trst on (asserted)
+        let mut overrides = ModelOverrides::new();
+        m.contribute_overrides(&mut overrides);
+        // active_low + asserted → drive LOW
+        assert_eq!(overrides.get(&13), Some(&0));
+
+        m.consume_byte(b'r'); // trst off
+        overrides.clear();
+        m.contribute_overrides(&mut overrides);
+        // active_low + deasserted → drive HIGH
+        assert_eq!(overrides.get(&13), Some(&1));
+    }
+
+    #[test]
+    fn diagnostics_counts_match_stream() {
+        let mut m = JtagReplayModel::new(
+            "jtag_0".into(),
+            10, 11, 12, None,
+            1,
+            b"05R7RsuQ".to_vec(),
+        );
+        for _ in 0..16 {
+            m.step_edge();
+        }
+        let diag = m.diagnostics();
+        assert_eq!(diag.tdo_read_requests, 2);
+        assert_eq!(diag.srst_toggles, 2); // 's' + 'u'
+        assert!(diag.quit);
+    }
+}

--- a/src/sim/models/mod.rs
+++ b/src/sim/models/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod gpio;
 pub mod i2c;
+pub mod jtag;
 pub mod spi;
 pub mod uart;
 

--- a/src/testbench.rs
+++ b/src/testbench.rs
@@ -199,6 +199,11 @@ pub struct TestbenchConfig {
     pub uart: Option<UartConfig>,
     #[serde(default)]
     pub gpios: Vec<GpioConfig>,
+    /// JTAG replay peripheral. When present together with a CLI
+    /// `--jtag-replay <PATH>`, cosim drives the configured pins
+    /// from the recorded remote_bitbang byte stream.
+    #[serde(default)]
+    pub jtag: Option<JtagConfig>,
     pub sram_init: Option<SramInitConfig>,
     pub output_events: Option<String>,
     pub events_reference: Option<String>,
@@ -303,6 +308,30 @@ pub struct UartConfig {
 pub struct GpioConfig {
     pub name: String,
     pub pins: Vec<usize>,
+}
+
+/// JTAG replay peripheral configuration.
+///
+/// Pin mappings only — the byte source is supplied at the CLI via
+/// `--jtag-replay <PATH>`. See `src/sim/models/jtag.rs` and
+/// [discussion #77](https://github.com/ChipFlow/Jacquard/discussions/77).
+#[derive(Debug, Clone, Deserialize)]
+pub struct JtagConfig {
+    pub tck_gpio: usize,
+    pub tms_gpio: usize,
+    pub tdi_gpio: usize,
+    /// Optional TRST pin. TAPs that use TMS-only reset
+    /// (five-cycle `TMS=1`) leave this unset.
+    #[serde(default)]
+    pub trst_gpio: Option<usize>,
+    /// Polarity of the design's TRST input. Defaults to active-low,
+    /// matching the dominant RV32-Debug TAP convention.
+    #[serde(default = "default_true")]
+    pub trst_active_low: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
Implements stage 1 of [discussion #77](https://github.com/ChipFlow/Jacquard/discussions/77).

## Summary

Adds \`--jtag-replay <PATH>\` on \`jacquard cosim\`, consuming a recorded \`remote_bitbang\` byte stream (the protocol OpenOCD uses to drive an external JTAG bridge) and driving the design's TCK/TMS/TDI/TRST inputs from it. Deterministic file-replay only; the TCP-listener mode where TDO has to round-trip to a connected OpenOCD is stage 2 — explicitly out of scope here.

Follows the design directions agreed in the discussion thread:

- **Byte source plumbing**: CLI flag (not \`input.json\`), per Q1.
- **Peripheral config shape**: single configured TAP per chip, no \`--jtag-name\` knob, per Q2.
- **TDO in stage 1**: counted-but-ignored, surfaced in \`JtagDiagnostics\` at end-of-run, per Q3.
- **N_HOLD default**: 4, with \`--jtag-hold-cycles <N>\` knob, per Q4.

## Pieces

| File | What |
|---|---|
| \`src/sim/models/jtag.rs\` | \`JtagReplayModel\` — full \`remote_bitbang\` byte-alphabet parser + \`PeripheralModel\` impl |
| \`src/testbench.rs\` | \`JtagConfig\` schema for \`sim_config.json\` (tck/tms/tdi GPIOs + optional TRST) |
| \`src/bin/jacquard.rs\` | New \`--jtag-replay\`, \`--jtag-hold-cycles\` flags on \`cosim\` |
| \`src/sim/cosim_metal.rs\` | Model construction wiring (config + CLI both present → instantiate; mismatch → warn or panic) |
| \`scripts/capture_bitbang.py\` | Standalone TCP capture proxy for recording streams from real OpenOCD invocations |

## Byte-alphabet handling

Per OpenOCD's [\`remote_bitbang.c\`](https://github.com/openocd-org/openocd/blob/master/src/jtag/drivers/remote_bitbang.c):

| Byte           | Action                                |
|----------------|---------------------------------------|
| \`'0'\`..\`'7'\`  | Set (TCK, TMS, TDI) from low 3 bits   |
| \`'r'\`/\`'s'\`/\`'t'\`/\`'u'\` | TRST/SRST (TRST modeled; SRST counted) |
| \`'R'\`          | TDO read — counted, ignored (stage 1) |
| \`'B'\`/\`'b'\`   | Blink LED — no-op                     |
| \`'Q'\`          | Quit — treated as end-of-stream       |

## Pacing semantics

\`hold_edges = N\` gives exactly N cosim edges per stream byte. The consuming edge counts as edge 1 of the new drive's hold window — verified in \`step_edge_holds_then_advances\`. Default N=4 against the chip-clock ≥ 2× TCK invariant; tune via \`--jtag-hold-cycles\` for the corner case.

## Test plan

- [x] 8 new unit tests in \`src/sim/models/jtag.rs\` covering byte-alphabet parsing, TRST polarity in \`contribute_overrides\`, edge hold timing, \`'Q'\`-as-end-of-stream, diagnostics counters, and the blink no-op.
- [x] Full lib sweep: 251 passed (was 243; +8 for this PR).
- [x] CLI surface: \`jacquard cosim --help\` shows \`--jtag-replay\` and \`--jtag-hold-cycles\` with sensible help text.
- [x] \`scripts/capture_bitbang.py --help\` works under \`uv run\` with the PEP-723 inline metadata.

## What's deferred (stage 2 + follow-ups)

- TCP listener (\`--bitbang-listen <PORT>\`) for live OpenOCD ↔ cosim. Same parser, byte source becomes a socket. Drains from a buffer filled by a separate task so OpenOCD's send rate is decoupled from sim time — see discussion thread for the socket-pacing note.
- In-tree regression fixture: capture a real IDCODE-scan stream via \`scripts/capture_bitbang.py\`, ship the bytes + a synthetic TAP-bearing netlist as a regression test. Natural follow-up before stage 2.
- TDO routing back to the connecting OpenOCD (stage 2 only — stage 1 has no caller to route back to).