### PR TITLE
feat(xprop): xsources manifest + netlist-graph xroots backward X-source query (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ runners land (ADR 0018).
 
 ### Added
 
+- **X-source debugging: `jacquard xsources` + `netlist-graph xroots`**
+  (#98). A two-command workflow to answer "why does signal S read X under
+  `cosim --xprop`?" as a static query instead of a trace→guess→re-run loop.
+  `jacquard xsources <netlist> --config c.json -o xsources.json` statically
+  enumerates every X-source — unreset/reset DFF Q outputs, SRAM read ports,
+  and (with `--config`) undriven primary inputs — as a schema-versioned JSON
+  manifest, names resolved through netlistdb (no GPU required).
+  `netlist-graph xroots <netlist> <signal> --xsources xsources.json` then
+  reverse-reachability-walks the signal's cone (through DFF data pins,
+  skipping clock/reset), intersects with the manifest, and reports the nearest
+  X-source frontier classified by kind; `--emit-trace` writes a
+  `--trace-signals` list for a confirming `--xprop` run. DFF/SRAM sources
+  resolve by driving-cell instance, so jacquard's net-name canonicalisation
+  doesn't break the round-trip. Full guide: `docs/x-debugging.md`. The cosim
+  GPIO-index parser (`parse_gpio_index`) is now shared with the `xsources`
+  driven-set computation so the two stay consistent.
+
 - **Multi-corner support** (WS2.4, commits `5822343` / `530bb36` /
   `59fde04`). `opensta-to-ir` accepts `--liberty NAME=PATH` to attach
   Liberty files to named PVT corners (bare paths still go to a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,16 @@ are planned. See `docs/bus-tracing.md` for the full guide,
 
 See `docs/timing-violations.md` for the full guide on enabling GPU-side setup/hold violation checks, interpreting violation reports, and tracing violations back to source signals using `netlist_graph`.
 
+### X-value Debugging (`xsources` + `xroots`)
+
+When `cosim --xprop` produces an `x` on a signal, find *why* statically
+instead of trace→guess→re-run. `jacquard xsources <netlist> --config
+sim.json -o xsources.json` enumerates the design's X-sources (unreset DFFs,
+SRAM reads, undriven inputs) as JSON; `netlist-graph xroots <netlist>
+<signal> --xsources xsources.json` reverse-walks the signal's cone and reports
+the nearest X-source frontier, with `--emit-trace` writing a `--trace-signals`
+list for a confirming run. Full guide: `docs/x-debugging.md`.
+
 ## Python tooling
 
 Python tools (PDK fetchers, build scripts, harness utilities) belong in

--- a/docs/plans/netlist-graph-xroots.md
+++ b/docs/plans/netlist-graph-xroots.md
@@ -1,0 +1,134 @@
+# Plan: `xroots` — backward X-source frontier query
+
+Issue: [#98](https://github.com/gpu-eda/Jacquard/issues/98). Builds on the
+`netlist-graph` cone/driver fixes in [#101](https://github.com/gpu-eda/Jacquard/pull/101)
+(PR1), which is why this branch is stacked on `fix/netlist-graph-cone-drivers`.
+
+## Problem
+
+When a signal reads X under `jacquard cosim --xprop`, finding *why* is a
+manual trace→guess→re-run loop: the VCD can only report wires you already
+chose to trace, so you must half-know the answer to ask the question. But the
+information is **static**: an X originates at a known X-source (unreset DFF Q,
+SRAM read port, undriven primary input) and propagates forward. So *"what
+makes S read X?"* = *"which X-sources lie in S's backward cone?"* — a pure
+netlist query.
+
+## Design decisions (confirmed)
+
+1. **Driven-input set comes from jacquard, not re-derived in Python.** The
+   authoritative driven set (clock/reset/constant/peripheral pins + GPIO→port
+   mapping) is computed in Rust during cosim setup. A new `jacquard xsources`
+   subcommand dumps the X-source set (including the undriven-input complement)
+   as JSON; `netlist-graph xroots` consumes it. No drift, single source of
+   truth.
+2. **Dominators deferred.** v1 ships the frontier query + classification +
+   `--emit-trace`. Dominators (X-sources every path passes through) need a
+   careful formulation over the DFF-feedback cyclic graph and land as a
+   scoped follow-up once the frontier query proves useful.
+
+## Part A — `jacquard xsources` (Rust)
+
+A new clap subcommand alongside `Sim` / `Cosim` in `src/bin/jacquard.rs`.
+
+```
+jacquard xsources <netlist> --config <sim_config.json> -o xsources.json
+```
+
+Reuses the existing cosim setup path to build the `AIG` + `NetlistDB` and the
+driven-input set, then:
+
+- **DFF-Q / SRAM-read X-sources** from `AIG::compute_x_sources()`
+  (`src/aig.rs:3277`) — already enumerates these as AIG pins.
+- **Undriven primary inputs** = primary-input bits *not* in the cosim driven
+  set (the same complement `cosim --xprop` treats as X; see
+  `cosim-xprop.md` X-source taxonomy rows 3–4).
+- **Name resolution**: map each X-source AIG pin → hierarchical net name via
+  the existing `aigpin → (cell_id, cell_type, output_pin_name)` map
+  (`src/aig.rs:265`) and `NetlistDB` pin/net names. `WordSymbolMap`
+  (`src/flatten.rs:138`) is the precedent for this AIG→name translation.
+
+**Output schema** (`schema_version: "1.0"`, additive-only):
+
+```json
+{
+  "schema_version": "1.0",
+  "netlist": "design.v",
+  "x_sources": [
+    {"net": "top.cpu.regs[7]", "kind": "unreset-dff", "cell": "..."},
+    {"net": "top.sram.rd_data[3]", "kind": "sram-read", "cell": "..."},
+    {"net": "ext_in[2]", "kind": "undriven-input"}
+  ]
+}
+```
+
+`kind` ∈ {`unreset-dff`, `sram-read`, `undriven-input`}. The net names are
+emitted in the same conventions `--trace-signals` resolves, so they round-trip
+into the Python tool and back into a confirming `--xprop` run.
+
+> **Note on "unreset":** jacquard marks *all* DFF Qs as X at cycle 0; a DFF
+> with a connected reset resolves once reset asserts. For a static backward
+> query the useful classification is "is this DFF reset-connected?" — emitted
+> as `unreset-dff` only when no reset/set pin is wired. This is a static
+> over-approximation (documented in the command help).
+
+## Part B — `netlist-graph xroots` (Python)
+
+```
+netlist-graph xroots <netlist> <signal> [--xsources xsources.json] [--emit-trace <file>] [-d DEPTH]
+```
+
+1. **Resolve** `<signal>` to a net (reuse `resolve_name`).
+2. **Reverse-reachability** from the net through `find_drivers`, continuing
+   **through** DFF data pins (the same data-path-through-registers walk as
+   `logic_cone(through_regs=True)` restricted to `_DFF_DATA_PINS` — reuses
+   PR1's corrected `_is_register`). Clock/reset pins are not followed.
+3. **X-source set**:
+   - With `--xsources`: use the manifest's authoritative net set +
+     classification (covers `undriven-input`, which the netlist alone can't
+     classify).
+   - Without it: classify natively from the netlist — DFF-Q nets (cells
+     `_is_register` matches) and SRAM read-port nets — and emit
+     `undriven-input` as *unknown* (warn that `--xsources` is needed for the
+     driven-set complement). Genuinely-undriven internal nets (PR1's
+     `[undriven — X-source]` leaves) are reported as candidate roots.
+4. **Frontier**: BFS outward; when a reached net is an X-source, record it and
+   stop expanding past it (it is a root). Non-source nets keep expanding.
+   Frontier = X-sources reachable without passing through another X-source.
+5. **Report**: frontier X-sources, classified and grouped by kind, nearest
+   first (BFS depth). `--emit-trace <file>` writes them as a `--trace-signals`
+   list (one net per line, `# kind` comments) so a confirming `--xprop` run is
+   one command.
+
+### Reuse / new code
+
+- Reuses: `resolve_name`, `find_drivers`, `_is_register`, `_DFF_DATA_PINS`,
+  `_short_net`, the `out_driver`/`is_driven` machinery from PR1.
+- New: `xroots` graph method (reverse-reachability + frontier intersection),
+  `xroots` CLI command, manifest loader.
+
+## Tests
+
+- **Rust**: `xsources` unit test on a small netlist+config — assert DFF-Q,
+  SRAM-read, and undriven-input nets appear with correct `kind`; reset-
+  connected DFFs are *not* `unreset-dff`.
+- **Python**: synthetic netlist with a known X-source behind two logic
+  levels and a reset-defined path; assert the frontier finds the source, the
+  classification matches the manifest, `--emit-trace` output round-trips, and
+  the "no manifest" mode warns.
+- **Integration**: `xsources` on `tests/timing_test/minimal_build` →
+  `xroots --emit-trace` → feed back to `cosim --xprop --trace-signals` and
+  confirm the surfaced wires carry X (smoke test, gated on Metal availability).
+
+## Sequencing
+
+1. Part A (`jacquard xsources`) + Rust tests.
+2. Part B (`netlist-graph xroots`) + Python tests, consuming Part A's manifest.
+3. Docs: a `docs/x-debugging.md` user guide (xsources → xroots → confirming
+   --xprop run) + CHANGELOG entries + a one-line pointer in CLAUDE.md's
+   debugging-tools section.
+
+## Out of scope (follow-ups)
+
+- Dominator analysis (decision 2).
+- Wire-bundle reconstruction of multi-bit X-source buses (tracked separately).

--- a/docs/x-debugging.md
+++ b/docs/x-debugging.md
@@ -1,0 +1,148 @@
+# Debugging X values in cosim (`xsources` + `xroots`)
+
+When you run `jacquard cosim --xprop` and a signal reads `x` (unknown), the
+question is always *why* — which uninitialised state or undriven input is
+feeding that X forward? This guide covers the two-command workflow that
+answers it as a **static query**, without the trace→guess→re-run loop.
+
+- `jacquard xsources` — enumerate *where X originates* in the design.
+- `netlist-graph xroots` — given a signal, find *which* of those X-sources
+  reach it (its backward "X-root" frontier).
+
+See [ADR 0016](adr/0016-selective-x-propagation.md) for the X-propagation
+semantics and [issue #98](https://github.com/gpu-eda/Jacquard/issues/98) for
+the design rationale.
+
+## Background: where X comes from
+
+Under `--xprop`, an X value originates at one of three **X-sources** and then
+propagates forward through combinational logic:
+
+| Kind | X because… |
+|------|-----------|
+| `unreset-dff` | A DFF Q output with **no reset/set pin** — undefined at power-up and never forced to a known value. |
+| `reset-dff` | A DFF Q with a reset/set pin — undefined at power-up but **defined once reset asserts**. Usually *not* the culprit after reset. |
+| `sram-read` | An SRAM read-data port — undefined until the addressed cell is written. |
+| `undriven-input` | A primary input the testbench **leaves undriven** (no clock/reset/constant/peripheral drives it) — reads X every tick. |
+
+A signal reads X iff at least one X-source lies in its backward logic cone.
+That is a pure netlist property — no simulation needed to compute it.
+
+## Step 1 — enumerate X-sources: `jacquard xsources`
+
+```bash
+jacquard xsources <netlist> --config <sim_config.json> -o xsources.json
+```
+
+This builds the static AIG (no GPU) and writes a JSON manifest of every
+X-source. `--config` is required only to classify `undriven-input` sources
+(the driven-set complement); without it, only DFF and SRAM sources are
+emitted.
+
+```json
+{
+  "schema_version": "1.0",
+  "netlist": "design.v",
+  "undriven_inputs_classified": true,
+  "x_sources": [
+    { "net": "q_unreset",  "kind": "unreset-dff",    "cell": "_29_" },
+    { "net": "_10_[1]",    "kind": "unreset-dff",    "cell": "_30_" },
+    { "net": "q_reset",    "kind": "reset-dff",      "cell": "_28_" },
+    { "net": "unconnected","kind": "undriven-input" }
+  ]
+}
+```
+
+Notes:
+
+- **`net`** is jacquard's canonical net name (after assign-merging), which may
+  differ from the raw name in the Verilog. **`cell`** is the driving instance
+  and is stable across tools — `xroots` resolves DFF/SRAM sources by cell, so
+  the naming difference does not matter.
+- The `undriven-input` classification reflects the config's **declared
+  drivers**: clock(s), reset, `constant_inputs`, `constant_ports`, and each
+  peripheral's pins (flash/uart/gpio/jtag). An input outside that set is
+  reported as undriven.
+- A reset-connected DFF is emitted as `reset-dff`. It is X at power-up but
+  resolves once reset asserts, so `xroots` traverses **through** it rather
+  than stopping (see below).
+
+## Step 2 — find a signal's X-roots: `netlist-graph xroots`
+
+```bash
+netlist-graph xroots <netlist> <signal> --xsources xsources.json
+```
+
+`xroots` walks **backward** from `<signal>` through the driver cone — and
+*through* DFF data (`D`) pins, the reverse of the forward X-prop fixpoint —
+skipping clock/set/reset pins. It stops at each **persistent** X-source
+(`unreset-dff` / `sram-read` / `undriven-input`), reporting the nearest
+frontier:
+
+```text
+$ netlist-graph xroots design.v top.cpu.stall --xsources xsources.json
+X-source frontier of top.cpu.stall (2 root(s), nearest first):
+  [unreset-dff] top.cpu.state[3]   (depth 5)
+  [undriven-input] cfg_mode        (depth 8)
+```
+
+Reset DFFs (`reset-dff`) are **traversed through** (their data cone is
+followed), because reset defines them — so the frontier surfaces the *real*
+persistent roots behind them, not the reset flop itself.
+
+If no X-source reaches the signal, `xroots` says so — under `--xprop` that
+signal should be X-free.
+
+### Without a manifest
+
+`xroots` also runs without `--xsources`, classifying X-sources from the
+netlist alone (DFF Q by reset-pin presence, SRAM reads, and genuinely
+undriven internal nets). This cannot classify `undriven-input` sources (it
+does not know the cosim driven set), so pass `jacquard xsources --config`
+output when you need those.
+
+## Step 3 — confirm with a targeted `--xprop` run
+
+`--emit-trace` writes the frontier as a [`--trace-signals`](signal-tracing.md)
+file, so confirming the X actually originates where `xroots` says is one
+command:
+
+```bash
+netlist-graph xroots design.v top.cpu.stall \
+    --xsources xsources.json --emit-trace xroots.txt
+
+jacquard cosim design.v --config sim.json \
+    --xprop --trace-signals xroots.txt --output-vcd out.vcd
+```
+
+The traced frontier nets appear in `out.vcd`; watch them carry `x` and resolve
+(or not) over the reset window to confirm the diagnosis.
+
+## Worked example
+
+`tests/xprop_cosim/` is the X-propagation demo. `q_unreset` is a self-holding
+unreset register (stays X); `q_reset` resolves after reset:
+
+```bash
+jacquard xsources tests/xprop_cosim/xprop_demo_synth.gv \
+    --config tests/xprop_cosim/sim_config.json -o /tmp/xsrc.json
+
+# Why is the counter's next-state X?
+netlist-graph xroots tests/xprop_cosim/xprop_demo_synth.gv "_11_[3]" \
+    --xsources /tmp/xsrc.json
+#   [unreset-dff] unreset_count[3]  (depth 2)
+#   [unreset-dff] unreset_count[2]  (depth 3)
+#   ...
+```
+
+## Limitations
+
+- The frontier is a **static over-approximation**: it reports X-sources whose
+  cone reaches the signal, not whether the X is live on a given cycle (an
+  unreset DFF may resolve once its own data cone settles from known inputs).
+  It tells you *what to initialise/drive* to make the signal defined.
+- Name round-tripping is exact for **flattened** post-synthesis netlists (the
+  target of these tools). DFF/SRAM sources resolve by cell instance, which is
+  robust; `undriven-input` sources resolve by name.
+- Dominator analysis (X-sources that *every* path passes through — guaranteed
+  roots) is a planned follow-up; v1 reports the reachable frontier.

--- a/scripts/netlist_graph/src/netlist_graph/cli.py
+++ b/scripts/netlist_graph/src/netlist_graph/cli.py
@@ -1,5 +1,6 @@
 """Command-line interface for netlist-graph."""
 
+import json
 import logging
 import sys
 from pathlib import Path
@@ -322,6 +323,158 @@ def cone(netlist: Path, signal: str, depth: int, through_regs: bool):
             )
             reg_marker = " [REG]" if is_reg else ""
             click.echo(f"{indent}{short_net} = {short_type}({pin_str}){reg_marker}")
+
+
+# Persistent X-source kinds — roots the frontier stops at. `reset-dff` is
+# traversed *through* (reset defines it), so it is not persistent.
+_PERSISTENT_X_KINDS = {"unreset-dff", "sram-read", "undriven-input"}
+
+
+def _load_xsource_kinds(
+    graph: NetlistGraph, xsources_path: Path | None
+) -> tuple[dict[str, str], str]:
+    """Return (net→kind, summary message) for the X-source set.
+
+    Without a manifest, falls back to native netlist classification.
+
+    With a manifest, resolves each entry to a graph node. DFF/SRAM sources are
+    resolved by **driving cell instance** rather than net name: jacquard's
+    netlistdb canonicalises assign-merged nets (e.g. `unreset_count[1]` →
+    `_10_[1]`), so the manifest's net name need not match the raw cell-
+    connection name the Python parser uses — but the cell instance (`_30_`)
+    is identical in both. Inputs (no cell) resolve by net name.
+    """
+    if xsources_path is None:
+        kinds = graph.native_x_sources()
+        msg = (
+            f"No --xsources manifest; using native classification "
+            f"({len(kinds)} X-source net(s)). For authoritative undriven-input "
+            f"classification, pass `jacquard xsources --config ...` output."
+        )
+        return kinds, msg
+
+    data = json.loads(xsources_path.read_text())
+
+    # Cell instance → nets it drives, for resolving DFF/SRAM sources by stable
+    # cell name rather than canonicalised net name.
+    inst_to_nets = graph.inst_to_nets()
+
+    kinds: dict[str, str] = {}
+    unresolved = 0
+    for entry in data.get("x_sources", []):
+        node: str | None = None
+        cell = entry.get("cell")
+        if cell is not None:
+            nets = inst_to_nets.get(cell.lstrip("\\").rstrip(" "))
+            # Unambiguous only when the cell drives exactly one net (DFF Q);
+            # multi-output cells (SRAM) fall through to net-name resolution.
+            if nets is not None and len(nets) == 1:
+                node = nets[0]
+        if node is None:
+            raw_net = entry["net"]
+            node = raw_net if graph.has_net(raw_net) else graph.resolve_name(raw_net)
+        if node is None:
+            unresolved += 1
+            continue
+        kinds[node] = entry["kind"]
+
+    msg = (
+        f"Loaded {len(kinds)} X-source(s) from {xsources_path.name}"
+        + (f" ({unresolved} not found in this netlist)" if unresolved else "")
+    )
+    return kinds, msg
+
+
+@main.command()
+@click.argument("netlist", type=click.Path(exists=True, path_type=Path))
+@click.argument("signal", type=str)
+@click.option(
+    "--xsources",
+    "xsources_path",
+    type=click.Path(exists=True, path_type=Path),
+    help="X-source manifest from `jacquard xsources` (authoritative). Without "
+    "it, X-sources are classified from the netlist alone (no undriven-input).",
+)
+@click.option(
+    "--emit-trace",
+    "emit_trace",
+    type=click.Path(path_type=Path),
+    help="Write the frontier as a --trace-signals file for a confirming "
+    "`cosim --xprop` run.",
+)
+@click.option("-d", "--depth", default=100_000, help="Maximum backward walk depth")
+def xroots(
+    netlist: Path,
+    signal: str,
+    xsources_path: Path | None,
+    emit_trace: Path | None,
+    depth: int,
+):
+    """Find the X-sources that make SIGNAL read X under `cosim --xprop`.
+
+    Reverse-reachability from SIGNAL through the driver cone (and through DFF
+    data pins) intersected with the design's X-source set, reporting the
+    nearest frontier roots — unreset DFFs, SRAM reads, undriven inputs. This
+    answers "why is S X?" as a static query, replacing a trace→guess→re-run
+    loop. See `docs/x-debugging.md` and issue #98.
+
+    Examples:
+        jacquard xsources design.v --config sim.json -o xsrc.json
+        netlist-graph xroots design.v top.cpu.stall --xsources xsrc.json
+        netlist-graph xroots design.v some_net --xsources xsrc.json --emit-trace t.txt
+    """
+    graph = NetlistGraph.from_file(netlist)
+    click.echo(f"Loaded {graph.num_nodes} nodes, {graph.num_edges} edges")
+
+    resolved = graph.resolve_name(signal)
+    if not resolved:
+        matches = graph.search(signal, limit=10)
+        if matches:
+            click.echo(f"No unique match for '{signal}'. Candidates:")
+            for m in matches:
+                click.echo(f"  {graph._short_net(m)}")
+        else:
+            click.echo(f"No nets matching '{signal}'")
+        sys.exit(1)
+
+    kinds, msg = _load_xsource_kinds(graph, xsources_path)
+    click.echo(msg)
+
+    stop_nets = {net for net, kind in kinds.items() if kind in _PERSISTENT_X_KINDS}
+
+    if resolved in stop_nets:
+        click.echo(
+            f"\n{graph._short_net(resolved)} is itself an X-source "
+            f"({kinds[resolved]})."
+        )
+
+    frontier = graph.x_source_frontier(resolved, stop_nets, max_depth=depth)
+
+    if not frontier:
+        click.echo(
+            f"\nNo X-sources reach {graph._short_net(resolved)} — under --xprop "
+            f"it should be X-free (every path traces back to driven inputs / "
+            f"reset-defined state)."
+        )
+        return
+
+    click.echo(
+        f"\nX-source frontier of {graph._short_net(resolved)} "
+        f"({len(frontier)} root(s), nearest first):"
+    )
+    for d, net in frontier:
+        click.echo(f"  [{kinds.get(net, '?')}] {graph._short_net(net)}  (depth {d})")
+
+    if emit_trace:
+        lines: list[str] = [
+            f"# X-source frontier of {graph._short_net(resolved)} "
+            f"(from netlist-graph xroots)",
+        ]
+        for d, net in frontier:
+            lines.append(f"# {kinds.get(net, '?')} (depth {d})")
+            lines.append(graph._short_net(net))
+        emit_trace.write_text("\n".join(lines) + "\n")
+        click.echo(f"\nWrote {len(frontier)} frontier net(s) to {emit_trace}")
 
 
 @main.command("interactive")

--- a/scripts/netlist_graph/src/netlist_graph/graph.py
+++ b/scripts/netlist_graph/src/netlist_graph/graph.py
@@ -1,6 +1,7 @@
 """Graph wrapper with query methods for netlist analysis."""
 
 import fnmatch
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -408,3 +409,112 @@ class NetlistGraph:
             depth += 1
 
         return cone
+
+    # ── X-source frontier query (`xroots`, issue #98) ──────────────────────
+
+    # DFF reset/set pin leaves (lower-cased), mirroring the Rust
+    # `x_sources::RESET_SET_PIN_LEAVES`. Used to split unreset vs reset DFFs
+    # in native (no-manifest) mode.
+    _RESET_SET_PINS = {
+        "reset_b", "set_b", "resetn", "setn", "reset", "set", "clrz", "clr",
+        "clrn", "pre", "pren", "rn", "sn", "rb", "sb", "r", "s",
+    }
+
+    def x_source_frontier(
+        self,
+        net: str,
+        stop_nets: set[str],
+        max_depth: int = 100_000,
+    ) -> list[tuple[int, str]]:
+        """Nearest X-source nets in the backward cone of ``net``.
+
+        Walks backward through drivers, continuing **through** DFF data (``D``)
+        pins — the reverse of the forward X-prop fixpoint — and skipping
+        clock/set/reset/enable pins on sequential cells. When a reached net is
+        in ``stop_nets`` it is recorded as a frontier root and not expanded
+        past; other nets (combinational, and reset-defined DFFs that are *not*
+        in ``stop_nets``) keep expanding.
+
+        Returns ``(depth, net)`` for each frontier X-source, nearest first,
+        deduplicated. The start net is always expanded (the query is over its
+        cone, not the point itself).
+        """
+        frontier: list[tuple[int, str]] = []
+        visited: set[str] = set()
+        queue: deque[tuple[str, int]] = deque([(net, 0)])
+
+        while queue:
+            cur, depth = queue.popleft()
+            if cur in visited or depth > max_depth:
+                continue
+            visited.add(cur)  # dequeued once, so each root is recorded once
+
+            if cur != net and cur in stop_nets:
+                frontier.append((depth, cur))
+                continue  # a root — do not expand past it
+
+            for d in self.find_drivers(cur):
+                if (
+                    self._is_register(d.cell_type)
+                    and d.in_pin not in self._DFF_DATA_PINS
+                ):
+                    continue  # clock/set/reset/enable on a sequential cell
+                queue.append((d.from_net, depth + 1))
+
+        frontier.sort()
+        return frontier
+
+    def inst_to_nets(self) -> dict[str, list[str]]:
+        """Map each driving cell instance to the nets it drives.
+
+        Instance names are normalised (leading escape backslash and trailing
+        space stripped) so a manifest's cell name matches regardless of Verilog
+        escaping. Used to resolve X-source manifest entries by stable cell
+        instance rather than by net name (which differs between jacquard's
+        canonicalised and the raw cell-connection naming).
+        """
+        idx: dict[str, list[str]] = {}
+        out_driver: dict[str, tuple[str, str, str]] = self._graph.graph.get("out_driver", {})
+        for net, (inst, _ct, _pin) in out_driver.items():
+            idx.setdefault(inst.lstrip("\\").rstrip(" "), []).append(net)
+        return idx
+
+    def native_x_sources(self) -> dict[str, str]:
+        """Best-effort X-source classification from the netlist alone.
+
+        The fallback when no ``jacquard xsources`` manifest is supplied. Maps
+        each X-source net to its kind:
+
+          - DFF Q nets → ``unreset-dff`` (no reset/set pin) or ``reset-dff``
+          - SRAM read-output nets → ``sram-read``
+          - genuinely undriven internal nets → ``undriven-input``
+
+        Less precise than the manifest: the cosim *driven set* is unknown here,
+        so an undriven primary input cannot be distinguished from one the
+        testbench drives. Use ``jacquard xsources --config`` for authoritative
+        classification.
+        """
+        out_driver: dict[str, tuple[str, str, str]] = self._graph.graph.get("out_driver", {})
+
+        # One pass: index each cell instance's connected input-pin names, so
+        # reset detection is O(E) total rather than O(E) per DFF.
+        cell_in_pins: dict[str, set[str]] = {}
+        for _u, _v, data in self._graph.edges(data=True):
+            cell = data.get("cell")
+            if cell is not None:
+                cell_in_pins.setdefault(cell, set()).add(data.get("in_pin", "").lower())
+
+        sources: dict[str, str] = {}
+        for net, (inst, cell_type, _pin) in out_driver.items():
+            if self._is_register(cell_type):
+                has_reset = bool(cell_in_pins.get(inst, set()) & self._RESET_SET_PINS)
+                sources[net] = "reset-dff" if has_reset else "unreset-dff"
+            elif "ram" in cell_type.lower():
+                sources[net] = "sram-read"
+
+        # Genuinely undriven internal nets (not a top-level port) are X-sources.
+        for n in self._graph.nodes():
+            if n not in sources and not self.is_driven(n) and not self.is_primary_input(n):
+                sources[n] = "undriven-input"
+
+        return sources

--- a/scripts/netlist_graph/tests/test_xroots.py
+++ b/scripts/netlist_graph/tests/test_xroots.py
@@ -1,0 +1,139 @@
+"""Tests for the xroots X-source frontier query (#98)."""
+
+import json
+import textwrap
+
+import pytest
+from click.testing import CliRunner
+
+from netlist_graph.cli import main
+from netlist_graph.graph import NetlistGraph
+
+
+@pytest.fixture
+def xsrc_netlist(tmp_path):
+    """A design with a controlled X-source topology.
+
+      out = and2(comb, undriven_w)
+      comb = nand2(q_a, q_b)
+      q_a  = unreset DFF (no reset pin)           <- persistent X-source
+      q_b  = reset DFF (RESET_B), D = ext_in       <- traversed through
+      undriven_w : no driver, not a port           <- persistent X-source
+    """
+    v = tmp_path / "design.v"
+    v.write_text(textwrap.dedent("""\
+        module top (clk, rst_n, ext_in, out);
+         input clk;
+         input rst_n;
+         input ext_in;
+         output out;
+         wire q_a, q_b, comb, undriven_w;
+
+         sky130_fd_sc_hd__dfxtp_1 ra (.CLK(clk), .D(comb), .Q(q_a));
+         sky130_fd_sc_hd__dfrtp_1 rb (.CLK(clk), .RESET_B(rst_n), .D(ext_in), .Q(q_b));
+         sky130_fd_sc_hd__nand2_1 g0 (.A(q_a), .B(q_b), .Y(comb));
+         sky130_fd_sc_hd__and2_0  g1 (.A(comb), .B(undriven_w), .X(out));
+        endmodule
+    """))
+    return v
+
+
+class TestNativeXSources:
+    def test_classification(self, xsrc_netlist):
+        g = NetlistGraph.from_file(xsrc_netlist)
+        src = g.native_x_sources()
+        assert src.get("q_a") == "unreset-dff"
+        assert src.get("q_b") == "reset-dff"
+        assert src.get("undriven_w") == "undriven-input"
+        # ext_in is a primary input (driven externally) — not an X-source here.
+        assert "ext_in" not in src
+
+
+class TestFrontier:
+    def test_stops_at_persistent_sources(self, xsrc_netlist):
+        g = NetlistGraph.from_file(xsrc_netlist)
+        stop = {"q_a", "undriven_w"}  # persistent roots; q_b (reset) traversed
+        frontier = g.x_source_frontier("out", stop)
+        nets = {n for _, n in frontier}
+        assert nets == {"q_a", "undriven_w"}
+
+    def test_traverses_through_reset_dff(self, xsrc_netlist):
+        g = NetlistGraph.from_file(xsrc_netlist)
+        # q_b is a reset DFF: not a stop net, so the walk continues through its
+        # D pin to ext_in. With ext_in marked persistent, it becomes a root.
+        stop = {"q_a", "undriven_w", "ext_in"}
+        frontier = g.x_source_frontier("out", stop)
+        nets = {n for _, n in frontier}
+        assert "ext_in" in nets  # reached by traversing through the reset DFF
+
+    def test_nearest_first(self, xsrc_netlist):
+        g = NetlistGraph.from_file(xsrc_netlist)
+        frontier = g.x_source_frontier("out", {"q_a", "undriven_w"})
+        depths = [d for d, _ in frontier]
+        assert depths == sorted(depths)
+
+    def test_does_not_walk_clock_pin(self, xsrc_netlist):
+        g = NetlistGraph.from_file(xsrc_netlist)
+        # clk drives the DFF CLK pins; the frontier walk must not descend into
+        # the clock, so clk never appears even if marked an X-source.
+        frontier = g.x_source_frontier("out", {"clk", "q_a"})
+        nets = {n for _, n in frontier}
+        assert "clk" not in nets
+
+
+class TestXrootsCli:
+    def test_native_frontier(self, xsrc_netlist):
+        runner = CliRunner()
+        result = runner.invoke(main, ["xroots", str(xsrc_netlist), "out"])
+        assert result.exit_code == 0, result.output
+        assert "[unreset-dff] q_a" in result.output
+        assert "[undriven-input] undriven_w" in result.output
+        # reset DFF is traversed through, not reported as a root.
+        assert "q_b" not in result.output
+
+    def test_manifest_resolution_by_cell(self, xsrc_netlist, tmp_path):
+        # A manifest naming the source net `CANON_qa` (a name absent from the
+        # netlist) but with the correct driving cell `ra` must still resolve,
+        # via cell→net, to the graph's `q_a`.
+        manifest = tmp_path / "xsrc.json"
+        manifest.write_text(json.dumps({
+            "schema_version": "1.0",
+            "netlist": str(xsrc_netlist),
+            "undriven_inputs_classified": True,
+            "x_sources": [
+                {"net": "CANON_qa", "kind": "unreset-dff", "cell": "ra"},
+                {"net": "undriven_w", "kind": "undriven-input"},
+            ],
+        }))
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["xroots", str(xsrc_netlist), "out", "--xsources", str(manifest)]
+        )
+        assert result.exit_code == 0, result.output
+        # Resolved by cell despite the mismatched net name.
+        assert "[unreset-dff] q_a" in result.output
+        assert "[undriven-input] undriven_w" in result.output
+
+    def test_emit_trace_roundtrips(self, xsrc_netlist, tmp_path):
+        out = tmp_path / "trace.txt"
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["xroots", str(xsrc_netlist), "out", "--emit-trace", str(out)]
+        )
+        assert result.exit_code == 0, result.output
+        content = out.read_text()
+        # One bare net name per non-comment line, resolvable in the netlist.
+        nets = [ln for ln in content.splitlines() if ln and not ln.startswith("#")]
+        assert "q_a" in nets
+        assert "undriven_w" in nets
+
+    def test_signal_is_itself_a_source(self, xsrc_netlist):
+        runner = CliRunner()
+        result = runner.invoke(main, ["xroots", str(xsrc_netlist), "q_a"])
+        assert result.exit_code == 0, result.output
+        assert "is itself an X-source" in result.output
+
+    def test_unknown_signal_errors(self, xsrc_netlist):
+        runner = CliRunner()
+        result = runner.invoke(main, ["xroots", str(xsrc_netlist), "nonexistent_xyz"])
+        assert result.exit_code == 1

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -59,6 +59,15 @@ enum Commands {
     /// Analyzes the AIG timing and shows the critical paths from source to sink,
     /// including cell origins (synthesis cells), gate delays, and cumulative arrivals.
     DumpPaths(DumpPathsArgs),
+
+    /// Emit the design's X-source set as JSON (for `cosim --xprop` debugging).
+    ///
+    /// Statically enumerates where X originates: unreset DFF Q outputs, SRAM
+    /// read ports, and — with `--config` — primary inputs the testbench leaves
+    /// undriven. Feed the output to `netlist-graph xroots` to answer "which
+    /// X-sources make signal S read X?". No GPU required. See
+    /// `docs/x-debugging.md` and issue #98.
+    Xsources(XsourcesArgs),
 }
 
 #[derive(Parser)]
@@ -372,6 +381,30 @@ struct DumpPathsArgs {
     /// Number of critical paths to dump (default: 5).
     #[clap(long, default_value = "5")]
     limit: usize,
+}
+
+#[derive(Parser)]
+struct XsourcesArgs {
+    /// Gate-level Verilog path synthesized with AIGPDK, SKY130, or GF180MCU.
+    netlist_verilog: PathBuf,
+
+    /// Testbench configuration JSON. Required to classify undriven primary
+    /// inputs (the cosim driven-set complement); without it only DFF and SRAM
+    /// X-sources are emitted.
+    #[clap(long)]
+    config: Option<PathBuf>,
+
+    /// Output JSON path. Writes to stdout when omitted.
+    #[clap(long, short = 'o')]
+    output: Option<PathBuf>,
+
+    /// Top module name in the netlist.
+    #[clap(long)]
+    top_module: Option<String>,
+
+    /// User-supplied Verilog cell-library files (same as `sim`/`cosim`).
+    #[clap(long = "cell-library", value_name = "PATH")]
+    cell_library: Vec<PathBuf>,
 }
 
 #[allow(unused_variables)]
@@ -1579,6 +1612,60 @@ fn cmd_dump_paths(args: DumpPathsArgs) {
     println!("{}", output);
 }
 
+/// Emit the design's X-source set as JSON. No GPU — builds only the static
+/// NetlistDB + AIG, then enumerates DFF/SRAM/undriven-input X-sources.
+fn cmd_xsources(args: XsourcesArgs) {
+    use jacquard::sim::setup::build_netlist_and_aig;
+    use jacquard::sim::x_sources::{compute_x_source_manifest, XSourceKind};
+    use jacquard::testbench::TestbenchConfig;
+
+    let (netlistdb, aig) = build_netlist_and_aig(
+        &args.netlist_verilog,
+        args.top_module.as_deref(),
+        &args.cell_library,
+    );
+
+    let config: Option<TestbenchConfig> = args.config.as_ref().map(|path| {
+        let file = std::fs::File::open(path)
+            .unwrap_or_else(|e| panic!("opening config {}: {e}", path.display()));
+        serde_json::from_reader(std::io::BufReader::new(file))
+            .unwrap_or_else(|e| panic!("parsing config {}: {e}", path.display()))
+    });
+
+    let manifest = compute_x_source_manifest(
+        &netlistdb,
+        &aig,
+        config.as_ref(),
+        &args.netlist_verilog.to_string_lossy(),
+    );
+
+    // Per-kind summary on stderr (stdout stays clean JSON when piped).
+    let count = |k: XSourceKind| manifest.x_sources.iter().filter(|s| s.kind == k).count();
+    clilog::info!(
+        "X-sources: {} total — {} unreset-dff, {} reset-dff, {} sram-read, {} undriven-input{}",
+        manifest.x_sources.len(),
+        count(XSourceKind::UnresetDff),
+        count(XSourceKind::ResetDff),
+        count(XSourceKind::SramRead),
+        count(XSourceKind::UndrivenInput),
+        if manifest.undriven_inputs_classified {
+            ""
+        } else {
+            " (pass --config to classify undriven inputs)"
+        }
+    );
+
+    let json = serde_json::to_string_pretty(&manifest).expect("serialize X-source manifest");
+    match args.output.as_ref() {
+        Some(path) => {
+            std::fs::write(path, format!("{json}\n"))
+                .unwrap_or_else(|e| panic!("writing {}: {e}", path.display()));
+            clilog::info!("Wrote {} X-source(s) to {}", manifest.x_sources.len(), path.display());
+        }
+        None => println!("{json}"),
+    }
+}
+
 fn main() {
     clilog::init_stderr_color_debug();
     clilog::set_max_print_count(clilog::Level::Warn, "NL_SV_LIT", 1);
@@ -1588,6 +1675,7 @@ fn main() {
         Commands::Sim(args) => cmd_sim(args),
         Commands::Cosim(args) => cmd_cosim(args),
         Commands::DumpPaths(args) => cmd_dump_paths(args),
+        Commands::Xsources(args) => cmd_xsources(args),
     }
 }
 

--- a/src/sim/cosim_metal.rs
+++ b/src/sim/cosim_metal.rs
@@ -10,6 +10,9 @@ use std::collections::HashMap;
 use crate::aig::{DriverType, AIG};
 use crate::flatten::FlattenedScriptV1;
 use crate::sim::setup::LoadedDesign;
+// Shared with the `xsources` driven-input computation so cosim's GPIO
+// mapping and the static X-source query stay consistent (issue #98).
+use crate::sim::x_sources::parse_gpio_index;
 use crate::testbench::{CppSpiFlash, PortMapping, TestbenchConfig, UartEvent};
 use metal::{
     CommandQueue, ComputePipelineState, Device as MTLDevice, MTLResourceOptions, MTLSize,
@@ -1333,24 +1336,6 @@ pub(crate) fn build_gpio_mapping(
         clock_domains,
         named_input_bits,
     }
-}
-
-/// Parse a GPIO index from a pin name like "gpio_in[38]" or "gpio_in:38".
-fn parse_gpio_index(pin_name: &str, prefix: &str) -> Option<usize> {
-    // Try "gpio_in[N]" format
-    if let Some(start) = pin_name.find(&format!("{}[", prefix)) {
-        let after = &pin_name[start + prefix.len() + 1..];
-        if let Some(end) = after.find(']') {
-            return after[..end].parse().ok();
-        }
-    }
-    // Try "gpio_in:N" format
-    if let Some(start) = pin_name.find(&format!("{}:", prefix)) {
-        let after = &pin_name[start + prefix.len() + 1..];
-        let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
-        return num_str.parse().ok();
-    }
-    None
 }
 
 /// Resolve an internal signal name to its output state bit position.

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -21,3 +21,4 @@ pub mod sram_preload;
 pub mod trace_signals;
 pub mod timing_ir_loader;
 pub mod vcd_io;
+pub mod x_sources;

--- a/src/sim/setup.rs
+++ b/src/sim/setup.rs
@@ -80,14 +80,18 @@ pub struct LoadedDesign {
     pub json_path: PathBuf,
 }
 
-/// Load a design through the full pipeline: netlist → AIG → staged → script.
-///
-/// Detects cell library (AIGPDK, SKY130, or GF180MCU), loads display info
-/// from JSON, builds the flattened script, and optionally loads SDF timing
-/// data.
-pub fn load_design(args: &DesignArgs) -> LoadedDesign {
+/// Build just the `NetlistDB` and `AIG` from a netlist — the feature-
+/// independent front half of [`load_design`], without staging, partitioning,
+/// or GPU script generation. Used by `load_design` and by the `jacquard
+/// xsources` subcommand, which needs only the static AIG to enumerate
+/// X-sources (issue #98).
+pub fn build_netlist_and_aig(
+    netlist_verilog: &Path,
+    top_module: Option<&str>,
+    cell_library: &[PathBuf],
+) -> (NetlistDB, AIG) {
     // Detect cell library
-    let lib = detect_library_from_file(&args.netlist_verilog).expect("Failed to read netlist file");
+    let lib = detect_library_from_file(netlist_verilog).expect("Failed to read netlist file");
     clilog::info!("Detected cell library: {}", lib);
 
     if lib == CellLibrary::Mixed {
@@ -97,10 +101,10 @@ pub fn load_design(args: &DesignArgs) -> LoadedDesign {
     // Load any user-supplied runtime cell libraries (`--cell-library`).
     // Empty when no flags were passed; in that case the chained
     // provider degenerates to its built-in fallback.
-    let runtime_lib = if args.cell_library.is_empty() {
+    let runtime_lib = if cell_library.is_empty() {
         RuntimeCellLibrary::default()
     } else {
-        let loaded = RuntimeCellLibrary::from_files(&args.cell_library)
+        let loaded = RuntimeCellLibrary::from_files(cell_library)
             .unwrap_or_else(|e| panic!("loading --cell-library: {e}"));
         clilog::info!(
             "Loaded {} cell-library pin entries, {} kind annotations from --cell-library",
@@ -116,12 +120,8 @@ pub fn load_design(args: &DesignArgs) -> LoadedDesign {
                 runtime: &runtime_lib,
                 fallback: &SKY130LeafPins,
             };
-            NetlistDB::from_sverilog_file(
-                &args.netlist_verilog,
-                args.top_module.as_deref(),
-                &provider,
-            )
-            .expect("cannot build netlist")
+            NetlistDB::from_sverilog_file(netlist_verilog, top_module, &provider)
+                .expect("cannot build netlist")
         }
         // GF180MCU (7t5v0 + 9t5v0). Combinational + sequential paths
         // (DFFs, latches, scan, clock-gating) are all wired through
@@ -131,24 +131,16 @@ pub fn load_design(args: &DesignArgs) -> LoadedDesign {
                 runtime: &runtime_lib,
                 fallback: &crate::gf180mcu::GF180MCULeafPins,
             };
-            NetlistDB::from_sverilog_file(
-                &args.netlist_verilog,
-                args.top_module.as_deref(),
-                &provider,
-            )
-            .expect("cannot build netlist")
+            NetlistDB::from_sverilog_file(netlist_verilog, top_module, &provider)
+                .expect("cannot build netlist")
         }
         CellLibrary::AIGPDK | CellLibrary::Mixed => {
             let provider = ChainedPinProvider {
                 runtime: &runtime_lib,
                 fallback: &AIGPDKLeafPins(),
             };
-            NetlistDB::from_sverilog_file(
-                &args.netlist_verilog,
-                args.top_module.as_deref(),
-                &provider,
-            )
-            .expect("cannot build netlist")
+            NetlistDB::from_sverilog_file(netlist_verilog, top_module, &provider)
+                .expect("cannot build netlist")
         }
     };
 
@@ -162,7 +154,21 @@ pub fn load_design(args: &DesignArgs) -> LoadedDesign {
     } else {
         Some(&runtime_lib)
     };
-    let mut aig = AIG::from_netlistdb_with_cells(&netlistdb, cell_lib_ref);
+    let aig = AIG::from_netlistdb_with_cells(&netlistdb, cell_lib_ref);
+    (netlistdb, aig)
+}
+
+/// Load a design through the full pipeline: netlist → AIG → staged → script.
+///
+/// Detects cell library (AIGPDK, SKY130, or GF180MCU), loads display info
+/// from JSON, builds the flattened script, and optionally loads SDF timing
+/// data.
+pub fn load_design(args: &DesignArgs) -> LoadedDesign {
+    let (netlistdb, mut aig) = build_netlist_and_aig(
+        &args.netlist_verilog,
+        args.top_module.as_deref(),
+        &args.cell_library,
+    );
 
     // Register user-supplied trace signals (--trace-signals). Must
     // run before staging/partitioning so the resolved aigpins land

--- a/src/sim/x_sources.rs
+++ b/src/sim/x_sources.rs
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Static enumeration of a design's X-sources for `cosim --xprop` debugging.
+//!
+//! Under `cosim --xprop` an X value originates at a known X-source — an
+//! unreset DFF Q (undefined at power-up), an SRAM read port (memory undefined
+//! until written), or a primary input the testbench leaves undriven — and
+//! propagates forward through combinational logic. Finding *why* a given
+//! signal reads X is otherwise a manual trace→guess→re-run loop.
+//!
+//! This module computes the X-source set statically from the netlist (+ the
+//! cosim config, for the undriven-input class) so the `jacquard xsources`
+//! subcommand can dump it as JSON. `netlist-graph xroots` then intersects a
+//! signal's backward cone with this set to answer "which X-sources make
+//! signal S read X?" — see issue #98 and `docs/x-debugging.md`.
+//!
+//! Everything here is plain CPU logic (no GPU/Metal feature): X-sources are a
+//! static property of the netlist + config, independent of simulation.
+
+use std::collections::{HashMap, HashSet};
+
+use netlistdb::{Direction, GeneralHierName, GeneralPinName, NetlistDB};
+use serde::Serialize;
+
+use crate::aig::{DriverType, AIG};
+use crate::testbench::TestbenchConfig;
+
+/// Schema version of the emitted manifest. Additive-only: new fields and new
+/// `XSourceKind` variants may be added without a major bump.
+pub const X_SOURCE_SCHEMA_VERSION: &str = "1.0";
+
+/// Classification of an X-source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum XSourceKind {
+    /// DFF Q with no reset/set pin connected — X at power-up and never reset,
+    /// so a persistent root unless its data cone resolves to a known value.
+    UnresetDff,
+    /// DFF Q *with* a reset/set pin — X at power-up but defined once reset
+    /// asserts. Reported so a backward query can see it, but it is usually not
+    /// the culprit when reset has been applied.
+    ResetDff,
+    /// SRAM read-data port — X until the addressed cell has been written.
+    SramRead,
+    /// Primary input the cosim config leaves undriven — no clock/reset/
+    /// constant/peripheral drives it, so it reads X every tick.
+    UndrivenInput,
+}
+
+/// One X-source: the net that carries the X, its classification, and (for
+/// DFF/SRAM) the driving cell instance.
+#[derive(Debug, Clone, Serialize)]
+pub struct XSource {
+    /// Hierarchical net name, in the same convention `--trace-signals`
+    /// resolves and `netlist-graph` matches against.
+    pub net: String,
+    pub kind: XSourceKind,
+    /// Driving cell instance name (DFF/SRAM sources only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cell: Option<String>,
+}
+
+/// The full manifest emitted by `jacquard xsources`.
+#[derive(Debug, Clone, Serialize)]
+pub struct XSourceManifest {
+    pub schema_version: String,
+    /// The netlist path the manifest was computed from.
+    pub netlist: String,
+    /// Whether undriven-input classification was performed. False when no
+    /// config was supplied (then only DFF/SRAM sources are present).
+    pub undriven_inputs_classified: bool,
+    pub x_sources: Vec<XSource>,
+}
+
+/// Pin-name leaves that mark a DFF reset or set input. Matched case-
+/// insensitively against the cell's pin port names across sky130 / gf180mcu /
+/// generic libraries.
+const RESET_SET_PIN_LEAVES: &[&str] = &[
+    "reset_b", "set_b", "resetn", "setn", "reset", "set", "clrz", "clr", "clrn",
+    "pre", "pren", "rn", "sn", "rb", "sb", "r", "s",
+];
+
+/// Parse a GPIO index from a port name like `gpio_in[5]` or `gpio_in:5`.
+///
+/// Shared by cosim's GPIO mapping (`build_gpio_mapping`) and `xsources`'
+/// driven-input set so the two stay consistent — see issue #98.
+pub fn parse_gpio_index(pin_name: &str, prefix: &str) -> Option<usize> {
+    // Try "gpio_in[N]" format.
+    if let Some(start) = pin_name.find(&format!("{}[", prefix)) {
+        let after = &pin_name[start + prefix.len() + 1..];
+        if let Some(end) = after.find(']') {
+            return after[..end].parse().ok();
+        }
+    }
+    // Try "gpio_in:N" format.
+    if let Some(start) = pin_name.find(&format!("{}:", prefix)) {
+        let after = &pin_name[start + prefix.len() + 1..];
+        let num_str: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+        return num_str.parse().ok();
+    }
+    None
+}
+
+/// Build aigpin → representative netlistdb net-id. A net's driver pin and all
+/// its load pins share the same aigpin, so any pin on the net resolves the
+/// name; we keep the first seen.
+fn build_aigpin_to_net(netlistdb: &NetlistDB, aig: &AIG) -> HashMap<usize, usize> {
+    let mut map: HashMap<usize, usize> = HashMap::new();
+    for pinid in 0..netlistdb.num_pins {
+        let aigpin = aig.pin2aigpin_iv[pinid] >> 1;
+        let netid = netlistdb.pin2net[pinid];
+        map.entry(aigpin).or_insert(netid);
+    }
+    map
+}
+
+/// Name an aigpin by its net (falling back to a synthetic label if unmapped).
+fn net_name_of(aigpin: usize, aigpin2net: &HashMap<usize, usize>, netlistdb: &NetlistDB) -> String {
+    match aigpin2net.get(&aigpin) {
+        Some(&netid) => netlistdb.netnames[netid].dbg_fmt_pin(),
+        None => format!("<aigpin {aigpin}>"),
+    }
+}
+
+/// Name a cell's primary output net (the net driven by its first output pin).
+///
+/// Used to name DFF Q and SRAM read-data sources directly from the netlist,
+/// which is robust where an AIG-pin → net lookup is not: a reset DFF's
+/// `dff.q` aigpin is the post-reset-mux internal node, not the node bound to
+/// the netlist Q pin, so it has no entry in the aigpin→net map.
+fn cell_output_net_name(netlistdb: &NetlistDB, cell_id: usize) -> Option<String> {
+    for pinid in netlistdb.cell2pin.iter_set(cell_id) {
+        if netlistdb.pindirect[pinid] == Direction::O {
+            let netid = netlistdb.pin2net[pinid];
+            return Some(netlistdb.netnames[netid].dbg_fmt_pin());
+        }
+    }
+    None
+}
+
+/// Whether a DFF cell instance has a reset or set pin wired up.
+fn dff_has_reset(netlistdb: &NetlistDB, cell_id: usize) -> bool {
+    for pinid in netlistdb.cell2pin.iter_set(cell_id) {
+        // pinnames[pinid].1 is the port leaf name (e.g. "RESET_B").
+        let leaf = netlistdb.pinnames[pinid].1.to_ascii_lowercase();
+        if RESET_SET_PIN_LEAVES.contains(&leaf.as_str()) {
+            return true;
+        }
+    }
+    false
+}
+
+/// The set of GPIO indices and explicit port names the config drives.
+///
+/// Mirrors the driver wiring `cosim` performs: clock(s), reset, constant
+/// inputs/ports, and every peripheral's pins. A primary input outside this set
+/// is left undriven and reads X under `--xprop`. Keep in sync with the cosim
+/// driving sites in `cosim_metal.rs` (reset/constant application, `build_edge_ops`,
+/// `set_flash_din`, and each `PeripheralModel`'s driven pins) — a peripheral
+/// that starts driving an input there must be reflected here, or that input is
+/// mis-reported as an undriven X-source.
+fn driven_gpios_and_ports(config: &TestbenchConfig) -> (HashSet<usize>, HashSet<String>) {
+    let mut gpios: HashSet<usize> = HashSet::new();
+    let mut ports: HashSet<String> = HashSet::new();
+
+    gpios.insert(config.reset_gpio);
+    for clk in config.effective_clocks() {
+        gpios.insert(clk.gpio);
+    }
+    for key in config.constant_inputs.keys() {
+        if let Ok(idx) = key.parse::<usize>() {
+            gpios.insert(idx);
+        }
+    }
+    for name in config.constant_ports.keys() {
+        ports.insert(name.clone());
+    }
+    if let Some(flash) = &config.flash {
+        gpios.extend([flash.clk_gpio, flash.csn_gpio]);
+        // `set_flash_din` drives 4 data lanes (d0..d0+3) for dual/quad SPI.
+        gpios.extend((0..4).map(|i| flash.d0_gpio + i));
+    }
+    for uart in config.effective_uarts() {
+        // rx is a design input the model drives; tx is a design output —
+        // harmless to include, it is not a primary input.
+        gpios.insert(uart.rx_gpio);
+        gpios.insert(uart.tx_gpio);
+    }
+    for gpio in &config.gpios {
+        gpios.extend(gpio.pins.iter().copied());
+    }
+    if let Some(jtag) = &config.jtag {
+        gpios.extend([jtag.tck_gpio, jtag.tms_gpio, jtag.tdi_gpio]);
+        if let Some(trst) = jtag.trst_gpio {
+            gpios.insert(trst);
+        }
+    }
+    (gpios, ports)
+}
+
+/// Compute the X-source manifest for a design.
+///
+/// `config` is required only for the `undriven-input` class; without it those
+/// sources are omitted and `undriven_inputs_classified` is false.
+pub fn compute_x_source_manifest(
+    netlistdb: &NetlistDB,
+    aig: &AIG,
+    config: Option<&TestbenchConfig>,
+    netlist_path: &str,
+) -> XSourceManifest {
+    let aigpin2net = build_aigpin_to_net(netlistdb, aig);
+    let mut x_sources: Vec<XSource> = Vec::new();
+
+    // DFF Q outputs (cell_id → DFF). Name via the netlist Q output pin
+    // (robust for reset DFFs, whose `dff.q` aigpin is the post-mux node).
+    for &cell_id in aig.dffs.keys() {
+        let net = cell_output_net_name(netlistdb, cell_id)
+            .unwrap_or_else(|| format!("<dff cell {cell_id}>"));
+        let kind = if dff_has_reset(netlistdb, cell_id) {
+            XSourceKind::ResetDff
+        } else {
+            XSourceKind::UnresetDff
+        };
+        x_sources.push(XSource {
+            net,
+            kind,
+            cell: Some(netlistdb.cellnames[cell_id].dbg_fmt_hier()),
+        });
+    }
+
+    // SRAM read-data ports (cell_id → RAMBlock). Slot 0 = unused, skip.
+    for (&cell_id, sram) in &aig.srams {
+        let cell = netlistdb.cellnames[cell_id].dbg_fmt_hier();
+        for &rd_pin in &sram.port_r_rd_data {
+            if rd_pin == 0 {
+                continue;
+            }
+            x_sources.push(XSource {
+                net: net_name_of(rd_pin, &aigpin2net, netlistdb),
+                kind: XSourceKind::SramRead,
+                cell: Some(cell.clone()),
+            });
+        }
+    }
+
+    // Undriven primary inputs — needs the config to know the driven set.
+    let undriven_inputs_classified = config.is_some();
+    if let Some(config) = config {
+        let (driven_gpios, driven_ports) = driven_gpios_and_ports(config);
+        let input_name_to_gpio: HashMap<String, usize> = config
+            .port_mapping
+            .as_ref()
+            .map(|pm| {
+                pm.inputs
+                    .iter()
+                    .filter_map(|(k, v)| k.parse::<usize>().ok().map(|idx| (v.clone(), idx)))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        for (aigpin, driv) in aig.drivers.iter().enumerate() {
+            let DriverType::InputPort(pinid) = driv else {
+                continue;
+            };
+            let pin_name = netlistdb.pinnames[*pinid].dbg_fmt_pin();
+            let gpio_idx = input_name_to_gpio
+                .get(&pin_name)
+                .copied()
+                .or_else(|| parse_gpio_index(&pin_name, "gpio_in"));
+            let driven = gpio_idx.is_some_and(|idx| driven_gpios.contains(&idx))
+                || driven_ports.contains(&pin_name);
+            if !driven {
+                x_sources.push(XSource {
+                    net: net_name_of(aigpin, &aigpin2net, netlistdb),
+                    kind: XSourceKind::UndrivenInput,
+                    cell: None,
+                });
+            }
+        }
+    }
+
+    XSourceManifest {
+        schema_version: X_SOURCE_SCHEMA_VERSION.to_string(),
+        netlist: netlist_path.to_string(),
+        undriven_inputs_classified,
+        x_sources,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+    use crate::sim::setup::build_netlist_and_aig;
+
+    const DEMO_NETLIST: &str =
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/xprop_cosim/xprop_demo_synth.gv");
+    const DEMO_CONFIG: &str =
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/xprop_cosim/sim_config.json");
+
+    fn demo_manifest(with_config: bool) -> XSourceManifest {
+        let (netlistdb, aig) = build_netlist_and_aig(Path::new(DEMO_NETLIST), None, &[]);
+        let config: Option<TestbenchConfig> = if with_config {
+            let f = std::fs::File::open(DEMO_CONFIG).unwrap();
+            Some(serde_json::from_reader(std::io::BufReader::new(f)).unwrap())
+        } else {
+            None
+        };
+        compute_x_source_manifest(&netlistdb, &aig, config.as_ref(), DEMO_NETLIST)
+    }
+
+    fn kind_of<'a>(m: &'a XSourceManifest, net: &str) -> Option<&'a XSourceKind> {
+        m.x_sources.iter().find(|s| s.net == net).map(|s| &s.kind)
+    }
+
+    /// Look up a source by its driving cell instance. Cell names are stable;
+    /// net names go through netlistdb canonicalisation (assign-merge), so the
+    /// counter flops' Q nets are emitted as `_10_[*]` not `unreset_count[*]`.
+    fn kind_of_cell<'a>(m: &'a XSourceManifest, cell: &str) -> Option<&'a XSourceKind> {
+        m.x_sources
+            .iter()
+            .find(|s| s.cell.as_deref() == Some(cell))
+            .map(|s| &s.kind)
+    }
+
+    #[test]
+    fn dff_sources_classified_by_reset_connection() {
+        let m = demo_manifest(false);
+        // Self-holding register with no reset → unreset (named output port).
+        assert_eq!(kind_of(&m, "q_unreset"), Some(&XSourceKind::UnresetDff));
+        // The counter flops (cells _30_/_31_/_32_) have no reset either.
+        assert_eq!(kind_of_cell(&m, "_30_"), Some(&XSourceKind::UnresetDff));
+        assert_eq!(kind_of_cell(&m, "_32_"), Some(&XSourceKind::UnresetDff));
+        // DFFSR-based regs carry a reset/set pin → reset-dff.
+        assert_eq!(kind_of(&m, "q_reset"), Some(&XSourceKind::ResetDff));
+        assert_eq!(kind_of(&m, "q_undriven_reg"), Some(&XSourceKind::ResetDff));
+    }
+
+    #[test]
+    fn dff_nets_named_not_synthetic() {
+        // Reset DFFs must resolve to real net names, not `<aigpin N>` /
+        // `<dff cell N>` fallbacks (regression for the post-reset-mux aigpin).
+        let m = demo_manifest(false);
+        for s in &m.x_sources {
+            assert!(
+                !s.net.starts_with('<'),
+                "x-source {s:?} fell back to a synthetic name"
+            );
+        }
+    }
+
+    #[test]
+    fn no_config_omits_undriven_inputs() {
+        let m = demo_manifest(false);
+        assert!(!m.undriven_inputs_classified);
+        assert!(
+            !m.x_sources.iter().any(|s| s.kind == XSourceKind::UndrivenInput),
+            "undriven inputs must not be classified without a config"
+        );
+    }
+
+    #[test]
+    fn config_classifies_undriven_but_not_driven_inputs() {
+        let m = demo_manifest(true);
+        assert!(m.undriven_inputs_classified);
+        // The genuinely-unconnected input reads X.
+        assert_eq!(kind_of(&m, "unconnected"), Some(&XSourceKind::UndrivenInput));
+        // clk / rst_n are driven (clock / reset gpio via port_mapping), so
+        // they must NOT be reported as undriven X-sources.
+        assert!(kind_of(&m, "clk").is_none());
+        assert!(kind_of(&m, "rst_n").is_none());
+    }
+
+    #[test]
+    fn manifest_is_serializable() {
+        let m = demo_manifest(true);
+        let json = serde_json::to_string(&m).unwrap();
+        assert!(json.contains("\"schema_version\":\"1.0\""));
+        assert!(json.contains("\"unreset-dff\""));
+        assert!(json.contains("\"undriven-input\""));
+    }
+}


### PR DESCRIPTION
Closes #98.

Answers **"why does signal S read X under `cosim --xprop`?"** as a static query, replacing the manual trace→guess→re-run loop. An X originates at a known X-source and propagates forward, so "what makes S read X?" = "which X-sources lie in S's backward cone?" — a pure netlist query.

Two commands:

## `jacquard xsources` (Rust, new — no GPU)

```bash
jacquard xsources <netlist> --config sim.json -o xsources.json
```

Statically enumerates the design's X-sources into a schema-versioned JSON manifest:

| kind | source |
|------|--------|
| `unreset-dff` | DFF Q with no reset/set pin |
| `reset-dff` | DFF Q with reset/set (X at power-up, defined after reset) |
| `sram-read` | SRAM read-data port |
| `undriven-input` | primary input the config leaves undriven (needs `--config`) |

DFF/SRAM sources are named via their netlist output pin (robust where a reset DFF's post-mux `dff.q` aigpin has no net binding) and tagged with the driving **cell instance**.

## `netlist-graph xroots` (Python, new)

```bash
netlist-graph xroots <netlist> <signal> --xsources xsources.json [--emit-trace t.txt]
```

Reverse-reachability-walks the signal's driver cone — **through** DFF data pins, skipping clock/reset (reusing PR #101's corrected `_is_register`) — intersects with the manifest, and reports the nearest frontier classified by kind. `reset-dff`s are traversed *through* (reset defines them) so the real persistent roots surface. `--emit-trace` writes a `--trace-signals` list so a confirming `--xprop` run is one command.

**Naming round-trip:** jacquard canonicalises assign-merged net names (`unreset_count[1]` → `_10_[1]`), so DFF/SRAM manifest entries resolve by **driving-cell instance** (stable across both parsers), not net name. A native (no-manifest) classification is the fallback.

## Design decisions (confirmed up front)

- **jacquard emits the authoritative manifest** rather than Python re-deriving the cosim driven set (which is metal-gated + GPU-position-based and can't be called from a CPU path). `parse_gpio_index` was lifted into the shared `x_sources` module so the driven-input set stays consistent with cosim's GPIO mapping.
- **Dominators deferred** — v1 reports the reachable frontier; dominator analysis over the DFF-feedback cyclic graph is a scoped follow-up.

Plan doc: `docs/plans/netlist-graph-xroots.md`.

## Implementation notes

- New feature-independent `src/sim/x_sources.rs`.
- `setup::build_netlist_and_aig` extracted as the feature-independent front half of `load_design`, reused by `cmd_xsources` (no duplication).
- Driven-input set mirrors cosim's config wiring (clock/reset/constant/flash **4-lane**/uart/gpio/jtag), cross-referenced to the cosim driving sites.

## Tests & docs

- **Rust:** 7 unit tests over the `tests/xprop_cosim/` demo fixture (DFF reset-classification, non-synthetic naming, undriven-input only with config, driven inputs excluded, serialization).
- **Python:** frontier BFS (stop-at-persistent, traverse-through-reset-dff, nearest-first, no-clock-walk), native classification, manifest cell-based resolution, `--emit-trace` round-trip, error paths.
- **Docs:** `docs/x-debugging.md` user guide (xsources → xroots → confirming `--xprop` run); CHANGELOG + CLAUDE.md pointers.

Verified end-to-end on `tests/xprop_cosim/xprop_demo_synth.gv`: `xroots _11_[3]` correctly surfaces the unreset counter flops as the frontier in both manifest and native modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)