### PR TITLE
feat(aig): model bi_24t tristate read-back as Y = OE ? A : external (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ the public contracts in `docs/release-process.md` follow stricter rules).
   produced a nil `MTLBuffer` (`new_buffer(0)`) whose `.contents()` is null;
   the SRAM data buffer is now sized to `max(1)` word (matching the X-mask
   shadow buffer), so pure-logic designs run under `jacquard cosim`.
+- **`bi_24t` bidirectional pad core read-back** (#96). The AIG modelled a
+  bidir pad's core read as `Y = PAD` always, so a design that drives a pad
+  and reads it back in the same path read the *external* PAD net instead of
+  its own drive `A` — wrong in two-state (reads the external stim/0) and
+  conservatively-X under `--xprop` (the external pad is an undriven input).
+  `AIG::from_netlistdb` now builds the tristate read-back combinationally as
+  `Y = OE ? A : external`: on `OE=1` the core reads its own drive `A`
+  (X-exact — known whenever `A` is), on `OE=0` it reads the external net.
+  `in_c`/`in_s` input pads are unchanged. See ADR 0016. Unit test:
+  `aig::gf180mcu_chip_top_tests::bi_24t_models_tristate_readback`.
 
 ## [0.1.0] - 2026-06-04
 

--- a/docs/adr/0016-selective-x-propagation.md
+++ b/docs/adr/0016-selective-x-propagation.md
@@ -70,15 +70,15 @@ Two points the original design did not address, because the static
    drive only *some* input bits each edge (clock, reset, JTAG/UART
    pins, configured constants). Every primary-input bit *not* in that
    driven set is unconnected and must be **X**, not `0`.
-2. **Bidir pad reads are conservatively X.** A `bi_24t` pad's core-read
-   is modelled `Y = PAD` (tristate not modelled), and `PAD` is an
-   undriven primary input — so bidir reads fall out of rule (1) as X,
-   which is the safe answer (false-X, never false-0). The
-   combinationally-correct read `Y = OE ? A : external` requires
-   modelling the tristate mux in the AIG; that is deferred to
-   [#96](https://github.com/gpu-eda/Jacquard/issues/96). (An earlier
-   draft of this amendment proposed a per-edge OE→input feedback with
-   one-edge latency — that was wrong; the correct read is combinational.)
+2. **Bidir pad reads.** A `bi_24t` pad's core-read was originally
+   modelled `Y = PAD` (tristate not modelled); since `PAD` is an undriven
+   primary input, bidir reads fell out of rule (1) as X — safe (false-X,
+   never false-0) but pessimistic for the `OE=1` loopback. The
+   combinationally-correct read `Y = OE ? A : external` is now modelled as
+   a mux in the AIG ([#96](https://github.com/gpu-eda/Jacquard/issues/96),
+   implemented — see the dated subsection below). (An earlier draft of this
+   amendment proposed a per-edge OE→input feedback with one-edge latency —
+   that was wrong; the correct read is combinational.)
 
 So the X-source taxonomy is now three-way: uninitialised DFF,
 uninitialised SRAM (both as before), and **undriven input pads** (which
@@ -127,3 +127,20 @@ genuinely undriven inputs — stays X. `sim` keeps inputs known (driven from
 the VCD) and pays no extra X-aware cost. End-to-end guards covering the
 DFF and undriven-input X-sources, in both sim and cosim, live in
 `tests/xprop_cosim/` (CI, fatal).
+
+### Bidir tristate read-back mux (implemented 2026-06-04)
+
+Point #2 above is now implemented (#96). `AIG::from_netlistdb`'s `bi_24t`
+branch builds `Y = OE ? A : external` combinationally in the AIG —
+`OR(AND(OE, A), AND(!OE, PAD))` via the De Morgan idiom already used by
+`wire_dff_reset_set_overlay` — instead of the conservative `Y = PAD`. The
+external arm is the same undriven PAD primary input (X under rule (1) until
+a peripheral model drives it); the `OE=1` arm reads the core's own drive
+`A`, so the loopback is **X-exact** (known whenever `A` is) and the
+two-state read returns `A`, not the external stim. This removes bidir reads
+from the "undriven input → X" subsumption for the `OE=1` case; they are now
+exact rather than conservatively-X. `in_c`/`in_s` stay `Y = PAD`. Without
+both `A` and `OE` pins the conservative `Y = PAD` still stands. Unit test:
+`aig::gf180mcu_chip_top_tests::bi_24t_models_tristate_readback` evaluates
+the full `Y` truth table. (#107's `$isunknown` x-assert work can now assert
+bidir read-backs go definite when `OE` is asserted.)

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -626,10 +626,10 @@ impl AIG {
 
             // `bi_24t` on the clock path: only PAD is the clock input.
             // The cell also exposes `A` and `OE` as Direction::I (the
-            // core-side tristate driver inputs), but those are
-            // discarded by `gf180mcu_postprocess`'s `Y = PAD`
-            // simplification, so they're not part of the clock cone.
-            // Without this guard, both PAD and A match the
+            // core-side tristate driver inputs); those feed the read-back
+            // mux `Y = OE ? A : PAD` (#96), not the clock — the clock
+            // enters through PAD only, so A/OE are not part of the clock
+            // cone. Without this guard, both PAD and A match the
             // "A | I | PAD" arm below and whichever is enumerated
             // last wins — wrong if A wins. See #75.
             let is_gf180mcu_bi_24t = matches!(variant, Some(PdkVariant::Gf180Mcu))
@@ -1661,16 +1661,15 @@ impl AIG {
         //   external `PAD`. PU / PD pull controls have no logic effect.
         // * `bi_24t`: bidirectional pad. The real cell is
         //   `Y = PAD & IE` (input side) and `PAD = A when OE=1`
-        //   (output side, tristate). Jacquard does not model tristate,
-        //   so we adopt `Y = PAD` always (IE=1 implied) for the input
-        //   direction. To make the *output* direction observable, we
-        //   also promote the bidir pad's `A` (core drive) and `OE`
-        //   (output-enable) AIG pins to primary outputs with synthetic
-        //   names `<top-port>__out` / `<top-port>__oe`. Downstream
-        //   consumers can then reconstruct the pad's external value as
-        //   `OE ? A : external_stim`. The wider tristate caveat (lack
-        //   of in-AIG tristate) is unchanged — see
-        //   docs/plans/gf180mcu-enablement.md.
+        //   (output side, tristate). We model the core read-back
+        //   combinationally as `Y = OE ? A : external` (IE=1 implied;
+        //   see the mux built below, #96): on `OE=1` the core reads its
+        //   own drive `A`, on `OE=0` it reads the external PAD net. We
+        //   also promote the pad's `A` (core drive) and `OE` (output-
+        //   enable) AIG pins to primary outputs with synthetic names
+        //   `<top-port>__out` / `<top-port>__oe`, so the output VCD can
+        //   capture the pad's drive-out direction. (`in_c`/`in_s` stay
+        //   `Y = PAD`.) See docs/plans/gf180mcu-enablement.md.
         if crate::gf180mcu_pdk::is_io_pad_cell(cell_type) {
             let output_pin_name = netlistdb.pinnames[pinid].1.as_str();
             assert_eq!(
@@ -1706,25 +1705,50 @@ impl AIG {
             // observable still has a stable, traceable label.
             if cell_type == "bi_24t" {
                 let base = self.resolve_bi_24t_observable_base(netlistdb, cellid, pad_pinid);
-                if a_pinid != usize::MAX {
-                    let a_iv = self.pin2aigpin_iv[a_pinid];
-                    if a_iv != usize::MAX {
-                        self.primary_outputs.insert(a_iv);
-                        self.extra_observable_names
-                            .entry(a_iv)
-                            .or_default()
-                            .push(format!("{}__out", base));
-                    }
+                // Resolve A (core drive) and OE (output-enable) once; `None`
+                // if the pin is absent or unmapped (malformed/partial
+                // instantiation — real netlists always wire both).
+                let a_iv = (a_pinid != usize::MAX)
+                    .then(|| self.pin2aigpin_iv[a_pinid])
+                    .filter(|&iv| iv != usize::MAX);
+                let oe_iv = (oe_pinid != usize::MAX)
+                    .then(|| self.pin2aigpin_iv[oe_pinid])
+                    .filter(|&iv| iv != usize::MAX);
+
+                // #96: model the tristate read-back combinationally as
+                // `Y = OE ? A : external`, replacing the conservative
+                // `Y = PAD` set above. When OE=1 the core reads its own
+                // drive `A` (known whenever `A` is — no false-X under
+                // --xprop, and the two-state loopback reads `A`, not the
+                // external stim); when OE=0 it reads the external PAD net
+                // (an undriven primary input → X under --xprop, or a
+                // peripheral model's drive). `pad_iv` is that external
+                // primary input; `Y` becomes a distinct mux node. Built as
+                // OR(AND(OE, A), AND(!OE, ext)) via De Morgan — same idiom
+                // as `wire_dff_reset_set_overlay`. Without both A and OE we
+                // can't form the mux, so the conservative `Y = PAD` stands.
+                if let (Some(a_iv), Some(oe_iv)) = (a_iv, oe_iv) {
+                    let drive = self.add_and_gate(oe_iv, a_iv); // OE & A
+                    let ext = self.add_and_gate(oe_iv ^ 1, pad_iv); // !OE & ext
+                    // Y = drive | ext = !(!drive & !ext)
+                    self.pin2aigpin_iv[pinid] = self.add_and_gate(drive ^ 1, ext ^ 1) ^ 1;
                 }
-                if oe_pinid != usize::MAX {
-                    let oe_iv = self.pin2aigpin_iv[oe_pinid];
-                    if oe_iv != usize::MAX {
-                        self.primary_outputs.insert(oe_iv);
-                        self.extra_observable_names
-                            .entry(oe_iv)
-                            .or_default()
-                            .push(format!("{}__oe", base));
-                    }
+
+                // Surface A/OE as named primary outputs so the output VCD
+                // can capture the pad's drive-out direction.
+                if let Some(a_iv) = a_iv {
+                    self.primary_outputs.insert(a_iv);
+                    self.extra_observable_names
+                        .entry(a_iv)
+                        .or_default()
+                        .push(format!("{}__out", base));
+                }
+                if let Some(oe_iv) = oe_iv {
+                    self.primary_outputs.insert(oe_iv);
+                    self.extra_observable_names
+                        .entry(oe_iv)
+                        .or_default()
+                        .push(format!("{}__oe", base));
                 }
             }
             return;
@@ -4421,6 +4445,103 @@ endmodule
                 names,
                 aigpin
             );
+        }
+    }
+
+    /// `bi_24t` models the core read-back combinationally as
+    /// `Y = OE ? A : external` (#96), not the old conservative `Y = PAD`.
+    /// With `A`, `OE`, and the external PAD net as three distinct primary
+    /// inputs, the `Y` cone must evaluate to that mux across all 8 input
+    /// combinations — proving `OE=1` reads the core drive `A` (no false-X /
+    /// no two-state loopback bug) and `OE=0` reads the external stim.
+    #[test]
+    fn bi_24t_models_tristate_readback() {
+        const VERILOG: &str = r#"
+module top(a, oe, p, y);
+  input a;
+  input oe;
+  inout p;
+  output y;
+  gf180mcu_fd_io__bi_24t bidir_pad (
+      .PAD(p), .A(a), .OE(oe),
+      .IE(1'b1), .CS(1'b0), .SL(1'b0), .PU(1'b0), .PD(1'b0),
+      .Y(y)
+  );
+endmodule
+"#;
+        let nl = netlistdb::NetlistDB::from_sverilog_source(
+            VERILOG,
+            Some("top"),
+            &GF180MCULeafPins,
+        )
+        .expect("netlist parse");
+        let aig = AIG::from_netlistdb(&nl);
+
+        // Find the bi_24t's A / OE / PAD inputs and Y output by pin name.
+        let (mut a_pinid, mut oe_pinid, mut pad_pinid, mut y_pinid) =
+            (usize::MAX, usize::MAX, usize::MAX, usize::MAX);
+        for pin in 0..nl.num_pins {
+            match nl.pinnames[pin].1.as_str() {
+                "A" => a_pinid = pin,
+                "OE" => oe_pinid = pin,
+                "PAD" => pad_pinid = pin,
+                "Y" => y_pinid = pin,
+                _ => {}
+            }
+        }
+        assert!(
+            a_pinid != usize::MAX
+                && oe_pinid != usize::MAX
+                && pad_pinid != usize::MAX
+                && y_pinid != usize::MAX,
+            "bi_24t pins not all found"
+        );
+
+        // Bare aigpins of the three primary inputs, and the iv `Y` resolves to.
+        let a_pin = aig.pin2aigpin_iv[a_pinid] >> 1;
+        let oe_pin = aig.pin2aigpin_iv[oe_pinid] >> 1;
+        let pad_pin = aig.pin2aigpin_iv[pad_pinid] >> 1;
+        let y_iv = aig.pin2aigpin_iv[y_pinid];
+
+        // The specific bug this fixes: `Y` must be a distinct mux node, not
+        // aliased to the external PAD primary input. (The truth-table loop
+        // below is the full semantic proof; this is the explicit bug marker.)
+        assert_ne!(
+            y_iv >> 1,
+            pad_pin,
+            "Y is still aliased to the external PAD input (mux not built)"
+        );
+
+        // Recursive AIG evaluator: `env` maps each named primary input's bare
+        // aigpin to its assigned value; everything else folds through Tie0 /
+        // AndGate (the only driver kinds in this combinational cone).
+        fn eval(aig: &AIG, iv: usize, env: &[(usize, bool)]) -> bool {
+            let pin = iv >> 1;
+            let inv = (iv & 1) == 1;
+            let v = if let Some(&(_, val)) = env.iter().find(|&&(p, _)| p == pin) {
+                val
+            } else {
+                match aig.drivers[pin] {
+                    DriverType::Tie0 => false,
+                    DriverType::AndGate(x, z) => eval(aig, x, env) && eval(aig, z, env),
+                    ref other => panic!("unexpected leaf driver {other:?} for aigpin {pin}"),
+                }
+            };
+            v ^ inv
+        }
+
+        for a in [false, true] {
+            for oe in [false, true] {
+                for pad in [false, true] {
+                    let env = [(a_pin, a), (oe_pin, oe), (pad_pin, pad)];
+                    let got = eval(&aig, y_iv, &env);
+                    let want = if oe { a } else { pad };
+                    assert_eq!(
+                        got, want,
+                        "Y mismatch at A={a} OE={oe} PAD={pad}: got {got}, want OE?A:PAD={want}"
+                    );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Implements **#96** — model a `bi_24t` bidirectional pad's core read-back as the tristate mux `Y = OE ? A : external`, instead of the conservative `Y = PAD`.

### Problem

`AIG::from_netlistdb` modelled a bidir pad's core read as `Y = PAD` always. A design that drives a pad and reads it back in the same path therefore read the **external** PAD net, not its own drive `A`:

- **two-state:** reads the external stim / 0 (a real loopback bug).
- **`--xprop`:** reads **X** — the external pad is an undriven primary input, so a legitimate `OE=1` loopback reads false-X (safe but pessimistic).

### Fix

Build the read-back combinationally in the AIG:

```
Y = OE ? A : external   ==   OR(AND(OE, A), AND(!OE, PAD))
```

constructed via the De Morgan idiom already used by `wire_dff_reset_set_overlay`. On `OE=1` the core reads its own drive `A` (**X-exact** — known whenever `A` is); on `OE=0` it reads the external PAD net (undriven → X under `--xprop`, or a peripheral model's drive).

Doing this **in the AIG** (as `AndGate` nodes) is the right altitude: X-prop, two-state sim, partitioning, `flatten`, and all three GPU backends (CUDA/HIP/Metal) get it for free — no sim-loop special case. (ADR 0016 explicitly rejected an earlier per-edge `OE→input` feedback idea because it introduced one-cycle latency that the real cell doesn't have; the correct read is combinational.)

- Scoped to `bi_24t`; `in_c`/`in_s` input pads stay `Y = PAD`.
- The `A`/`OE` → `__out`/`__oe` observable promotion (output-direction VCD capture) is unchanged.
- Falls back to `Y = PAD` if `A` or `OE` pins are absent (malformed/partial instantiation; real netlists always wire both).

## Testing

- New unit test `aig::gf180mcu_chip_top_tests::bi_24t_models_tristate_readback` builds an AIG with `A`, `OE`, and the external PAD net as three distinct primary inputs, then evaluates the full `Y` truth table (8 combinations) against `OE ? A : PAD`. Also asserts `Y` is a distinct mux node, not aliased to the PAD input (the specific bug).
- Existing `bi_24t` tests still pass (with `OE` tied 0, the mux const-folds to `Y = PAD`, so input-mode behaviour is unchanged).
- Full lib suite: 293 passed.
- `/simplify` run over the diff.

## Docs

- ADR 0016 bullet #2 + new dated subsection: bidir read-back is now exact for `OE=1` rather than conservatively-X.
- CHANGELOG `[Unreleased]` → Fixed.
- Corrected the now-stale clock-path comment that said A/OE are "discarded by the `Y = PAD` simplification".

## Relation to other work

- Removes the bidir-read pessimism noted in #95 (now closed) as a deferred follow-up.
- #107's `$isunknown` x-assert work can now assert bidir read-backs go definite when `OE` is asserted.

Closes #96.
