### PR TITLE
ci: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
@@ -34,7 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -57,7 +57,7 @@ jobs:
     name: opensta-to-ir Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
 
@@ -92,7 +92,7 @@ jobs:
       # across runs because the version is constant.
       - name: Cache CUDD
         id: cache-cudd
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/cudd-3.0.0
           key: cudd-3.0.0-v1
@@ -113,7 +113,7 @@ jobs:
       # changes.
       - name: Cache OpenSTA build
         id: cache-opensta
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor/opensta/build
           key: opensta-${{ steps.opensta-sha.outputs.sha }}-cudd-3.0.0-v1
@@ -125,7 +125,7 @@ jobs:
         run: scripts/build-opensta.sh
 
       - name: Cache cargo (opensta-to-ir + timing-ir)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -148,7 +148,7 @@ jobs:
     # macos-runner-1 (Apple Silicon + Metal GPU).
     runs-on: macos-runner-1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
@@ -173,7 +173,7 @@ jobs:
           echo "LLVM_VERSION=$LLVM_VER" >> $GITHUB_ENV
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -404,7 +404,7 @@ jobs:
           python3 tests/dual_uart/check_pass.py target/test-out/dual_uart_events.json
 
       - name: Upload VCD artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: vcd-outputs
@@ -435,7 +435,7 @@ jobs:
     if: ${{ false }}
     runs-on: nvidia-runner-1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
@@ -454,7 +454,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -505,7 +505,7 @@ jobs:
           fi
 
       - name: Upload CUDA artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: cuda-outputs
@@ -526,7 +526,7 @@ jobs:
     if: ${{ false }}
     runs-on: nvidia-runner-1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
@@ -577,7 +577,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -626,7 +626,7 @@ jobs:
           fi
 
       - name: Upload HIP artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: hip-outputs
@@ -643,7 +643,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
@@ -672,7 +672,7 @@ jobs:
     name: Benchmarks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
@@ -682,7 +682,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -710,7 +710,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: benchmark-results
           path: benchmark_results.txt
@@ -725,7 +725,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
 
@@ -742,7 +742,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Install OpenSTA build deps
         run: |
@@ -753,7 +753,7 @@ jobs:
 
       - name: Cache CUDD
         id: cache-cudd
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/cudd-3.0.0
           key: cudd-3.0.0-v1
@@ -772,7 +772,7 @@ jobs:
       # runs first warms it for the other.
       - name: Cache OpenSTA build
         id: cache-opensta
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: vendor/opensta/build
           key: opensta-${{ steps.opensta-sha.outputs.sha }}-cudd-3.0.0-v1
@@ -784,7 +784,7 @@ jobs:
         run: scripts/build-opensta.sh
 
       - name: Cache cargo (opensta-to-ir)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry/index/
@@ -801,7 +801,7 @@ jobs:
       # ~500MB download happens once and warm runs reuse it.
       - name: Cache volare PDK (sky130A)
         id: cache-volare
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.volare
           key: volare-sky130A-c6d73a35f524070e85faff4a6a9eef49553ebc2b
@@ -832,7 +832,7 @@ jobs:
             --output tests/mcu_soc/data/6_final.jtir
 
       - name: Upload MCU SoC timing IR artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mcu-soc-jtir
           path: tests/mcu_soc/data/6_final.jtir
@@ -847,7 +847,7 @@ jobs:
     timeout-minutes: 30
     needs: [prepare-mcu-soc-jtir]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: true
@@ -869,10 +869,10 @@ jobs:
           echo "LLVM_VERSION=$LLVM_VER" >> $GITHUB_ENV
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -925,7 +925,7 @@ jobs:
           fi
 
       - name: Download MCU SoC timing IR
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mcu-soc-jtir
           path: tests/mcu_soc/data/
@@ -979,7 +979,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: mcu-soc-results
@@ -1008,7 +1008,7 @@ jobs:
     # Regression gate for #84 (model-driven clock edge flags).
     continue-on-error: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: true
