### PR TITLE
ci: cross-backend equivalence test (CUDA/HIP/Metal output VCDs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,16 @@ jobs:
             exit 1
           fi
 
+      # Upload Metal's dff_test outputs so the backend-equivalence job can
+      # diff them against the CUDA/HIP outputs (which already upload theirs).
+      - name: Upload Metal artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: metal-outputs
+          path: |
+            tests/timing_test/ci_output.vcd
+            tests/timing_test/ci_xprop_output.vcd
+
       # End-to-end X-propagation regression guard (#95). Uses the xprop_demo
       # design: an UNRESET toggle counter (q_unreset, must stay X forever —
       # X+1=X) and a reset flop (q_reset, must resolve to known after reset).
@@ -1512,3 +1522,47 @@ jobs:
         with:
           name: mcu-soc-comparison-results
           path: mcu_comparison.txt
+
+  # Cross-backend equivalence guard. The CUDA, HIP, and Metal kernels are
+  # the same boolean-processor algorithm; a `jacquard sim` of one design
+  # must yield a byte-identical output VCD on all three. Each backend job
+  # runs the dff_test design and uploads its output; this job diffs them.
+  # A mismatch means a kernel has drifted between backends — the failure
+  # mode hand-maintained twin kernels (kernel_v1_impl.cuh vs kernel_v1.metal)
+  # invite, and the safety net that makes a future single-source compute
+  # kernel safe to attempt.
+  backend-equivalence:
+    name: Backend Equivalence (CUDA/HIP/Metal)
+    runs-on: ubuntu-latest
+    needs: [cuda, hip-on-nvidia, metal]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Download CUDA outputs
+        uses: actions/download-artifact@v7
+        with:
+          name: cuda-outputs
+          path: out/cuda
+      - name: Download HIP outputs
+        uses: actions/download-artifact@v7
+        with:
+          name: hip-outputs
+          path: out/hip
+      - name: Download Metal outputs
+        uses: actions/download-artifact@v7
+        with:
+          name: metal-outputs
+          path: out/metal
+      - name: Compare functional output VCDs
+        run: |
+          python3 scripts/ci/compare_backend_vcds.py --label functional \
+            out/cuda/ci_cuda_output.vcd \
+            out/hip/ci_hip_output.vcd \
+            out/metal/ci_output.vcd
+      - name: Compare X-propagation output VCDs
+        run: |
+          python3 scripts/ci/compare_backend_vcds.py --label xprop \
+            out/cuda/ci_cuda_xprop_output.vcd \
+            out/hip/ci_hip_xprop_output.vcd \
+            out/metal/ci_xprop_output.vcd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1554,15 +1554,23 @@ jobs:
         with:
           name: metal-outputs
           path: out/metal
+      # Locate each VCD by basename: artifacts nest differently depending on
+      # whether the producing job bundled root-level log files (which shifts
+      # upload-artifact's common-ancestor to the repo root, keeping the
+      # tests/timing_test/ prefix). `find` makes the comparison independent
+      # of that. `set -e` + the script's own missing-input check catch a
+      # genuinely absent file.
       - name: Compare functional output VCDs
         run: |
-          python3 scripts/ci/compare_backend_vcds.py --label functional \
-            out/cuda/ci_cuda_output.vcd \
-            out/hip/ci_hip_output.vcd \
-            out/metal/ci_output.vcd
+          set -euo pipefail
+          cuda=$(find out/cuda -name ci_cuda_output.vcd | head -1)
+          hip=$(find out/hip -name ci_hip_output.vcd | head -1)
+          metal=$(find out/metal -name ci_output.vcd | head -1)
+          python3 scripts/ci/compare_backend_vcds.py --label functional "$cuda" "$hip" "$metal"
       - name: Compare X-propagation output VCDs
         run: |
-          python3 scripts/ci/compare_backend_vcds.py --label xprop \
-            out/cuda/ci_cuda_xprop_output.vcd \
-            out/hip/ci_hip_xprop_output.vcd \
-            out/metal/ci_xprop_output.vcd
+          set -euo pipefail
+          cuda=$(find out/cuda -name ci_cuda_xprop_output.vcd | head -1)
+          hip=$(find out/hip -name ci_hip_xprop_output.vcd | head -1)
+          metal=$(find out/metal -name ci_xprop_output.vcd | head -1)
+          python3 scripts/ci/compare_backend_vcds.py --label xprop "$cuda" "$hip" "$metal"

--- a/scripts/ci/compare_backend_vcds.py
+++ b/scripts/ci/compare_backend_vcds.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Assert that GPU backends produce byte-identical simulation output.
+
+The CUDA, HIP, and Metal kernels implement the *same* boolean-processor
+algorithm (`simulate_block_v1`); the output VCD is written by shared Rust
+code, so a `jacquard sim` of one design+stimulus must yield an identical VCD
+on every backend. This is the cross-backend equivalence guard: if the three
+diverge, a kernel ported to one backend has drifted from the others — the
+exact failure mode that hand-maintained twin kernels invite.
+
+Volatile header lines (`$date`, `$version`, `$comment` blocks) are stripped
+before comparison; everything else (timescale, `$var` declarations, scope,
+and every value-change line) must match exactly.
+
+Usage:
+    compare_backend_vcds.py --label <name> <vcd> <vcd> [<vcd> ...]
+
+Exit code 0 if all inputs are identical after normalisation, 1 otherwise
+(with a unified diff of the first mismatch on stderr).
+"""
+import argparse
+import difflib
+import sys
+from pathlib import Path
+
+# VCD declaration blocks whose contents are run-dependent (wall-clock date,
+# tool version string, free-form comments) and so must be ignored.
+VOLATILE_BLOCKS = ("$date", "$version", "$comment")
+
+
+def normalise(path: Path) -> list[str]:
+    """Return the VCD's lines with volatile `$date/$version/$comment` blocks
+    removed. A block runs from its opening keyword to the next `$end`."""
+    lines = path.read_text().splitlines()
+    out: list[str] = []
+    skip_until_end = False
+    for ln in lines:
+        stripped = ln.strip()
+        if skip_until_end:
+            if stripped.endswith("$end"):
+                skip_until_end = False
+            continue
+        if stripped.startswith(VOLATILE_BLOCKS):
+            # Single-line form (`$version ... $end`) or multi-line.
+            if not stripped.endswith("$end"):
+                skip_until_end = True
+            continue
+        out.append(ln)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", required=True, help="comparison name for logs")
+    ap.add_argument("vcds", nargs="+", help="VCD files to compare (>=2)")
+    args = ap.parse_args()
+
+    if len(args.vcds) < 2:
+        print("need at least two VCDs to compare", file=sys.stderr)
+        return 2
+
+    paths = [Path(p) for p in args.vcds]
+    missing = [p for p in paths if not p.is_file()]
+    if missing:
+        print(f"FAIL [{args.label}]: missing inputs: {missing}", file=sys.stderr)
+        return 1
+
+    ref_path, *rest = paths
+    ref = normalise(ref_path)
+    ok = True
+    for other_path in rest:
+        other = normalise(other_path)
+        if other != ref:
+            ok = False
+            print(
+                f"FAIL [{args.label}]: {other_path} differs from {ref_path}",
+                file=sys.stderr,
+            )
+            diff = difflib.unified_diff(
+                ref, other,
+                fromfile=str(ref_path), tofile=str(other_path),
+                lineterm="",
+            )
+            # Cap the dump so a wholesale divergence doesn't flood the log.
+            for i, line in enumerate(diff):
+                if i >= 60:
+                    print("  ... (diff truncated)", file=sys.stderr)
+                    break
+                print(line, file=sys.stderr)
+
+    if ok:
+        print(
+            f"PASS [{args.label}]: {len(paths)} backends produce identical VCDs "
+            f"({ref_path.name} == " + ", ".join(p.name for p in rest) + ")"
+        )
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The simplest, lowest-risk first step in aligning the GPU backends: a **cross-backend equivalence guard**.

The CUDA, HIP, and Metal kernels implement the *same* boolean-processor algorithm (`simulate_block_v1` — identical in `kernel_v1_impl.cuh` and `kernel_v1.metal` modulo primitive spelling), and the output VCD is written by shared Rust code. So a `jacquard sim` of one design+stimulus must yield a **byte-identical output VCD on every backend**. Nothing verified that — each backend job did its own weak inline check (CUDA/HIP: `grep -q 'x'`; Metal: first-20-transitions vs the input VCD).

## What this adds

- A `backend-equivalence` job (`needs: [cuda, hip-on-nvidia, metal]`, runs on cheap `ubuntu-latest`) that downloads the `dff_test` outputs the three jobs already produce and diffs them. Metal now uploads its output too (CUDA/HIP already did).
- `scripts/ci/compare_backend_vcds.py` — normalises volatile `$date`/`$version`/`$comment` header blocks, then asserts the rest (timescale, `$var` decls, every value-change line) is identical across all three. Covers both the **functional** and **`--xprop`** outputs.

All three already run the same design with `NUM_BLOCKS=1`, so a mismatch is a genuine kernel-divergence signal, not an ordering artifact.

## Why this first (vs a cross-shader rewrite)

The kernels are already ~95% converged; the real risk is silent drift between the hand-maintained copies. This guard:
- catches that drift today, on every PR, now that the T4 + Metal runners are both live;
- is **purely additive** — touches no kernel code;
- is the **prerequisite that makes a future single-source compute kernel safe to attempt** (you can refactor the kernel behind a macro prelude and trust this test to prove behaviour is unchanged).

Cross-shader tools (Slang/Ferrox) were evaluated and rejected for now: neither targets HIP/ROCm, neither exposes CUDA cooperative `grid.sync`, and both would rewrite the most-tuned working code — i.e. they don't close the actual gaps. (See discussion in the linked thread.)

## Validation

`compare_backend_vcds.py` unit-smoke-tested locally (passes on identical-modulo-header, fails with a unified diff on a real value difference); `actionlint` clean (remaining findings are pre-existing shellcheck); `ruff` clean. The job's first real run on this PR is itself the proof that the three backends currently agree.
