### PR TITLE
fix(netlist-graph): cone leaf labeling (#99) + drivers --data-only (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ the authoritative record.
   binary now embeds its kernel library so a downloaded binary is
   relocatable, and `cargo binstall` metadata is in place. GitHub
   Releases + a Homebrew tap (macOS/Metal) follow.
+- **`netlist-graph drivers --data-only`** (#100): on sequential cells,
+  follow the data (`D`) pin only and skip clock/set/reset/enable pins,
+  so tracing a register stays on the data path instead of diving into
+  the clock and reset distribution trees.
 
 ### Changed
 
@@ -120,6 +124,17 @@ the authoritative record.
   `--stimulus-vcd`), and the stale "forces single-tick mode" help text
   removed (VCD capture uses a GPU ring buffer, preserving batched
   dispatch).
+- `netlist-graph cone` no longer stops at driven internal nets and
+  mislabels them `[primary input]` (#99). Inverting/tie output pins
+  (`ZN`, `LO`, `HI`, `QN`, `CO`, …) were misclassified as cell *inputs*,
+  so their output nets had no driver edge and looked undriven. The cone
+  now follows them, and a genuinely undriven internal net is flagged
+  `[undriven — X-source]` distinctly from a real top-level port; constant
+  tie-cell outputs (sky130 `conb_1`) are labeled `[constant: …]`.
+- `netlist-graph` register detection (`_is_register`) now recognises
+  reset/set/scan flop variants (sky130 `dfrtp`/`dfstp`/`dfbbn`/`sdf*`,
+  gf180 `dffrnq`/`latrnq`), not just the plain DFF, by matching the
+  functional cell name after the library prefix.
 
 ### Deprecated / Removed
 

--- a/scripts/netlist_graph/src/netlist_graph/cli.py
+++ b/scripts/netlist_graph/src/netlist_graph/cli.py
@@ -33,7 +33,14 @@ def main(ctx, verbose):
 @click.argument("netlist", type=click.Path(exists=True, path_type=Path))
 @click.argument("net", type=str)
 @click.option("-d", "--depth", default=10, help="Maximum trace depth")
-def drivers(netlist: Path, net: str, depth: int):
+@click.option(
+    "--data-only",
+    is_flag=True,
+    help="On sequential cells, follow the data (D) pin only — skip "
+    "clock/set/reset/enable pins so the clock and reset trees don't "
+    "swamp the data path.",
+)
+def drivers(netlist: Path, net: str, depth: int, data_only: bool):
     """Trace backwards to find drivers of a net."""
     graph = NetlistGraph.from_file(netlist)
     click.echo(f"Loaded {graph.num_nodes} nodes, {graph.num_edges} edges")
@@ -52,8 +59,10 @@ def drivers(netlist: Path, net: str, depth: int):
 
     target = matches[0]
     click.echo(f"\nTracing drivers of: {target}")
+    if data_only:
+        click.echo("(data path only — skipping clock/set/reset/enable pins)")
 
-    trace = graph.trace_back(target, max_depth=depth)
+    trace = graph.trace_back(target, max_depth=depth, data_only=data_only)
     for d, n, driver in trace:
         indent = "  " * d
         if driver:
@@ -298,6 +307,12 @@ def cone(netlist: Path, signal: str, depth: int, through_regs: bool):
 
         if cell_type == "(primary)":
             click.echo(f"{indent}{short_net}  [primary input]")
+        elif cell_type == "(const)":
+            ct = graph.driver_cell_type(net)
+            label = graph._short_cell_type(ct) if ct else "const"
+            click.echo(f"{indent}{short_net}  [constant: {label}]")
+        elif cell_type == "(undriven)":
+            click.echo(f"{indent}{short_net}  [undriven — X-source]")
         elif cell_type == "(reg-output)":
             click.echo(f"{indent}{short_net}  [REG output]")
         else:

--- a/scripts/netlist_graph/src/netlist_graph/graph.py
+++ b/scripts/netlist_graph/src/netlist_graph/graph.py
@@ -97,6 +97,38 @@ class NetlistGraph:
         """Check if a net exists."""
         return self._graph.has_node(net)
 
+    def is_primary_input(self, net: str) -> bool:
+        """Whether a net is a declared top-level input/inout port.
+
+        Used to distinguish a genuine primary input (driven from outside the
+        module) from an undriven internal net (an X-source). Both have no
+        driver inside the netlist.
+        """
+        ports: dict[str, str] = self._graph.graph.get("ports", {})
+        return ports.get(net) in ("input", "inout")
+
+    def is_driven(self, net: str) -> bool:
+        """Whether a net is driven by some cell output anywhere in the netlist.
+
+        Unlike ``find_drivers`` (which is edge-based and therefore misses
+        zero-input cells), this also reports nets driven by constant/tie
+        cells whose outputs produce no input->output edge.
+        """
+        if self._graph.has_node(net) and any(self._graph.predecessors(net)):
+            return True
+        out_driver: dict = self._graph.graph.get("out_driver", {})
+        return net in out_driver
+
+    def driver_cell_type(self, net: str) -> str | None:
+        """Cell type driving ``net`` via a zero-input (constant/tie) cell.
+
+        Returns None if the net is driven through normal edges (use
+        ``find_drivers``) or is undriven.
+        """
+        out_driver: dict[str, tuple[str, str, str]] = self._graph.graph.get("out_driver", {})
+        entry = out_driver.get(net)
+        return entry[1] if entry else None
+
     def find_drivers(self, net: str) -> list[Driver]:
         """Find all cells that drive a net."""
         if not self._graph.has_node(net):
@@ -133,11 +165,22 @@ class NetlistGraph:
             )
         return loads
 
-    def trace_back(self, net: str, max_depth: int = 10) -> list[tuple[int, str, Driver | None]]:
+    def trace_back(
+        self,
+        net: str,
+        max_depth: int = 10,
+        data_only: bool = False,
+    ) -> list[tuple[int, str, Driver | None]]:
         """
         Trace backwards from a net to find its driver chain.
 
         Returns list of (depth, net, driver) tuples.
+
+        When ``data_only`` is set, the walk does not descend into the
+        clock / set / reset / enable pins of sequential cells — only the
+        data (D) input is followed. This keeps a register trace on the
+        data path instead of diving into the clock and reset distribution
+        trees, which otherwise swamp the output.
         """
         result = []
         visited = set()
@@ -153,6 +196,13 @@ class NetlistGraph:
 
             drivers = self.find_drivers(current_net)
             for d in drivers:
+                if (
+                    data_only
+                    and self._is_register(d.cell_type)
+                    and d.in_pin not in self._DFF_DATA_PINS
+                ):
+                    # Control pin on a sequential cell (CLK/RESET_B/SET_B/...).
+                    continue
                 queue.append((d.from_net, depth + 1, d))
 
         return result
@@ -223,9 +273,19 @@ class NetlistGraph:
 
     @staticmethod
     def _is_register(cell_type: str) -> bool:
-        """Check if a cell type is a register (DFF/latch)."""
-        ct = cell_type.lower()
-        return any(k in ct for k in ("dff", "dfx", "dlat", "dlxtp", "sdff", "sdf"))
+        """Check if a cell type is a register (DFF/latch).
+
+        Matches on the functional cell name (the part after the last ``__``
+        library prefix) so reset/set/scan flop variants are recognised, not
+        just the plain DFF. Covers sky130 (dfxtp/dfrtp/dfstp/dfbbn/edfxtp/
+        sdf*) and gf180mcu (dffq/dffrnq/dffsnq/sdffq, latq/latrnq) naming.
+        """
+        name = cell_type.lower().rsplit("__", 1)[-1]
+        return name.startswith((
+            "df", "sdf", "edf",          # D flip-flops + scan/enable variants
+            "dlxtp", "dlrtp", "dlat",    # sky130 latches
+            "lat",                       # gf180 latches (latq/latnq/latrnq)
+        ))
 
     @staticmethod
     def _short_cell_type(cell_type: str) -> str:
@@ -273,8 +333,17 @@ class NetlistGraph:
 
             drivers = self.find_drivers(net)
             if not drivers:
-                # Primary input — no driver
-                result.append((depth, net, "(primary)", []))
+                # No driver *edge*. Classify the leaf:
+                #   - driven by a zero-input cell (constant/tie) → (const)
+                #   - declared top-level input/inout port        → (primary)
+                #   - otherwise undriven internal net (X-source) → (undriven)
+                const_type = self.driver_cell_type(net)
+                if const_type is not None:
+                    result.append((depth, net, "(const)", []))
+                elif self.is_primary_input(net):
+                    result.append((depth, net, "(primary)", []))
+                else:
+                    result.append((depth, net, "(undriven)", []))
                 return
 
             # Group drivers by cell (a cell may have multiple input edges)

--- a/scripts/netlist_graph/src/netlist_graph/parser.py
+++ b/scripts/netlist_graph/src/netlist_graph/parser.py
@@ -9,14 +9,40 @@ import networkx as nx
 
 logger = logging.getLogger(__name__)
 
-# SKY130 cell pin directions
-OUTPUT_PINS = {"X", "Y", "Q", "Q_N", "COUT", "SUM", "DO", "Z"}
+# Standard-cell output pin names, unambiguous across the libraries we parse
+# (sky130, gf180mcu, Nangate/generic). These names are NEVER inputs on any
+# cell, so a name-based allowlist is safe. Adding an ambiguous name here
+# (e.g. ``S``, which is an adder *sum* output but also a mux *select* input)
+# would misclassify edges, so keep this list to output-only names.
+#   X, Y, Z, ZN      — combinational outputs (buf/inv/aoi/oai/nand/nor)
+#   Q, QN, Q_N       — flop outputs
+#   SUM, CO, COUT    — adder outputs (sky130 uses SUM/COUT, gf180 uses S/CO —
+#                      ``S`` is intentionally omitted, see above)
+#   HI, LO           — sky130 conb_1 tie cell outputs
+#   DO               — SRAM data-out
+#   GCLK, ECK, CLKOUT — clock-gate / clock-buffer outputs
+OUTPUT_PINS = {
+    "X", "Y", "Z", "ZN",
+    "Q", "QN", "Q_N",
+    "SUM", "CO", "COUT",
+    "HI", "LO",
+    "DO",
+    "GCLK", "ECK", "CLKOUT",
+}
 INPUT_PINS = {
     "A", "B", "C", "D", "A1", "A2", "A3", "B1", "B2", "C1", "D1",
     "S", "S0", "CLK", "RESET_B", "SET_B", "GATE", "EN",
     "A0", "DI", "AD", "BEN", "CLKin", "R_WB", "WLBI", "SM", "TM",
     "ScanInDR", "ScanInDL", "ScanInCC", "vpwrpc", "vpwrac",
 }
+
+# Top-level port declaration:  input|output|inout [msb:lsb] name1, name2, ...;
+PORT_DECL_PATTERN = re.compile(
+    r"^\s*(input|output|inout)\s+"
+    r"(?:\[(\d+)\s*:\s*(\d+)\]\s*)?"  # optional bus range
+    r"([^;]+);",
+    re.MULTILINE,
+)
 
 # Cell pattern: cell_type instance_name (.port(net), ...);
 CELL_PATTERN = re.compile(
@@ -31,7 +57,7 @@ PORT_PATTERN = re.compile(r"\.(\w+)\s*\(([^)]*)\)")
 
 
 def classify_pin(pin_name: str) -> str:
-    """Classify a pin as 'input', 'output', or 'unknown'."""
+    """Classify a pin as 'input' or 'output'."""
     pin_base = pin_name.rstrip("0123456789")
     if pin_base in OUTPUT_PINS or pin_name in OUTPUT_PINS:
         return "output"
@@ -41,6 +67,60 @@ def classify_pin(pin_name: str) -> str:
     if pin_name.startswith("Q") or pin_name in ("X", "Y", "Z"):
         return "output"
     return "input"  # Default to input
+
+
+def pin_is_recognized(pin_name: str) -> bool:
+    """Whether ``classify_pin`` resolves this pin name confidently.
+
+    Pin direction is inferred from a name-based allowlist (no Liberty file is
+    available). An unrecognized pin silently defaults to ``input`` — which, if
+    the pin is really an output, makes its net look undriven (the #99 failure
+    mode, relocated to the next cell library). ``parse_netlist`` uses this to
+    warn about unknown pin names so a new PDK surfaces as a diagnostic rather
+    than a silent misclassification. Mirrors the branches of ``classify_pin``.
+    """
+    pin_base = pin_name.rstrip("0123456789")
+    if pin_base in OUTPUT_PINS or pin_name in OUTPUT_PINS:
+        return True
+    if pin_base in INPUT_PINS or pin_name in INPUT_PINS:
+        return True
+    return pin_name.startswith("Q") or pin_name in ("X", "Y", "Z")
+
+
+def parse_top_ports(content: str) -> dict[str, str]:
+    """Parse top-level module port declarations.
+
+    Returns a mapping of (bit-expanded) net name -> direction, where
+    direction is one of ``"input"``, ``"output"``, ``"inout"``. Bus ports
+    are expanded to match how nets appear in cell connections, e.g.
+    ``input [43:0] gpio_in`` yields ``gpio_in[0] .. gpio_in[43]``.
+
+    Used to distinguish a genuine top-level primary input (driven from
+    outside the module) from an *undriven internal net* (an X-source). Both
+    have no driver inside the netlist, but only the latter is a defect/X-root.
+    """
+    ports: dict[str, str] = {}
+    for m in PORT_DECL_PATTERN.finditer(content):
+        direction = m.group(1)
+        msb, lsb = m.group(2), m.group(3)
+        names_blob = m.group(4)
+        # Strip any leading data-type keyword (wire/reg) and whitespace, then
+        # split the comma-separated name list.
+        names_blob = re.sub(r"\b(wire|reg|logic|signed)\b", " ", names_blob)
+        for raw in names_blob.split(","):
+            name = raw.strip().lstrip("\\").rstrip(" ")
+            if not name:
+                continue
+            if msb is not None and lsb is not None:
+                hi, lo = int(msb), int(lsb)
+                step = 1 if hi >= lo else -1
+                for bit in range(lo, hi + step, step):
+                    ports[f"{name}[{bit}]"] = direction
+                # also record the bare name for scalar-style references
+                ports.setdefault(name, direction)
+            else:
+                ports[name] = direction
+    return ports
 
 
 def extract_nets(net_expr: str) -> list[str]:
@@ -69,8 +149,20 @@ def parse_netlist(netlist_path: Path) -> nx.DiGraph:
     G = nx.DiGraph()
     content = netlist_path.read_text()
 
+    # Top-level port directions, used to tell a real primary input from an
+    # undriven internal net (an X-source). Stored on the graph so query
+    # methods can classify leaf nets without re-reading the file.
+    G.graph["ports"] = parse_top_ports(content)
+
+    # net -> (instance, cell_type, out_pin) for every net that is some cell's
+    # output. Distinguishes a driven net (even via a zero-input tie cell) from
+    # a genuinely undriven net. Stored on the graph for query methods.
+    out_driver: dict[str, tuple[str, str, str]] = {}
+    G.graph["out_driver"] = out_driver
+
     cells_parsed = 0
     skip_types = {"wire", "input", "output", "inout", "module", "assign", "endmodule"}
+    unknown_pins: set[str] = set()
 
     for match in CELL_PATTERN.finditer(content):
         cell_type = match.group(1)
@@ -91,6 +183,8 @@ def parse_netlist(netlist_path: Path) -> nx.DiGraph:
             net_expr = port_match.group(2)
             nets = extract_nets(net_expr)
 
+            if not pin_is_recognized(pin_name):
+                unknown_pins.add(pin_name)
             pin_type = classify_pin(pin_name)
             if pin_type == "output":
                 for net in nets:
@@ -104,6 +198,14 @@ def parse_netlist(netlist_path: Path) -> nx.DiGraph:
             if net and not G.has_node(net):
                 G.add_node(net, type="net")
 
+        # Record every output net's driving cell. This captures nets driven
+        # by zero-input cells (constant/tie cells like sky130 conb_1, whose
+        # HI/LO outputs produce no input->output edge), so they are not
+        # mistaken for undriven X-sources downstream.
+        for out, out_pin in outputs:
+            if out:
+                out_driver[out] = (inst_name, cell_type, out_pin)
+
         # Create edges from inputs to outputs through this cell
         for inp, inp_pin in inputs:
             for out, out_pin in outputs:
@@ -116,6 +218,15 @@ def parse_netlist(netlist_path: Path) -> nx.DiGraph:
 
     logger.info(f"Parsed {cells_parsed} cells")
     logger.info(f"Graph has {G.number_of_nodes()} nodes, {G.number_of_edges()} edges")
+
+    if unknown_pins:
+        logger.warning(
+            "%d unrecognized pin name(s) defaulted to 'input': %s. If any is "
+            "actually an output, its net will look undriven — add it to "
+            "OUTPUT_PINS in parser.py.",
+            len(unknown_pins),
+            ", ".join(sorted(unknown_pins)),
+        )
 
     return G
 

--- a/scripts/netlist_graph/tests/test_cone_drivers.py
+++ b/scripts/netlist_graph/tests/test_cone_drivers.py
@@ -1,0 +1,173 @@
+"""Tests for cone (#99) and drivers --data-only (#100) fixes."""
+
+import textwrap
+
+import pytest
+from click.testing import CliRunner
+
+from netlist_graph.cli import main
+from netlist_graph.graph import NetlistGraph
+from netlist_graph.parser import classify_pin, parse_netlist, parse_top_ports, pin_is_recognized
+
+
+class TestPinClassification:
+    """#99: output pins must not be misclassified as inputs."""
+
+    @pytest.mark.parametrize(
+        "pin",
+        ["X", "Y", "Z", "ZN", "Q", "QN", "HI", "LO", "CO", "COUT", "SUM"],
+    )
+    def test_output_pins(self, pin):
+        assert classify_pin(pin) == "output", f"{pin} should be an output"
+
+    @pytest.mark.parametrize("pin", ["A", "B", "A1", "B2", "CLK", "RESET_B", "S", "S0", "D"])
+    def test_input_pins(self, pin):
+        assert classify_pin(pin) == "input", f"{pin} should be an input"
+
+    def test_unknown_pin_warns(self, tmp_path, caplog):
+        """An unrecognized pin name surfaces as a warning, not a silent default."""
+        assert not pin_is_recognized("WEIRDOUT")
+        v = tmp_path / "weird.v"
+        v.write_text(
+            "module top (a, o);\n input a; output o;\n"
+            " somecell c0 (.A(a), .WEIRDOUT(o));\nendmodule\n"
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            parse_netlist(v)
+        assert any("WEIRDOUT" in r.message for r in caplog.records)
+
+
+class TestTopPortParsing:
+    def test_scalar_and_bus(self):
+        content = textwrap.dedent("""\
+            module top (por_l, gpio_in, gpio_out, io);
+             input por_l;
+             input [3:0] gpio_in;
+             output [1:0] gpio_out;
+             inout [43:0] io;
+            endmodule
+        """)
+        ports = parse_top_ports(content)
+        assert ports["por_l"] == "input"
+        assert ports["gpio_in[0]"] == "input"
+        assert ports["gpio_in[3]"] == "input"
+        assert ports["gpio_out[1]"] == "output"
+        assert ports["io[43]"] == "inout"
+
+
+@pytest.fixture
+def driven_net_netlist(tmp_path):
+    """A register whose D is a hold mux fed by combinational cells.
+
+    Reproduces #99: with a conb tie cell and an inverting (.ZN) cell whose
+    outputs were previously misclassified as inputs, leaving the nets looking
+    undriven and mislabeled [primary input].
+    """
+    v = tmp_path / "design.v"
+    v.write_text(textwrap.dedent("""\
+        module top (clk, sel_in, dout);
+         input clk;
+         input sel_in;
+         output dout;
+         wire d_net, mux_o, hi_net, zn_net, undriven_net;
+
+         sky130_fd_sc_hd__conb_1 tie (.HI(hi_net));
+         sky130_fd_sc_hd__aoi21_1 g0 (.A1(hi_net), .A2(sel_in), .B1(undriven_net), .ZN(zn_net));
+         sky130_fd_sc_hd__mux2_1  mx (.A0(zn_net), .A1(dout), .S(hi_net), .X(mux_o));
+         sky130_fd_sc_hd__dfxtp_1 reg0 (.CLK(clk), .D(mux_o), .Q(dout));
+        endmodule
+    """))
+    return v
+
+
+class TestConeDrivenNets:
+    """#99: cone should expand driven internal nets, not stop at them."""
+
+    def test_zn_output_is_driven(self, driven_net_netlist):
+        g = NetlistGraph.from_file(driven_net_netlist)
+        # zn_net is driven by the aoi21 .ZN output → must have a driver edge.
+        assert g.find_drivers("zn_net"), "ZN output net should be driven"
+        assert g.is_driven("zn_net")
+        # hi_net is driven by the conb tie cell .HI output. A tie cell has no
+        # inputs so there is no driver *edge*, but the net is still driven.
+        assert not g.find_drivers("hi_net")
+        assert g.is_driven("hi_net"), "tie-cell output should count as driven"
+        assert g.driver_cell_type("hi_net") == "sky130_fd_sc_hd__conb_1"
+
+    def test_undriven_internal_net_flagged_distinctly(self, driven_net_netlist):
+        g = NetlistGraph.from_file(driven_net_netlist)
+        # undriven_net has no driver and is not a top-level port → X-source.
+        assert not g.find_drivers("undriven_net")
+        assert not g.is_primary_input("undriven_net")
+        # sel_in is a real primary input.
+        assert g.is_primary_input("sel_in")
+
+    def test_cone_cli_labels(self, driven_net_netlist):
+        runner = CliRunner()
+        result = runner.invoke(main, ["cone", str(driven_net_netlist), "dout"])
+        assert result.exit_code == 0, result.output
+        # zn_net must be expanded, not labeled [primary input].
+        assert "zn_net = aoi21_1" in result.output or "zn_net" in result.output
+        # the genuinely undriven net is flagged as an X-source, not primary.
+        assert "undriven_net  [undriven — X-source]" in result.output
+        # the real primary input keeps its label.
+        assert "sel_in  [primary input]" in result.output
+        # the driven internal net must NOT be mislabeled as primary.
+        assert "zn_net  [primary input]" not in result.output
+
+
+@pytest.fixture
+def reg_with_reset_netlist(tmp_path):
+    """A register with a clock and reset tree feeding its control pins."""
+    v = tmp_path / "reg.v"
+    v.write_text(textwrap.dedent("""\
+        module top (clk_pad, rst_pad, d_in, q_out);
+         input clk_pad;
+         input rst_pad;
+         input d_in;
+         output q_out;
+         wire clk_buf, rst_sync, data_net;
+
+         sky130_fd_sc_hd__clkbuf_16 cb (.A(clk_pad), .X(clk_buf));
+         sky130_fd_sc_hd__dfxtp_1   rs (.CLK(clk_buf), .D(rst_pad), .Q(rst_sync));
+         sky130_fd_sc_hd__buf_1     db (.A(d_in), .X(data_net));
+         sky130_fd_sc_hd__dfrtp_1   r0 (.CLK(clk_buf), .RESET_B(rst_sync), .D(data_net), .Q(q_out));
+        endmodule
+    """))
+    return v
+
+
+class TestDriversDataOnly:
+    """#100: --data-only skips clk/reset pins on sequential cells."""
+
+    def test_default_walks_clock_and_reset(self, reg_with_reset_netlist):
+        g = NetlistGraph.from_file(reg_with_reset_netlist)
+        trace = g.trace_back("q_out", max_depth=10)
+        nets = {n for _, n, _ in trace}
+        # Default walk reaches the clock and reset trees.
+        assert "clk_buf" in nets
+        assert "rst_sync" in nets
+        assert "data_net" in nets
+
+    def test_data_only_skips_control(self, reg_with_reset_netlist):
+        g = NetlistGraph.from_file(reg_with_reset_netlist)
+        trace = g.trace_back("q_out", max_depth=10, data_only=True)
+        nets = {n for _, n, _ in trace}
+        # Data path is kept ...
+        assert "data_net" in nets
+        assert "d_in" in nets
+        # ... but the clock and reset trees of r0 are not descended into.
+        assert "clk_buf" not in nets
+        assert "rst_sync" not in nets
+
+    def test_cli_data_only_flag(self, reg_with_reset_netlist):
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["drivers", str(reg_with_reset_netlist), "q_out", "--data-only"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "data path only" in result.output
+        assert "clk_buf" not in result.output
+        assert "rst_sync" not in result.output


### PR DESCRIPTION
Fixes #99 and #100 — two correctness/usability fixes to `netlist-graph`.

## #99 — `cone` mislabels driven internal nets as `[primary input]`

`cone` stopped at internal nets that are actually driven, labeling them
`[primary input]`, so the data path dead-ended one level too early.

**Root cause:** the parser's `OUTPUT_PINS` allowlist was missing common
output pin names — inverting outputs (`ZN`), tie-cell outputs (`LO`/`HI`,
sky130 `conb_1`), `QN`, `CO`, etc. Those pins were classified as cell
*inputs*, so their output nets got no driver edge and looked undriven.

**Fix:**
- Expand `OUTPUT_PINS` to the unambiguous output names across sky130 /
  gf180mcu / generic libraries. Ambiguous names (`S` — adder *sum* output
  but also a mux *select* input) are deliberately **not** added; see the
  comment block in `parser.py`.
- Parse top-level port declarations so a genuine primary input is
  distinguished from a genuinely **undriven internal net** (an X-source).
  `cone` now prints `[undriven — X-source]` distinctly from
  `[primary input]`.
- Track every cell-output net (`out_driver`) so **constant/tie-cell**
  outputs — which have no input→output edge — are recognized as driven and
  labeled `[constant: <cell>]` instead of as X-sources.
- Broaden `_is_register` to match reset/set/scan flop variants
  (`dfrtp`/`dfstp`/`dfbbn`/`sdf*`, gf180 `dffrnq`/`latrnq`) via
  functional-name prefix matching, instead of brittle substring checks.
- **Fragility guard:** warn once at parse time about unrecognized pin
  names that defaulted to `input`, so a new PDK surfaces as a diagnostic
  rather than silently reintroducing this exact bug.

Verified on `tests/timing_test/minimal_build/6_final.v`:
`gpio_analog_en[0]` now reports `[constant: conb_1]` instead of the old
incorrect `[primary input]`.

## #100 — `drivers` walks clk/set/reset pins, swamping the data path

Added `drivers --data-only`: on sequential cells, follow the data (`D`)
pin only and skip clock/set/reset/enable pins, so tracing a register
stays on the data path instead of diving into the clock and reset
distribution trees. Reuses the existing `_DFF_DATA_PINS` / `_is_register`
machinery that `cone` already relies on.

## Tests

`scripts/netlist_graph/tests/test_cone_drivers.py` — 28 cases covering pin
classification, top-level port parsing, the unknown-pin warning, the
const/primary/undriven leaf labeling, and `--data-only` on a reset flop.
Full suite: 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)