### PR TITLE
refactor(cosim): consolidate CPU simulate_block_v1 onto cpu_reference (#105)

### DIFF
--- a/src/sim/cosim_metal.rs
+++ b/src/sim/cosim_metal.rs
@@ -2125,15 +2125,20 @@ fn compare_aig_vs_flattened(
     }
 }
 
-/// CPU prototype partition executor.
-/// Used for --check-with-cpu verification.
+/// CPU partition executor for `--check-with-cpu` verification. Delegates to
+/// the canonical implementation in `cpu_reference` — these were a drifting
+/// duplicate of it; consolidated as the first step of the cosim
+/// backend-portability seam extraction (#105, ADR 0017). The compute is
+/// identical; only the diagnostic-print detail differs.
 fn simulate_block_v1(
     script: &[u32],
     input_state: &[u32],
     output_state: &mut [u32],
     sram_data: &mut [u32],
 ) {
-    simulate_block_v1_inner(script, input_state, output_state, sram_data, false);
+    crate::sim::cpu_reference::simulate_block_v1(
+        script, input_state, output_state, sram_data, false,
+    );
 }
 
 fn simulate_block_v1_diag(
@@ -2142,264 +2147,9 @@ fn simulate_block_v1_diag(
     output_state: &mut [u32],
     sram_data: &mut [u32],
 ) {
-    simulate_block_v1_inner(script, input_state, output_state, sram_data, true);
-}
-
-fn simulate_block_v1_inner(
-    script: &[u32],
-    input_state: &[u32],
-    output_state: &mut [u32],
-    sram_data: &mut [u32],
-    diag: bool,
-) {
-    use crate::aigpdk::AIGPDK_SRAM_SIZE;
-    let mut script_pi = 0;
-    loop {
-        let num_stages = script[script_pi];
-        let is_last_part = script[script_pi + 1];
-        let num_ios = script[script_pi + 2];
-        let io_offset = script[script_pi + 3];
-        let num_srams = script[script_pi + 4];
-        let sram_offset = script[script_pi + 5];
-        let num_global_read_rounds = script[script_pi + 6];
-        let num_output_duplicates = script[script_pi + 7];
-        let mut writeout_hooks = vec![0; 256];
-        for i in 0..128 {
-            let t = script[script_pi + 128 + i];
-            writeout_hooks[i * 2] = (t & ((1 << 16) - 1)) as u16;
-            writeout_hooks[i * 2 + 1] = (t >> 16) as u16;
-        }
-        if num_stages == 0 {
-            script_pi += 256;
-            break;
-        }
-        script_pi += 256;
-        let mut writeouts = vec![0u32; num_ios as usize];
-        let mut state = vec![0u32; 256];
-
-        for _gr_i in 0..num_global_read_rounds {
-            for i in 0..256 {
-                let mut cur_state = state[i];
-                let idx = script[script_pi + (i * 2)];
-                let mut mask = script[script_pi + (i * 2 + 1)];
-                if mask == 0 {
-                    continue;
-                }
-                let value = match (idx >> 31) != 0 {
-                    false => input_state[idx as usize],
-                    true => output_state[(idx ^ (1 << 31)) as usize],
-                };
-                while mask != 0 {
-                    cur_state <<= 1;
-                    let lowbit = mask & (-(mask as i32)) as u32;
-                    if (value & lowbit) != 0 {
-                        cur_state |= 1;
-                    }
-                    mask ^= lowbit;
-                }
-                state[i] = cur_state;
-            }
-            script_pi += 256 * 2;
-        }
-
-        for bs_i in 0..num_stages {
-            let mut hier_inputs = vec![0; 256];
-            let mut hier_flag_xora = vec![0; 256];
-            let mut hier_flag_xorb = vec![0; 256];
-            let mut hier_flag_orb = vec![0; 256];
-            for k_outer in 0..4 {
-                for i in 0..256 {
-                    for k_inner in 0..4 {
-                        let k = k_outer * 4 + k_inner;
-                        let t_shuffle = script[script_pi + i * 4 + k_inner];
-                        let t_shuffle_1_idx = (t_shuffle & ((1 << 16) - 1)) as u16;
-                        let t_shuffle_2_idx = (t_shuffle >> 16) as u16;
-                        hier_inputs[i] |=
-                            (state[(t_shuffle_1_idx >> 5) as usize] >> (t_shuffle_1_idx & 31) & 1)
-                                << (k * 2);
-                        hier_inputs[i] |=
-                            (state[(t_shuffle_2_idx >> 5) as usize] >> (t_shuffle_2_idx & 31) & 1)
-                                << (k * 2 + 1);
-                    }
-                }
-                script_pi += 256 * 4;
-            }
-            for i in 0..256 {
-                hier_flag_xora[i] = script[script_pi + i * 4];
-                hier_flag_xorb[i] = script[script_pi + i * 4 + 1];
-                hier_flag_orb[i] = script[script_pi + i * 4 + 2];
-            }
-            script_pi += 256 * 4;
-
-            for i in 0..128 {
-                let a = hier_inputs[i];
-                let b = hier_inputs[128 + i];
-                let xora = hier_flag_xora[128 + i];
-                let xorb = hier_flag_xorb[128 + i];
-                let orb = hier_flag_orb[128 + i];
-                hier_inputs[128 + i] = (a ^ xora) & ((b ^ xorb) | orb);
-            }
-            for hi in 1..=7 {
-                let hier_width = 1 << (7 - hi);
-                for i in 0..hier_width {
-                    let a = hier_inputs[hier_width * 2 + i];
-                    let b = hier_inputs[hier_width * 3 + i];
-                    let xora = hier_flag_xora[hier_width + i];
-                    let xorb = hier_flag_xorb[hier_width + i];
-                    let orb = hier_flag_orb[hier_width + i];
-                    hier_inputs[hier_width + i] = (a ^ xora) & ((b ^ xorb) | orb);
-                }
-            }
-            let v1 = hier_inputs[1];
-            let xora = hier_flag_xora[0];
-            let xorb = hier_flag_xorb[0];
-            let orb = hier_flag_orb[0];
-            let r8 = ((v1 << 16) ^ xora) & ((v1 ^ xorb) | orb) & 0xffff0000;
-            let r9 = ((r8 >> 8) ^ xora) & (((r8 >> 16) ^ xorb) | orb) & 0xff00;
-            let r10 = ((r9 >> 4) ^ xora) & (((r9 >> 8) ^ xorb) | orb) & 0xf0;
-            let r11 = ((r10 >> 2) ^ xora) & (((r10 >> 4) ^ xorb) | orb) & 0b1100;
-            let r12 = ((r11 >> 1) ^ xora) & (((r11 >> 2) ^ xorb) | orb) & 0b10;
-            hier_inputs[0] = r8 | r9 | r10 | r11 | r12;
-            state = hier_inputs;
-
-            for i in 0..256 {
-                let hooki = writeout_hooks[i];
-                if (hooki >> 8) as u32 == bs_i {
-                    writeouts[i] = state[(hooki & 255) as usize];
-                }
-            }
-        }
-
-        let mut sram_duplicate_perm = vec![0u32; (num_srams * 4 + num_output_duplicates) as usize];
-        for k_outer in 0..4 {
-            for i in 0..(num_srams * 4 + num_output_duplicates) {
-                for k_inner in 0..4 {
-                    let k = k_outer * 4 + k_inner;
-                    let t_shuffle = script[script_pi + (i * 4 + k_inner) as usize];
-                    let t_shuffle_1_idx = (t_shuffle & ((1 << 16) - 1)) as u32;
-                    let t_shuffle_2_idx = (t_shuffle >> 16) as u32;
-                    sram_duplicate_perm[i as usize] |=
-                        (writeouts[(t_shuffle_1_idx >> 5) as usize] >> (t_shuffle_1_idx & 31) & 1)
-                            << (k * 2);
-                    sram_duplicate_perm[i as usize] |=
-                        (writeouts[(t_shuffle_2_idx >> 5) as usize] >> (t_shuffle_2_idx & 31) & 1)
-                            << (k * 2 + 1);
-                }
-            }
-            script_pi += 256 * 4;
-        }
-        for i in 0..(num_srams * 4 + num_output_duplicates) as usize {
-            sram_duplicate_perm[i] &= !script[script_pi + i * 4 + 1];
-            sram_duplicate_perm[i] ^= script[script_pi + i * 4];
-        }
-        script_pi += 256 * 4;
-
-        for sram_i_u32 in 0..num_srams {
-            let sram_i = sram_i_u32 as usize;
-            let addrs = sram_duplicate_perm[sram_i * 4];
-            let port_r_addr_iv = addrs & 0xffff;
-            let port_w_addr_iv = (addrs & 0xffff0000) >> 16;
-            let port_w_wr_en = sram_duplicate_perm[sram_i * 4 + 1];
-            let port_w_wr_data_iv = sram_duplicate_perm[sram_i * 4 + 2];
-            let sram_st = sram_offset as usize + sram_i * AIGPDK_SRAM_SIZE;
-            let sram_ed = sram_st + AIGPDK_SRAM_SIZE;
-            let ram = &mut sram_data[sram_st..sram_ed];
-            let r = ram[port_r_addr_iv as usize];
-            let w0 = ram[port_w_addr_iv as usize];
-            writeouts[(num_ios - num_srams + sram_i_u32) as usize] = r;
-            ram[port_w_addr_iv as usize] =
-                (w0 & !port_w_wr_en) | (port_w_wr_data_iv & port_w_wr_en);
-        }
-
-        for i in 0..num_output_duplicates {
-            writeouts[(num_ios - num_srams - num_output_duplicates + i) as usize] =
-                sram_duplicate_perm[(num_srams * 4 + i) as usize];
-        }
-
-        let mut clken_perm = vec![0u32; num_ios as usize];
-        let writeouts_for_clken = writeouts.clone();
-        for k_outer in 0..4 {
-            for i in 0..num_ios {
-                for k_inner in 0..4 {
-                    let k = k_outer * 4 + k_inner;
-                    let t_shuffle = script[script_pi + (i * 4 + k_inner) as usize];
-                    let t_shuffle_1_idx = (t_shuffle & ((1 << 16) - 1)) as u32;
-                    let t_shuffle_2_idx = (t_shuffle >> 16) as u32;
-                    clken_perm[i as usize] |= (writeouts_for_clken
-                        [(t_shuffle_1_idx >> 5) as usize]
-                        >> (t_shuffle_1_idx & 31)
-                        & 1)
-                        << (k * 2);
-                    clken_perm[i as usize] |= (writeouts_for_clken
-                        [(t_shuffle_2_idx >> 5) as usize]
-                        >> (t_shuffle_2_idx & 31)
-                        & 1)
-                        << (k * 2 + 1);
-                }
-            }
-            script_pi += 256 * 4;
-        }
-        for i in 0..num_ios as usize {
-            clken_perm[i] &= !script[script_pi + i * 4 + 1];
-            clken_perm[i] ^= script[script_pi + i * 4];
-            writeouts[i] ^= script[script_pi + i * 4 + 2];
-        }
-
-        if diag {
-            // Count non-zero clken_perm bits across all DFF positions
-            let clken_nonzero: usize = clken_perm[..num_ios as usize]
-                .iter()
-                .map(|c| c.count_ones() as usize)
-                .sum();
-            let clken_set0_all_ones: usize = (0..num_ios as usize)
-                .filter(|&i| script[script_pi + i * 4 + 1] == u32::MAX)
-                .count();
-            let clken_set0_zero: usize = (0..num_ios as usize)
-                .filter(|&i| script[script_pi + i * 4 + 1] == 0)
-                .count();
-            let changed_bits: usize = (0..num_ios as usize)
-                .map(|i| {
-                    let old_wo = input_state[io_offset as usize + i];
-                    let clken = clken_perm[i];
-                    let wo = (old_wo & !clken) | (writeouts[i] & clken);
-                    (old_wo ^ wo).count_ones() as usize
-                })
-                .sum();
-            eprintln!("  DIAG partition: num_ios={}, io_offset={}, clken_nonzero_bits={}, set0_all={}, set0_zero={}, changed_bits={}",
-                num_ios, io_offset, clken_nonzero, clken_set0_all_ones, clken_set0_zero, changed_bits);
-            // Show first few positions with non-zero clken_perm
-            let mut shown = 0;
-            for i in 0..num_ios as usize {
-                if clken_perm[i] != 0 && shown < 3 {
-                    let set0 = script[script_pi + i * 4 + 1];
-                    let inv = script[script_pi + i * 4];
-                    eprintln!("    clken_perm[{}]=0x{:08X} (set0=0x{:08X}, inv=0x{:08X}, writeout=0x{:08X})",
-                        i, clken_perm[i], set0, inv, writeouts[i]);
-                    shown += 1;
-                }
-            }
-            // Also show posedge flag in input_state
-            eprintln!(
-                "    input_state[0]=0x{:08X} (bit0=posedge_flag={})",
-                input_state[0],
-                input_state[0] & 1
-            );
-        }
-
-        script_pi += 256 * 4;
-
-        for i in 0..num_ios {
-            let old_wo = input_state[(io_offset + i) as usize];
-            let clken = clken_perm[i as usize];
-            let wo = (old_wo & !clken) | (writeouts[i as usize] & clken);
-            output_state[(io_offset + i) as usize] = wo;
-        }
-
-        if is_last_part != 0 {
-            break;
-        }
-    }
-    assert_eq!(script_pi, script.len());
+    crate::sim::cpu_reference::simulate_block_v1(
+        script, input_state, output_state, sram_data, true,
+    );
 }
 
 // ── Public Entry Point ───────────────────────────────────────────────────────


### PR DESCRIPTION
**Phase 0 of cosim backend portability ([#105](https://github.com/gpu-eda/Jacquard/issues/105)), step 1** — see the [ADR 0017 amendment](https://github.com/gpu-eda/Jacquard/blob/main/docs/adr/0017-cosim-execution-model.md) and [plan](https://github.com/gpu-eda/Jacquard/blob/main/docs/plans/cosim-backend-portability.md).

## What

`cosim_metal.rs` carried a ~265-line **private duplicate** of `cpu_reference::simulate_block_v1` (`simulate_block_v1` / `_diag` / `_inner`), used only by `--check-with-cpu`. The two wrappers now delegate to `cpu_reference`; the copy is deleted. Net −261 lines.

This is the first, lowest-risk step of the seam extraction: kill the drifting CPU-reference duplicate so the eventual `CpuBackend` (Phase 1) builds on one canonical CPU stepper.

## Why it's safe (bit-identical)

- These functions feed **only `--check-with-cpu`**, never the cosim output VCD — so the cosim output is untouched by construction.
- Compute verified identical line-by-line (diffs were only `debug_verbose`/`diag` print blocks and no-op `as u32` casts).
- Confirmed in a **release build** (matching CI): `cosim --check-with-cpu` produces the *identical* mismatch report before and after (the pre-existing clock-flag `word[0]` / one-output `--check-with-cpu` artifact is unchanged). Only the on-mismatch diagnostic-print detail shifts to `cpu_reference`'s style.

## Note (pre-existing, out of scope)

`cpu_reference::simulate_block_v1`'s `mask & (-(mask as i32)) as u32` lowest-set-bit idiom panics on `mask` bit 31 in **debug** builds ("negate with overflow"); release wraps correctly. The deleted copy had the byte-identical line, so this isn't a regression — but `mask & mask.wrapping_neg()` would make debug `cosim --check-with-cpu` runnable. Flagging for a separate fix.

## Remaining Phase 0 (follow-up PRs)

0b — de-Metal `ScheduleBuffers` (`Vec<BitOp>`, backend materializes); 0c — introduce the `CosimBackend` trait + `MetalBackend` impl (the big one); 0d — move buffer allocations into the backend.