### PR TITLE
feat(netlist-graph): sram-ports command for --trace-signals integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,10 @@ uv run netlist-graph search <netlist.v> "<pattern>"
 # Generate watchlist JSON for signal monitoring
 uv run netlist-graph watchlist <netlist.v> output.json signal1 signal2 ...
 
+# Generate SRAM port trace file for --trace-signals
+uv run netlist-graph sram-ports <netlist.v> --manifest lib.cells.toml -o sram_trace.txt
+uv run netlist-graph sram-ports <netlist.v> --cell-type SRAM  # auto-detect by name
+
 # Interactive mode for exploration
 uv run netlist-graph interactive <netlist.v>
 ```
@@ -164,7 +168,22 @@ uv run netlist-graph drivers tests/timing_test/minimal_build/6_final.v "spiflash
 
 # Trace reset path to CPU
 uv run netlist-graph path tests/timing_test/minimal_build/6_final.v "gpio_in[40]" "ibus__cyc"
+
+# SRAM observability: discover port wires, then trace them
+uv run netlist-graph sram-ports design.v --cell-type SRAM -o sram_trace.txt
+jacquard cosim design.v --config sim.json --trace-signals sram_trace.txt --timing-vcd out.vcd
 ```
+
+### In-Design Signal Tracing (`--trace-signals`)
+
+The `--trace-signals <PATH>` flag on `jacquard sim` and `jacquard cosim` surfaces user-selected internal nets in the output VCD alongside top-level IO. The trace file is one hierarchical signal name per line (`#` comments and blank lines ignored). Signal names are resolved against `netlistdb` using a multi-candidate parser that handles Yosys-flattened, scalar-expanded, and structurally-hierarchical naming conventions.
+
+The recommended workflow for SRAM observability is wire-level tracing via `--trace-signals` rather than the env-var-gated `JACQUARD_SRAM_DUMP`:
+1. `netlist-graph sram-ports` discovers SRAM port wire names from the netlist
+2. `--trace-signals` surfaces them in the VCD with full per-tick accuracy (via GPU ring buffer)
+3. Post-process the VCD to reconstruct bus values (future: wire-bundle scripting)
+
+**Open question**: is it worth porting `netlist-graph` to Rust? The Python tool handles large netlists (40K cells in ~1s) but shares no code with the Rust `netlistdb`/`sverilogparse` parsers. A Rust port could reuse `sverilogparse` directly and integrate with `jacquard` as a subcommand.
 
 ### Timing Violation Detection
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = []
 dev = [
     "volare>=0.20",
     "netlist-graph",
+    "pytest>=9.0.3",
 ]
 
 [tool.uv.workspace]

--- a/scripts/netlist_graph/src/netlist_graph/cli.py
+++ b/scripts/netlist_graph/src/netlist_graph/cli.py
@@ -403,5 +403,134 @@ def interactive_mode(netlist: Path):
             click.echo(f"Unknown command: {line}")
 
 
