### PR TITLE
fix(cpu_reference): avoid debug-build overflow in mask isolation

### DIFF
--- a/src/sim/cpu_reference.rs
+++ b/src/sim/cpu_reference.rs
@@ -59,7 +59,7 @@ pub fn simulate_block_v1(
                 };
                 while mask != 0 {
                     cur_state <<= 1;
-                    let lowbit = mask & (-(mask as i32)) as u32;
+                    let lowbit = mask & mask.wrapping_neg();
                     if (value & lowbit) != 0 {
                         cur_state |= 1;
                     }
@@ -373,7 +373,7 @@ pub fn simulate_block_v1_xprop(
                 while mask != 0 {
                     cur_v <<= 1;
                     cur_x <<= 1;
-                    let lowbit = mask & (-(mask as i32)) as u32;
+                    let lowbit = mask & mask.wrapping_neg();
                     if (value & lowbit) != 0 {
                         cur_v |= 1;
                     }


### PR DESCRIPTION
## What

`cpu_reference::simulate_block_v1` (and `_xprop`) isolate the lowest set
bit of `mask` via `mask & (-(mask as i32)) as u32`. When `mask` has bit
31 set, `-(i32::MIN)` overflows and **panics in debug builds**
("negate with overflow"); release builds wrap silently, masking the bug.

## Fix

Use `mask & mask.wrapping_neg()` — same two's-complement lowest-set-bit
isolation, but defined for all inputs. Behaviour is identical in release;
debug builds no longer panic, so `cosim --check-with-cpu` is now runnable
under debug builds.

Carry-forward item flagged in #115 / the backend-alignment handoff.