@@ -1028,7 +1028,7 @@ jobs:
           echo "LLVM_VERSION=$LLVM_VER" >> $GITHUB_ENV
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -1061,7 +1061,7 @@ jobs:
             tests/jtag_minimal/data/cosim_trace.vcd
 
       - name: Upload artefacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: jtag-minimal-results
@@ -1074,7 +1074,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
@@ -1084,7 +1084,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/
@@ -1151,11 +1151,11 @@ jobs:
     name: CVC Reference Simulation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache CVC binary
         id: cache-cvc
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/cvc/bin
           key: cvc-binary-debug-v4-toplevel-makefile
@@ -1242,7 +1242,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: cvc-reference-results
@@ -1258,18 +1258,18 @@ jobs:
     needs: [metal, cvc-reference]
     if: always() && needs.metal.result == 'success' && needs.cvc-reference.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v8
 
       - name: Download Metal artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: vcd-outputs
           path: metal-results/
 
       - name: Download CVC artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: cvc-reference-results
           path: cvc-results/
@@ -1298,7 +1298,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: timing-comparison-results
@@ -1314,17 +1314,17 @@ jobs:
     needs: [mcu-soc-metal]
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
         run: git submodule update --init vendor/sky130_fd_sc_hd
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v8
 
       - name: Cache CVC binary
         id: cache-cvc
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/cvc/bin
           key: cvc-binary-debug-v2
@@ -1349,7 +1349,7 @@ jobs:
         run: echo "$HOME/cvc/bin" >> "$GITHUB_PATH"
 
       - name: Download Metal artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mcu-soc-results
           path: metal-results/
@@ -1397,7 +1397,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: mcu-soc-cvc-results
@@ -1413,18 +1413,18 @@ jobs:
     needs: [mcu-soc-metal, mcu-soc-cvc]
     if: always() && needs.mcu-soc-metal.result == 'success' && needs.mcu-soc-cvc.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v8
 
       - name: Download Metal artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mcu-soc-results
           path: metal-results/
 
       - name: Download CVC artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mcu-soc-cvc-results
           path: cvc-results/
@@ -1467,7 +1467,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: mcu-soc-comparison-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -742,7 +742,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Install OpenSTA build deps
         run: |
@@ -869,7 +869,7 @@ jobs:
           echo "LLVM_VERSION=$LLVM_VER" >> $GITHUB_ENV
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Cache cargo
         uses: actions/cache@v5
@@ -1260,7 +1260,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
 
       - name: Download Metal artifacts
         uses: actions/download-artifact@v8
@@ -1320,7 +1320,7 @@ jobs:
       - name: Init required submodules
         run: git submodule update --init vendor/sky130_fd_sc_hd
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
 
       - name: Cache CVC binary
         id: cache-cvc
@@ -1415,7 +1415,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
 
       - name: Download Metal artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -42,7 +42,7 @@ jobs:
           submodules: recursive
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
 
       - name: Generate RTLIL
         run: |

--- a/.github/workflows/mcu-soc-rebuild.yml
+++ b/.github/workflows/mcu-soc-rebuild.yml
@@ -37,12 +37,12 @@ jobs:
           sudo swapon /swapfile
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Generate RTLIL
         run: |
@@ -180,7 +180,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create or update PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: auto/update-mcu-soc-data
           commit-message: "Update MCU SoC test data from librelane rebuild"


### PR DESCRIPTION
## Summary
- Bump all GitHub Actions to latest major versions ahead of the Node.js 20 deprecation (forced to Node 24 runtime on **June 2nd 2026**)
- `actions/checkout` v4 → v6, `actions/cache` v4 → v5, `actions/upload-artifact` v4 → v7, `actions/download-artifact` v4 → v8, `astral-sh/setup-uv` v4 → v8, `peter-evans/create-pull-request` v7 → v8
- `peaceiris/actions-gh-pages@v4` and `dtolnay/rust-toolchain@stable` are already current

## Test plan
- [ ] CI passes on this PR (all jobs use the bumped actions)
- [ ] Artifact upload/download still works across jobs (upload v7 ↔ download v8)
- [ ] Self-hosted Metal tests still run on macos-runner-1