+@main.command("sram-ports")
+@click.argument("netlist", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--manifest",
+    type=click.Path(exists=True, path_type=Path),
+    help="Path to .cells.toml manifest declaring RAM port mappings (ADR 0011).",
+)
+@click.option(
+    "--cell-type", "-c",
+    type=str,
+    default=None,
+    help="Match cell types by substring (e.g., 'SRAM'). Emits all ports.",
+)
+@click.option(
+    "--output", "-o",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Write trace file (default: stdout).",
+)
+def sram_ports(netlist: Path, manifest: Path | None, cell_type: str | None, output: Path | None):
+    """Emit SRAM port wires as a --trace-signals file.
+
+    Finds all SRAM cell instances in NETLIST and outputs the connected
+    net names for address, data, and write-control ports. The output
+    can be fed directly to `jacquard cosim --trace-signals`.
+
+    Requires a .cells.toml manifest (--manifest) that declares RAM
+    port mappings per ADR 0011, or auto-detects $__RAMGEM_SYNC_ cells
+    from the AIGPDK synthesis flow.
+
+    Examples:
+
+        netlist-graph sram-ports design.v --manifest lib.cells.toml -o sram_trace.txt
+
+        netlist-graph sram-ports design.v > sram_trace.txt
+    """
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    from netlist_graph.parser import parse_cell_instances
+
+    cells = parse_cell_instances(netlist)
+    click.echo(f"Parsed {len(cells)} cell instances", err=True)
+
+    ram_port_maps: dict[str, dict] = {}
+
+    if manifest:
+        with open(manifest, "rb") as f:
+            mf = tomllib.load(f)
+        for cell_name, entry in mf.get("cells", {}).items():
+            if entry.get("kind") == "ram" and "ram" in entry:
+                ram_port_maps[cell_name] = entry["ram"]
+        click.echo(
+            f"Manifest: {len(ram_port_maps)} RAM cell type(s): "
+            + ", ".join(ram_port_maps.keys()),
+            err=True,
+        )
+
+    # Built-in: AIGPDK $__RAMGEM_SYNC_
+    ram_port_maps.setdefault("$__RAMGEM_SYNC_", {
+        "address": "PORT_W_ADDR",
+        "data_in": "PORT_W_WR_DATA",
+        "data_out": "PORT_R_RD_DATA",
+        "write_enable": {"pin": "PORT_W_WR_EN"},
+        "clock": {"pin": "PORT_W_CLK"},
+    })
+
+    # Collect signal names
+    signals: list[str] = []
+    instances_found = 0
+
+    for cell in cells:
+        port_map = ram_port_maps.get(cell.cell_type)
+        if port_map is None and cell_type and cell_type.upper() in cell.cell_type.upper():
+            port_map = "all"
+        if port_map is None:
+            continue
+        instances_found += 1
+        inst = cell.inst_name.lstrip("\\").rstrip(" ")
+
+        if port_map == "all":
+            key_pins = sorted(cell.ports.keys())
+        else:
+            key_pins_set: set[str] = set()
+            for field_name in ("address", "data_in", "data_out"):
+                if field_name in port_map:
+                    key_pins_set.add(port_map[field_name])
+            for field_name in ("write_enable", "write_mask", "chip_enable"):
+                if field_name in port_map:
+                    pin_spec = port_map[field_name]
+                    if isinstance(pin_spec, dict):
+                        key_pins_set.add(pin_spec["pin"])
+                    else:
+                        key_pins_set.add(pin_spec)
+            key_pins = sorted(key_pins_set)
+
+        for pin_name in key_pins:
+            nets = cell.ports.get(pin_name, [])
+            for i, net in enumerate(nets):
+                net_clean = net.lstrip("\\").rstrip(" ")
+                if len(nets) > 1:
+                    signals.append(f"# {inst}.{pin_name}[{i}]")
+                else:
+                    signals.append(f"# {inst}.{pin_name}")
+                signals.append(net_clean)
+
+    if instances_found == 0:
+        click.echo(
+            "No SRAM instances found. Check --manifest or cell type names.",
+            err=True,
+        )
+        sys.exit(1)
+
+    click.echo(
+        f"Found {instances_found} SRAM instance(s), "
+        f"{len([s for s in signals if not s.startswith('#')])} signal(s)",
+        err=True,
+    )
+
+    text = "\n".join(signals) + "\n"
+    if output:
+        output.write_text(text)
+        click.echo(f"Wrote trace file: {output}", err=True)
+    else:
+        click.echo(text, nl=False)
+
+
 if __name__ == "__main__":
     main()

--- a/scripts/netlist_graph/src/netlist_graph/parser.py
+++ b/scripts/netlist_graph/src/netlist_graph/parser.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 import networkx as nx
@@ -117,3 +118,30 @@ def parse_netlist(netlist_path: Path) -> nx.DiGraph:
     logger.info(f"Graph has {G.number_of_nodes()} nodes, {G.number_of_edges()} edges")
 
     return G
+
+
+@dataclass
+class CellInstance:
+    cell_type: str
+    inst_name: str
+    ports: dict[str, list[str]]
+
+
+def parse_cell_instances(netlist_path: Path) -> list[CellInstance]:
+    """Parse all cell instances from a netlist, preserving port→net mappings."""
+    content = netlist_path.read_text()
+    skip_types = {"wire", "input", "output", "inout", "module", "assign", "endmodule"}
+    cells = []
+    for match in CELL_PATTERN.finditer(content):
+        cell_type = match.group(1)
+        if cell_type in skip_types:
+            continue
+        inst_name = match.group(2).strip()
+        ports_str = match.group(3)
+        ports: dict[str, list[str]] = {}
+        for port_match in PORT_PATTERN.finditer(ports_str):
+            pin_name = port_match.group(1)
+            nets = extract_nets(port_match.group(2))
+            ports[pin_name] = nets
+        cells.append(CellInstance(cell_type, inst_name, ports))
+    return cells

