### PR TITLE
docs(cosim): plan backend portability — CPU + CUDA/HIP (#105)

### DIFF
--- a/docs/adr/0017-cosim-execution-model.md
+++ b/docs/adr/0017-cosim-execution-model.md
@@ -141,6 +141,84 @@ needed — all drains happen after `waitUntilCompleted`.
   designs it can reach thousands of entries, but each buffer is
   small (tens of bytes).
 
+## Amendment 2026-06-05: backend portability (#105)
+
+The execution model above is **Metal-only** — `run_cosim` lives in
+`cosim_metal.rs` (gated `#[cfg(feature = "metal")]`) and `cmd_cosim`
+hard-errors on other backends. This amendment records the decision to make
+cosim **backend-portable** (CPU reference + CUDA/HIP), tracked as
+[#105](https://github.com/gpu-eda/Jacquard/issues/105). It does **not**
+change the batch/scheduler model above; it factors *where* each part runs.
+
+### The seam: backend-agnostic orchestration vs a `CosimBackend` trait
+
+`run_cosim` is split along a seam that already exists in spirit:
+
+- **Above the seam (backend-agnostic, moves to a shared `cosim` driver):**
+  the `MultiClockScheduler`, `build_edge_ops`, batch-size logic, peripheral
+  models (`PeripheralModel::step_edge` → `ModelOverrides`), the input
+  dispatcher, reset/constant init, VCD writing, and event/ring-buffer
+  draining. None of this is GPU-specific; it operates on `&[u32]` state and
+  `Vec<BitOp>` edge ops.
+- **Below the seam (a `CosimBackend` trait, one impl per backend):** owning
+  the `[2 × state_size]` state buffer and performing, per edge —
+  `state_prep` (output→input copy + apply BitOps + clear driven X-mask),
+  the design step (`simulate_v1_stage` / the boolean processor), and
+  exposing `input_state()` / `output_state()` as `&[u32]`/`&mut [u32]` to
+  the orchestration. `MetalSimulator` becomes one implementation.
+
+Two structural facts make this tractable rather than a rewrite:
+
+1. **cosim is inherently per-edge dispatch on every backend.** Inputs
+   depend on outputs each cycle, so the reactive loop dispatches the design
+   one edge at a time — it does **not** use the single cooperative-launch +
+   `grid.sync` model that the `sim` command uses on CUDA/HIP. CUDA/HIP cosim
+   therefore dispatches the design kernel per-edge exactly as Metal already
+   does, sidestepping the one CUDA feature (`cooperative_groups` grid sync)
+   that is hardest to port. cosim's structure is *closer* across backends
+   than `sim`'s.
+2. **The peripheral protocol models are already backend-agnostic CPU Rust**
+   (`src/sim/models/*.rs` implement `PeripheralModel`, no GPU deps). The
+   on-GPU IO kernels (`gpu_flash_model_step`, `gpu_io_step`,
+   `gpu_apply_flash_din`) are a Metal **performance optimization** that
+   eliminates per-tick CPU↔GPU round-trips — they are *not* required for
+   correctness. A new backend can run peripherals on the CPU and only
+   dispatch the design step on the GPU; porting the IO kernels is a later
+   optimization, not a prerequisite.
+
+### Two implementations
+
+- **Path A — `CpuBackend` (reference, no GPU).** Design step =
+  `cpu_reference::simulate_block_v1` per block (the existing
+  `--check-with-cpu` loop is already a prototype of exactly this). Not for
+  throughput (won't beat Verilator); its value is a portable reference, an
+  oracle, contributor access on non-Apple hardware, and — decisively —
+  **running cosim regression tests on free Linux CI** (today they are
+  Metal-only). Builds and validates the seam.
+- **Path B — `Cuda`/`HipBackend` (the Linux perf story).** Design step =
+  the existing CUDA/HIP `simulate` kernel dispatched per-edge, reusing
+  Path A's seam and the CPU peripheral models. Was "runner-gated"; the
+  GitHub-hosted T4 runner (`tesla4-runner`) now makes it CI-testable.
+
+### Consequences
+
+- The `sim` cooperative-launch model and the cosim per-edge model remain
+  distinct *per backend*; this amendment unifies the cosim *driver*, not the
+  two execution models.
+- `ScheduleBuffers` currently stores `metal::Buffer` pairs and
+  `update_model_driven_in_ops` writes into Metal shared memory directly;
+  these must become backend-neutral (`Vec<BitOp>`) with the backend
+  materializing its native form. This is the main refactor friction.
+- `cosim_metal.rs` carries private copies of `simulate_block_v1`; these
+  consolidate onto `cpu_reference` as part of the seam extraction.
+- Correctness is guarded by extending the cross-backend equivalence test
+  ([#113](https://github.com/gpu-eda/Jacquard/pull/113), today sim-only) to
+  cosim once a second backend exists — a CPU/Metal output-VCD diff on the
+  same reactive design.
+
+Full phasing, the trait signature, and file-by-file steps are in
+[`docs/plans/cosim-backend-portability.md`](../plans/cosim-backend-portability.md).
+
 ## Cross-references
 
 - ADR 0012 — CDC jitter injection (uses the scheduler's edge
@@ -149,3 +227,5 @@ needed — all drains happen after `waitUntilCompleted`.
   model patterns and ring buffers).
 - [`docs/plans/multi-clock-and-stimulus-architecture.md`](../plans/multi-clock-and-stimulus-architecture.md)
   — design-space doc for the multi-clock scheduler.
+- [`docs/plans/cosim-backend-portability.md`](../plans/cosim-backend-portability.md)
+  — implementation plan for backend portability (#105).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -29,6 +29,7 @@ persistent plans here.
 | [WS3: delete SDF parser + interim runtime hook](ws3-delete-sdf-parser.md) | Implemented — historical record (see ADR 0006 Amendment) |
 | [WS3 follow-up: re-add cosim `--sdf` via `opensta-to-ir`](ws3-cosim-sdf-followup.md) | Deferred |
 | [Multi-clock and stimulus architecture](multi-clock-and-stimulus-architecture.md) | Exploratory — demand-driven |
+| [Cosim backend portability](cosim-backend-portability.md) | Active — design captured (#105); see ADR 0017 amendment |
 
 ## Reading order for new contributors
 

--- a/docs/plans/cosim-backend-portability.md
+++ b/docs/plans/cosim-backend-portability.md
@@ -1,0 +1,164 @@
+# Cosim Backend Portability
+
+**Status:** Active — design captured, not yet scheduled.
+**Issue:** [#105](https://github.com/gpu-eda/Jacquard/issues/105).
+**Architecture:** [ADR 0017 — Cosim execution model](../adr/0017-cosim-execution-model.md)
+(see the *Amendment 2026-06-05: backend portability* section).
+
+cosim is Metal-only today: `run_cosim` lives in `src/sim/cosim_metal.rs`
+(gated `#[cfg(feature = "metal")]`) and `cmd_cosim` hard-errors on other
+backends. This plan factors the driver into a backend-agnostic orchestration
+layer plus a `CosimBackend` trait, then adds a CPU implementation (Path A)
+and a CUDA/HIP implementation (Path B).
+
+## Goal & non-goals
+
+**Goal:** `jacquard cosim` runs on CPU (reference, no GPU) and on CUDA/HIP,
+not just Metal — reusing the existing scheduler, peripheral models, and VCD
+machinery unchanged.
+
+**Non-goals:**
+- Changing the batch/scheduler execution model of ADR 0017 (untouched).
+- Matching Metal cosim throughput on the CPU path (it's a reference/oracle).
+- Porting the on-GPU IO-model kernels to CUDA/HIP up front — peripherals run
+  on the CPU first; GPU IO models are a later optimization (Phase 3).
+
+## What's already portable (no work needed)
+
+- **Peripheral protocol models** — `src/sim/models/*.rs` (gpio, uart, i2c,
+  spi, jtag, bus_trace) are pure CPU Rust implementing `PeripheralModel`
+  (`models/mod.rs:56`). Reusable as-is across all backends.
+- **CPU design step** — `cpu_reference::simulate_block_v1` is the exact CPU
+  equivalent of one `simulate_v1_stage` threadgroup. The existing
+  `run_cosim` `--check-with-cpu` path (`cosim_metal.rs:4282–4504`) already
+  runs `state_prep` + `apply_flash_din` + `simulate_block_v1` per block on
+  the CPU — a working prototype of the Path A backend step.
+- **The scheduler / batching / VCD / event drain** logic is GPU-agnostic in
+  intent; it operates on `&[u32]` state and `Vec<BitOp>` ops.
+
+## The seam
+
+```rust
+/// Per-edge design execution + state ownership. One impl per backend.
+/// The orchestration layer (scheduler, models, VCD, drains) calls this.
+trait CosimBackend {
+    /// output→input copy + apply scheduled BitOps + clear driven X-mask.
+    fn state_prep(&mut self, ops: &[BitOp], xmask_state_offset: u32);
+    /// Run the design for one edge (all major stages).
+    fn simulate_edge(&mut self);
+    /// Read-only view of the design output slot (VCD, model step_edge, drains).
+    fn output_state(&self) -> &[u32];
+    /// Mutable input slot (reset/constant init, flash MISO injection).
+    fn input_state_mut(&mut self) -> &mut [u32];
+    // Phase 3 (optional, perf): on-GPU peripheral hooks.
+    //   fn apply_flash_din(&mut self, ...); fn flash_model_step(&mut self, ...);
+    //   fn io_step(&mut self) -> IoEvents;
+}
+```
+
+`MetalSimulator` becomes the `MetalBackend` impl; `CpuBackend` and
+`Cuda`/`HipBackend` are added. The orchestration keeps peripherals on the
+CPU (calling `PeripheralModel::step_edge` → `ModelOverrides` → BitOps) and
+only delegates the design step + state ownership to the backend.
+
+### Why this is tractable
+
+cosim is **per-edge dispatch on every backend** (reactive inputs), so the
+CUDA/HIP path dispatches the design kernel one edge at a time exactly as
+Metal does — it does **not** need the `sim` command's cooperative
+single-launch + `grid.sync`, the one CUDA feature hardest to port. See ADR
+0017 amendment, fact (1).
+
+## Phases
+
+### Phase 0 — Extract the seam (Metal-only refactor, zero behaviour change)
+
+Refactor `cosim_metal.rs` into `cosim/mod.rs` (orchestration) + a
+`CosimBackend` trait + `cosim/metal.rs` (`MetalBackend`). No new backend
+yet — this is a pure restructuring that must leave Metal cosim
+bit-identical.
+
+- Make `ScheduleBuffers.edge_buffers` backend-neutral: store
+  `Vec<(StatePrepParams, Vec<BitOp>)>`; the backend materialises native
+  buffers (Metal buffers today). Currently it holds `metal::Buffer` pairs
+  (`cosim_metal.rs:3072`).
+- `update_model_driven_in_ops` / `update_reset_in_ops` write into
+  `Vec<BitOp>`, not Metal shared memory (`cosim_metal.rs:3643–3678`).
+- Consolidate the private `simulate_block_v1` copies in `cosim_metal.rs`
+  (`:2130–2413`) onto `cpu_reference`.
+- Move the ~20 ad-hoc `simulator.device.new_buffer(...)` allocations in
+  `run_cosim` into `MetalBackend`.
+
+**Entry:** #113 (sim cross-backend equivalence) merged.
+**Exit:** Metal cosim CI (`dual_uart`, `apb_trace`, JTAG-minimal,
+`xprop_cosim`) all green, byte-identical output VCDs vs pre-refactor.
+
+### Phase 1 — Path A: `CpuBackend` + Linux cosim CI
+
+- Implement `CpuBackend`: `state_prep` (output→input copy + BitOps +
+  X-mask clear — the loop at `cosim_metal.rs:4286–4301`), `simulate_edge`
+  via `cpu_reference::simulate_block_v1` per block, plain `Vec<u32>` state.
+- Peripherals stay on CPU (already are). The GPU flash kernel's FSM is a
+  simple SPI state machine; reimplement it as CPU Rust (or reuse the
+  existing `CppSpiFlash` FFI at `cosim_metal.rs:2493`) so flash cosim works
+  without Metal.
+- Wire `cmd_cosim` to select `CpuBackend` when `--features metal` is absent
+  (or via an explicit `--backend cpu`), removing the hard-error.
+- **Move the cosim regression tests to a Linux CI job** — they're
+  Metal-only today; CPU cosim lets `xprop_cosim` (cosim mode), `dual_uart`,
+  and `apb_trace` run on free `ubuntu-latest`.
+
+**Entry:** Phase 0 merged.
+**Exit:** `cargo run --bin jacquard -- cosim …` (no GPU features) runs the
+existing cosim fixtures on Linux CI and passes their checkers.
+
+### Phase 2 — Path B: `Cuda`/`HipBackend` (design on GPU, peripherals on CPU)
+
+- Implement the backend over the existing CUDA/HIP `simulate` kernel,
+  dispatched **per-edge** (not the cooperative single launch). State lives
+  in device memory exposed to the orchestration via host copy / pinned /
+  unified memory for the per-edge `output_state()` read.
+- Peripherals remain on the CPU (per-edge CPU↔GPU sync). Accept the
+  round-trip cost for the first cut; it's still the real Linux GPU path.
+- Gate the GPU-backed cosim CI on `tesla4-runner` (now available).
+
+**Entry:** Phase 1 merged (seam + CPU reference proven).
+**Exit:** `cosim --features cuda` runs a fixture on the T4 and its output
+VCD matches the CPU/Metal backends (cross-backend equivalence, below).
+
+### Phase 3 — (Deferred, perf) port on-GPU IO models to CUDA/HIP
+
+Port `gpu_apply_flash_din` / `gpu_flash_model_step` / `gpu_io_step` to
+CUDA/HIP to eliminate the per-edge CPU↔GPU round-trip from Phase 2. Pure
+throughput optimization; correctness already established by Phase 2.
+
+## Testing strategy
+
+- **Reuse existing fixtures**: `tests/xprop_cosim/` (cosim mode),
+  `tests/dual_uart/`, `tests/apb_trace/`, `tests/jtag_minimal/`.
+- **Cross-backend equivalence**: extend the #113 harness
+  (`scripts/ci/compare_backend_vcds.py`) to a reactive design — run the same
+  cosim on CPU and Metal (and CUDA in Phase 2) and assert byte-identical
+  output VCDs. This is the correctness backstop for the whole effort.
+- **Linux CI**: Phase 1 is the unlock — cosim regression coverage on free
+  `ubuntu-latest` instead of the single self-hosted Metal runner.
+
+## Risks
+
+- **Refactor drift (Phase 0):** the bit-identical-Metal exit criterion is
+  load-bearing; the equivalence test + existing checkers guard it.
+- **Flash FSM reimplementation (Phase 1):** the GPU flash kernel and the
+  `CppSpiFlash` FFI must agree. Prefer reusing `CppSpiFlash` to avoid a
+  third copy of the SPI FSM.
+- **Per-edge device-memory read (Phase 2):** reading `output_state` every
+  edge across the PCIe boundary is slow; that's the motivation for Phase 3,
+  not a correctness risk.
+
+## Sequencing relative to other backend-alignment work
+
+- Independent of [#104](https://github.com/gpu-eda/Jacquard/issues/104)
+  (CUDA/HIP `sim` timing) — both bring CUDA/HIP toward Metal parity and are
+  now T4-testable, but touch different code paths.
+- Complements the `sim` cross-backend equivalence test (#113) and the
+  proposed single-source `simulate_block_v1` macro prelude — those harden
+  the `sim` compute kernel; this plan adds the cosim *driver*.


### PR DESCRIPTION
## Summary

Plans **#105** (make cosim backend-portable; it's Metal-only today). Docs-only — no code changes.

- **ADR 0017** amended with the *backend-portability decision*: split `run_cosim` into a backend-agnostic **orchestration layer** (scheduler, peripheral models, VCD, ring drains) + a **`CosimBackend` trait** (state ownership + per-edge design step). `MetalSimulator` becomes one impl; CPU and CUDA/HIP join.
- **New plan** `docs/plans/cosim-backend-portability.md`: Phase 0 seam extraction (Metal-only, bit-identical) → Phase 1 `CpuBackend` + Linux cosim CI → Phase 2 CUDA/HIP (now T4-testable) → Phase 3 (deferred) on-GPU IO models.

## Two insights that make this tractable (not a rewrite)

1. **cosim is per-edge dispatch on every backend** (reactive inputs), so CUDA/HIP cosim dispatches the design kernel one edge at a time exactly as Metal does — it does **not** need the `sim` command's cooperative single-launch + `grid.sync`, the one CUDA feature hardest to port.
2. **Peripheral protocol models are already backend-agnostic CPU Rust** (`src/sim/models/`). The on-GPU IO kernels (flash/UART) are a Metal *perf optimization*, not a correctness prerequisite — a new backend runs peripherals on CPU first.

Plus: `cpu_reference::simulate_block_v1` is the CPU design stepper, and the existing `--check-with-cpu` path is already a working prototype of the Path A backend step.

## Grounding

The seam and friction points (ScheduleBuffers being Metal-typed, `update_model_driven_in_ops` writing into Metal memory, the duplicated `simulate_block_v1` copies) are mapped against the real code with file:line refs in the plan. Correctness backstop = extending the #113 cross-backend equivalence test to a reactive cosim design once a second backend exists.

Closes nothing — this is the design artifact for #105; implementation lands in the phased PRs.