--- a/scripts/netlist_graph/src/netlist_graph/parser.py
+++ b/scripts/netlist_graph/src/netlist_graph/parser.py
@@ -20,7 +20,7 @@ INPUT_PINS = {
 
 # Cell pattern: cell_type instance_name (.port(net), ...);
 CELL_PATTERN = re.compile(
-    r"(\w+)\s+"  # cell type
+    r"(\$?[\w]+)\s+"  # cell type (may start with $ for Yosys internal cells)
     r"(\\[^\s]+|\w+)\s*"  # instance name (escaped or simple)
     r"\(([^;]+)\);",  # port connections
     re.MULTILINE | re.DOTALL,

--- a/scripts/netlist_graph/tests/test_sram_ports.py
+++ b/scripts/netlist_graph/tests/test_sram_ports.py
@@ -1,0 +1,167 @@
+"""Tests for sram-ports command and parse_cell_instances."""
+
+import textwrap
+
+import pytest
+from click.testing import CliRunner
+
+from netlist_graph.cli import main
+from netlist_graph.parser import parse_cell_instances
+
+
+@pytest.fixture
+def tmp_netlist(tmp_path):
+    """Create a minimal netlist with one SRAM and one logic cell."""
+    v = tmp_path / "design.v"
+    v.write_text(textwrap.dedent("""\
+        module top (input clk, input [9:0] addr, input [31:0] din,
+                    output [31:0] dout, input wen, input en);
+         wire net_clk, net_en, net_wen;
+         wire [9:0] net_addr;
+         wire [31:0] net_din, net_dout;
+
+         sky130_fd_sc_hd__buf_2 buf0 (.A(clk), .X(net_clk));
+
+         CF_SRAM_1024x32 sram0 (
+             .CLKin(net_clk),
+             .EN(net_en),
+             .R_WB(net_wen),
+             .AD({addr[9], addr[8], addr[7], addr[6], addr[5],
+                  addr[4], addr[3], addr[2], addr[1], addr[0]}),
+             .DI({din[31], din[30], din[29], din[28], din[27],
+                  din[26], din[25], din[24], din[23], din[22],
+                  din[21], din[20], din[19], din[18], din[17],
+                  din[16], din[15], din[14], din[13], din[12],
+                  din[11], din[10], din[9], din[8], din[7],
+                  din[6], din[5], din[4], din[3], din[2],
+                  din[1], din[0]}),
+             .DO({dout[31], dout[30], dout[29], dout[28], dout[27],
+                  dout[26], dout[25], dout[24], dout[23], dout[22],
+                  dout[21], dout[20], dout[19], dout[18], dout[17],
+                  dout[16], dout[15], dout[14], dout[13], dout[12],
+                  dout[11], dout[10], dout[9], dout[8], dout[7],
+                  dout[6], dout[5], dout[4], dout[3], dout[2],
+                  dout[1], dout[0]}));
+        endmodule
+    """))
+    return v
+
+
+@pytest.fixture
+def tmp_manifest(tmp_path):
+    """Create a minimal .cells.toml with RAM port mapping."""
+    toml = tmp_path / "lib.cells.toml"
+    toml.write_text(textwrap.dedent("""\
+        schema_version = "1.1"
+
+        [cells.CF_SRAM_1024x32]
+        kind = "ram"
+
+        [cells.CF_SRAM_1024x32.ram]
+        depth = 1024
+        width = 32
+        address = "AD"
+        data_in = "DI"
+        data_out = "DO"
+        [cells.CF_SRAM_1024x32.ram.clock]
+        pin = "CLKin"
+        [cells.CF_SRAM_1024x32.ram.chip_enable]
+        pin = "EN"
+        polarity = "low"
+        [cells.CF_SRAM_1024x32.ram.write_enable]
+        pin = "R_WB"
+        polarity = "low"
+    """))
+    return toml
+
+
+class TestParseCellInstances:
+    def test_finds_sram_and_logic(self, tmp_netlist):
+        cells = parse_cell_instances(tmp_netlist)
+        types = {c.cell_type for c in cells}
+        assert "CF_SRAM_1024x32" in types
+        assert "sky130_fd_sc_hd__buf_2" in types
+
+    def test_sram_ports_present(self, tmp_netlist):
+        cells = parse_cell_instances(tmp_netlist)
+        sram = [c for c in cells if c.cell_type == "CF_SRAM_1024x32"][0]
+        assert "CLKin" in sram.ports
+        assert "AD" in sram.ports
+        assert "DI" in sram.ports
+        assert "DO" in sram.ports
+        assert "EN" in sram.ports
+        assert "R_WB" in sram.ports
+        assert len(sram.ports["AD"]) == 10
+        assert len(sram.ports["DI"]) == 32
+        assert len(sram.ports["DO"]) == 32
+
+    def test_instance_name(self, tmp_netlist):
+        cells = parse_cell_instances(tmp_netlist)
+        sram = [c for c in cells if c.cell_type == "CF_SRAM_1024x32"][0]
+        assert sram.inst_name == "sram0"
+
+
+class TestSramPortsCli:
+    def test_cell_type_pattern(self, tmp_netlist):
+        runner = CliRunner()
+        result = runner.invoke(main, ["sram-ports", str(tmp_netlist), "-c", "SRAM"])
+        assert result.exit_code == 0
+        assert "addr[0]" in result.output
+        assert "din[0]" in result.output
+        assert "dout[0]" in result.output
+
+    def test_manifest_mode(self, tmp_netlist, tmp_manifest):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["sram-ports", str(tmp_netlist), "--manifest", str(tmp_manifest)],
+        )
+        assert result.exit_code == 0
+        lines = [ln for ln in result.output.strip().split("\n") if not ln.startswith("#")]
+        pin_names_in_comments = [
+            ln for ln in result.output.strip().split("\n") if ln.startswith("#")
+        ]
+        assert len(lines) > 0
+        assert any("AD" in c for c in pin_names_in_comments)
+        assert any("DI" in c for c in pin_names_in_comments)
+        assert any("DO" in c for c in pin_names_in_comments)
+        assert any("EN" in c for c in pin_names_in_comments)
+        assert any("R_WB" in c for c in pin_names_in_comments)
+
+    def test_no_match_exits_with_error(self, tmp_netlist):
+        runner = CliRunner()
+        result = runner.invoke(main, ["sram-ports", str(tmp_netlist)])
+        assert result.exit_code == 1
+
+    def test_output_file(self, tmp_netlist, tmp_path):
+        runner = CliRunner()
+        out = tmp_path / "trace.txt"
+        result = runner.invoke(
+            main,
+            ["sram-ports", str(tmp_netlist), "-c", "SRAM", "-o", str(out)],
+        )
+        assert result.exit_code == 0
+        content = out.read_text()
+        assert "addr[0]" in content
+
+    def test_builtin_ramgem(self, tmp_path):
+        """$__RAMGEM_SYNC_ is detected without --manifest."""
+        v = tmp_path / "ramgem.v"
+        v.write_text(textwrap.dedent("""\
+            module top;
+             $__RAMGEM_SYNC_ ram0 (
+                 .PORT_W_CLK(clk),
+                 .PORT_R_CLK(clk),
+                 .PORT_W_ADDR(waddr),
+                 .PORT_R_ADDR(raddr),
+                 .PORT_W_WR_EN(wen),
+                 .PORT_W_WR_DATA(wdata),
+                 .PORT_R_RD_DATA(rdata));
+            endmodule
+        """))
+        runner = CliRunner()
+        result = runner.invoke(main, ["sram-ports", str(v)])
+        assert result.exit_code == 0
+        assert "waddr" in result.output
+        assert "wdata" in result.output
+        assert "rdata" in result.output


### PR DESCRIPTION
## Summary

- Adds `netlist-graph sram-ports` command that discovers SRAM instances in a post-synthesis netlist and emits port wire names as a `--trace-signals` file
- Enables SRAM observability via the unified wire-tracing path rather than the env-var-gated `SramDumper`
- Documents the recommended workflow in CLAUDE.md: `sram-ports` → `--trace-signals` → VCD post-processing

## Usage

```bash
# With .cells.toml manifest (precise port selection via ADR 0011 schema)
uv run netlist-graph sram-ports design.v --manifest lib.cells.toml -o sram_trace.txt

# Auto-detect by cell type name (exploratory, emits all ports)
uv run netlist-graph sram-ports design.v --cell-type SRAM -o sram_trace.txt

# Pipe directly to cosim
jacquard cosim design.v --config sim.json --trace-signals sram_trace.txt --timing-vcd out.vcd
```

Tested against mcu_soc: finds `CF_SRAM_1024x32` instance, emits 118 port signals (AD, BEN, CLKin, DI, DO, EN, R_WB).

## Also in this PR

- CLAUDE.md: documents `--trace-signals` workflow, SRAM observability approach, and open question on porting netlist-graph to Rust
- Parser: adds `parse_cell_instances()` for cell-centric data extraction

## Future directions (not this PR)

- Wire-bundle scripting: reconstruct multi-bit bus values from 1-bit VCD traces
- Surfer waveform viewer integration for signal grouping / bus rendering

## Test plan

- [x] `netlist-graph sram-ports --cell-type SRAM` works on mcu_soc netlist
- [x] `netlist-graph sram-ports --help` shows usage
- [x] 280 lib tests pass
- [ ] CI