### PR TITLE
feat(cosim): instrument batch utilisation + record backend-seam findings (#105)

### DIFF
--- a/docs/adr/0017-cosim-execution-model.md
+++ b/docs/adr/0017-cosim-execution-model.md
@@ -219,6 +219,55 @@ Two structural facts make this tractable rather than a rewrite:
 Full phasing, the trait signature, and file-by-file steps are in
 [`docs/plans/cosim-backend-portability.md`](../plans/cosim-backend-portability.md).
 
+### Measured batch utilisation (2026-06-07) and a seam refinement
+
+Before extracting the seam, the cosim loop was instrumented to measure how
+often the GPU-only batched fast path (`batch > 1`) is exercised versus
+forced single-edge dispatch (`force_single_edge = any_model_active`, plus
+the diagnostic modes). Per-edge handover is the only mode that needs a true
+per-edge CPU↔GPU round-trip; the telemetry prints in the run summary
+(`single_edge_batches`, mean/max batch).
+
+| Fixture | Edges | Batched (edges) | Single-edge commits | Commits |
+|---|---|---|---|---|
+| `dual_uart` | 10,000 | 100% | 0 | 11 |
+| `apb_trace` | 200 | 100% | 0 | 2 |
+| `xprop_cosim` | 40 | 100% | 0 | 2 |
+| `jtag_minimal` | 4,000,000 | 97.4% | 102,310 | 106,117 |
+
+Two conclusions:
+
+1. **Batching is the dominant path.** Designs whose peripherals have
+   GPU-side halves (UART, APB bus-trace, SPI flash — the `gpu_io_step` /
+   `gpu_flash_model_step` kernels) run **100% batched**: handover happens at
+   `BATCH_SIZE`-edge boundaries, not per clock edge. Even `jtag_minimal`
+   (CPU-side JTAG replay, the most per-edge-heavy fixture) batches 97% of
+   *edges* — though its 102k single-edge commits are 96% of all
+   command-buffer submits and dominate its wall-clock.
+
+2. **The `CosimBackend` trait must be batch-capable, not naive
+   per-edge.** The "cosim is inherently per-edge dispatch" framing above is
+   true of the *reactive* path, but Metal's production path encodes up to
+   `BATCH_SIZE` edges — with the GPU peripheral kernels and the VCD
+   ring-buffer drain — into a single command buffer. A literal
+   `simulate_edge`-per-edge trait would collapse this to one submit per edge
+   and regress Metal ~1000× on the 100%-batched designs. The seam therefore
+   exposes a **batch-granular** backend method ("run N consecutive edges,
+   snapshotting each to the ring") rather than a single-edge one: Metal
+   implements it with its GPU-peripheral batched loop; `CpuBackend` /
+   `Cuda`/`HipBackend` implement it as a per-edge loop with CPU-side
+   peripherals (N effectively 1 until their IO kernels land, Phase 3). The
+   batch-size decision (`force_single_edge`) stays *above* the seam,
+   unchanged — this is a refinement of the trait shape, not of the batch
+   model (still a non-goal to change).
+
+The 102k JTAG single-edge round-trips are precisely the
+"cosim CPU↔GPU round-trip measured as the bottleneck" trigger for **MC.3**
+(streaming stimulus buffer) and the motivation for **MC.4** (per-island
+multi-rate batching) in the multi-clock plan — both *orthogonal to* and
+larger than the #105 seam (MC.4 needs the MC.1 island partitioner). They are
+the right long-term fix for the per-edge tail, not a Phase 0 prerequisite.
+
 ## Cross-references
 
 - ADR 0012 — CDC jitter injection (uses the scheduler's edge

--- a/docs/adr/0017-cosim-execution-model.md
+++ b/docs/adr/0017-cosim-execution-model.md
@@ -88,8 +88,11 @@ resolution.
 
 A **scheduler edge** is one tick of the scheduler (duration =
 `gcd_ps`). A **clock cycle** is two half-periods of a given domain
-(= rising + falling edge). The ratio `edges_per_sys_clk_cycle =
-clock_period_ps / gcd_ps` converts between them.
+(= rising + falling edge). The ratio `sched_ticks_per_sys_clk_cycle =
+clock_period_ps / gcd_ps` converts between them. Note this ratio is the
+number of scheduler ticks per sys_clk *period*, which is 2 only when
+`gcd_ps` equals the half-period (single-clock or harmonic multi-clock);
+non-commensurate periods or phase offsets make it larger.
 
 This distinction is load-bearing for peripheral timing:
 - UART baud rate dividers count **edges**, not clock cycles.
@@ -98,7 +101,7 @@ This distinction is load-bearing for peripheral timing:
 
 Confusing edges with clock cycles was the root cause of the UART
 baud rate bug fixed in commit `a263e47` — `edges_per_period` (the
-LCM schedule length) was used where `edges_per_sys_clk_cycle` was
+LCM schedule length) was used where `sched_ticks_per_sys_clk_cycle` was
 needed, doubling the bit time in multi-clock designs.
 
 ### GPU→CPU ring buffer drain
@@ -133,7 +136,7 @@ needed — all drains happen after `waitUntilCompleted`.
   would remove this limit.
 - The edges-vs-cycles distinction must be maintained carefully in
   any code that converts user-facing "cycles" to internal "ticks".
-  The `edges_per_sys_clk_cycle` helper exists for this purpose.
+  The `sched_ticks_per_sys_clk_cycle` helper exists for this purpose.
 - Pre-allocated schedule buffers consume `O(schedule_len)` Metal
   buffer pairs at startup. Each schedule entry creates two Metal
   buffer objects (params + ops). For typical single-clock designs
@@ -141,92 +144,27 @@ needed — all drains happen after `waitUntilCompleted`.
   designs it can reach thousands of entries, but each buffer is
   small (tens of bytes).
 
-## Amendment 2026-06-05: backend portability (#105)
+## Amendment 2026-06-07: backend-portable cosim — target architecture (#105)
 
 The execution model above is **Metal-only** — `run_cosim` lives in
 `cosim_metal.rs` (gated `#[cfg(feature = "metal")]`) and `cmd_cosim`
-hard-errors on other backends. This amendment records the decision to make
-cosim **backend-portable** (CPU reference + CUDA/HIP), tracked as
-[#105](https://github.com/gpu-eda/Jacquard/issues/105). It does **not**
-change the batch/scheduler model above; it factors *where* each part runs.
-
-### The seam: backend-agnostic orchestration vs a `CosimBackend` trait
-
-`run_cosim` is split along a seam that already exists in spirit:
-
-- **Above the seam (backend-agnostic, moves to a shared `cosim` driver):**
-  the `MultiClockScheduler`, `build_edge_ops`, batch-size logic, peripheral
-  models (`PeripheralModel::step_edge` → `ModelOverrides`), the input
-  dispatcher, reset/constant init, VCD writing, and event/ring-buffer
-  draining. None of this is GPU-specific; it operates on `&[u32]` state and
-  `Vec<BitOp>` edge ops.
-- **Below the seam (a `CosimBackend` trait, one impl per backend):** owning
-  the `[2 × state_size]` state buffer and performing, per edge —
-  `state_prep` (output→input copy + apply BitOps + clear driven X-mask),
-  the design step (`simulate_v1_stage` / the boolean processor), and
-  exposing `input_state()` / `output_state()` as `&[u32]`/`&mut [u32]` to
-  the orchestration. `MetalSimulator` becomes one implementation.
-
-Two structural facts make this tractable rather than a rewrite:
-
-1. **cosim is inherently per-edge dispatch on every backend.** Inputs
-   depend on outputs each cycle, so the reactive loop dispatches the design
-   one edge at a time — it does **not** use the single cooperative-launch +
-   `grid.sync` model that the `sim` command uses on CUDA/HIP. CUDA/HIP cosim
-   therefore dispatches the design kernel per-edge exactly as Metal already
-   does, sidestepping the one CUDA feature (`cooperative_groups` grid sync)
-   that is hardest to port. cosim's structure is *closer* across backends
-   than `sim`'s.
-2. **The peripheral protocol models are already backend-agnostic CPU Rust**
-   (`src/sim/models/*.rs` implement `PeripheralModel`, no GPU deps). The
-   on-GPU IO kernels (`gpu_flash_model_step`, `gpu_io_step`,
-   `gpu_apply_flash_din`) are a Metal **performance optimization** that
-   eliminates per-tick CPU↔GPU round-trips — they are *not* required for
-   correctness. A new backend can run peripherals on the CPU and only
-   dispatch the design step on the GPU; porting the IO kernels is a later
-   optimization, not a prerequisite.
-
-### Two implementations
-
-- **Path A — `CpuBackend` (reference, no GPU).** Design step =
-  `cpu_reference::simulate_block_v1` per block (the existing
-  `--check-with-cpu` loop is already a prototype of exactly this). Not for
-  throughput (won't beat Verilator); its value is a portable reference, an
-  oracle, contributor access on non-Apple hardware, and — decisively —
-  **running cosim regression tests on free Linux CI** (today they are
-  Metal-only). Builds and validates the seam.
-- **Path B — `Cuda`/`HipBackend` (the Linux perf story).** Design step =
-  the existing CUDA/HIP `simulate` kernel dispatched per-edge, reusing
-  Path A's seam and the CPU peripheral models. Was "runner-gated"; the
-  GitHub-hosted T4 runner (`tesla4-runner`) now makes it CI-testable.
-
-### Consequences
-
-- The `sim` cooperative-launch model and the cosim per-edge model remain
-  distinct *per backend*; this amendment unifies the cosim *driver*, not the
-  two execution models.
-- `ScheduleBuffers` currently stores `metal::Buffer` pairs and
-  `update_model_driven_in_ops` writes into Metal shared memory directly;
-  these must become backend-neutral (`Vec<BitOp>`) with the backend
-  materializing its native form. This is the main refactor friction.
-- `cosim_metal.rs` carries private copies of `simulate_block_v1`; these
-  consolidate onto `cpu_reference` as part of the seam extraction.
-- Correctness is guarded by extending the cross-backend equivalence test
-  ([#113](https://github.com/gpu-eda/Jacquard/pull/113), today sim-only) to
-  cosim once a second backend exists — a CPU/Metal output-VCD diff on the
-  same reactive design.
-
-Full phasing, the trait signature, and file-by-file steps are in
+hard-errors on other backends. This amendment records the **target
+architecture** for making cosim backend-portable (CPU reference + CUDA/HIP),
+tracked as [#105](https://github.com/gpu-eda/Jacquard/issues/105). It
+supersedes the incremental 2026-06-05 note (whose "per-edge on every
+backend" framing the measurements below correct). It describes the
+steady-state design; the staging to reach it lives in
 [`docs/plans/cosim-backend-portability.md`](../plans/cosim-backend-portability.md).
+It does **not** change the batch/scheduler model above — it factors *where*
+each part runs and along what seam.
 
-### Measured batch utilisation (2026-06-07) and a seam refinement
+### The evidence: measured batch utilisation (2026-06-07)
 
-Before extracting the seam, the cosim loop was instrumented to measure how
-often the GPU-only batched fast path (`batch > 1`) is exercised versus
-forced single-edge dispatch (`force_single_edge = any_model_active`, plus
-the diagnostic modes). Per-edge handover is the only mode that needs a true
-per-edge CPU↔GPU round-trip; the telemetry prints in the run summary
-(`single_edge_batches`, mean/max batch).
+The cosim loop was instrumented (telemetry in the run summary:
+`single_edge_batches`, mean/max batch) to measure how often the batched
+fast path (`batch > 1`) runs versus forced single-edge dispatch
+(`force_single_edge = any_model_active`, plus diagnostic modes). Per-edge
+handover is the only mode needing a true per-edge CPU↔GPU round-trip.
 
 | Fixture | Edges | Batched (edges) | Single-edge commits | Commits |
 |---|---|---|---|---|
@@ -235,38 +173,119 @@ per-edge CPU↔GPU round-trip; the telemetry prints in the run summary
 | `xprop_cosim` | 40 | 100% | 0 | 2 |
 | `jtag_minimal` | 4,000,000 | 97.4% | 102,310 | 106,117 |
 
-Two conclusions:
+Designs whose peripherals have GPU-side halves (UART, APB bus-trace, SPI
+flash — the `gpu_io_step` / `gpu_flash_model_step` kernels) run **100%
+batched**: CPU↔GPU handover is at `BATCH_SIZE`-edge boundaries, not per
+clock edge. Even `jtag_minimal` (CPU-side JTAG replay, the most
+per-edge-heavy fixture) batches 97% of *edges* — but its 102k single-edge
+commits are 96% of all submits and dominate its wall-clock. **Batching is
+the dominant path; per-edge is the exception (CPU-side models + diagnostic
+modes).** This drives every decision below.
 
-1. **Batching is the dominant path.** Designs whose peripherals have
-   GPU-side halves (UART, APB bus-trace, SPI flash — the `gpu_io_step` /
-   `gpu_flash_model_step` kernels) run **100% batched**: handover happens at
-   `BATCH_SIZE`-edge boundaries, not per clock edge. Even `jtag_minimal`
-   (CPU-side JTAG replay, the most per-edge-heavy fixture) batches 97% of
-   *edges* — though its 102k single-edge commits are 96% of all
-   command-buffer submits and dominate its wall-clock.
+### Layer 1 — backend-agnostic orchestration (the shared `cosim` driver)
 
-2. **The `CosimBackend` trait must be batch-capable, not naive
-   per-edge.** The "cosim is inherently per-edge dispatch" framing above is
-   true of the *reactive* path, but Metal's production path encodes up to
-   `BATCH_SIZE` edges — with the GPU peripheral kernels and the VCD
-   ring-buffer drain — into a single command buffer. A literal
-   `simulate_edge`-per-edge trait would collapse this to one submit per edge
-   and regress Metal ~1000× on the 100%-batched designs. The seam therefore
-   exposes a **batch-granular** backend method ("run N consecutive edges,
-   snapshotting each to the ring") rather than a single-edge one: Metal
-   implements it with its GPU-peripheral batched loop; `CpuBackend` /
-   `Cuda`/`HipBackend` implement it as a per-edge loop with CPU-side
-   peripherals (N effectively 1 until their IO kernels land, Phase 3). The
-   batch-size decision (`force_single_edge`) stays *above* the seam,
-   unchanged — this is a refinement of the trait shape, not of the batch
-   model (still a non-goal to change).
+Everything that is not GPU-specific moves above the seam and operates on
+`&[u32]` state + `Vec<BitOp>` edge ops: the `MultiClockScheduler`,
+`build_edge_ops`, the **batch-size policy** (`force_single_edge`), peripheral
+*coordination*, the input dispatcher, reset/constant init, VCD writing, and
+event/ring-buffer draining. The batch-size decision stays here, unchanged.
 
-The 102k JTAG single-edge round-trips are precisely the
-"cosim CPU↔GPU round-trip measured as the bottleneck" trigger for **MC.3**
-(streaming stimulus buffer) and the motivation for **MC.4** (per-island
-multi-rate batching) in the multi-clock plan — both *orthogonal to* and
-larger than the #105 seam (MC.4 needs the MC.1 island partitioner). They are
-the right long-term fix for the per-edge tail, not a Phase 0 prerequisite.
+### Layer 2 — the `CosimBackend` trait (one impl per backend)
+
+Owns the `[2 × state_size]` design state and runs the design. Crucially it
+is **batch-granular, not single-edge** — the measurements show a literal
+`simulate_edge`-per-edge trait would collapse Metal's 100%-batched designs
+to one command-buffer submit per edge (~1000× regression). The trait method
+is therefore *"run N consecutive scheduler edges, applying each edge's ops
+and snapshotting each output slot to the ring"*, plus `state_prep`
+(output→input copy + apply `BitOp`s + clear driven X-mask) and
+`input_state()/output_state()` accessors. `MetalSimulator` becomes
+`MetalBackend`; `CpuBackend` and `Cuda`/`HipBackend` are added.
+
+- **`MetalBackend`** runs N edges in one command buffer with GPU peripherals
+  inside (today's `encode_and_commit_gpu_batch`).
+- **`CpuBackend`** runs the per-edge loop via `cpu_reference::simulate_block_v1`
+  — the reference/oracle, and the unlock for **cosim regression on free
+  Linux CI** (today Metal-only). N is effectively 1; throughput is not the
+  point.
+- **`Cuda`/`HipBackend`** run the existing `simulate` kernel **per-edge** —
+  sidestepping the `cooperative_groups` grid-sync that only the `sim`
+  command needs (the hardest CUDA feature to port). They reach true batching
+  only once GPU peripherals exist (Layer 3, Tier 2).
+
+### Layer 3 — the `GpuPeripheral` abstraction (3-tier, GPU peripherals primary)
+
+Batching a *reactive* design requires the peripheral to run **inside** the
+batch — i.e. on the GPU — because the peripheral consumes each edge's output
+to drive the next edge's input. On Metal this is hidden by unified memory;
+on a discrete GPU, per-edge means a **PCIe round-trip every edge** (~1–2 µs
+each way), which over millions of edges is likely *slower than the CPU
+backend*. **Therefore GPU-side peripherals are architecturally required for
+the CUDA/HIP perf story — not an optional optimization.** The decision
+(2026-06-07) is to make GPU peripherals the **primary** path, with a 3-tier
+model mirroring the `CosimBackend` seam:
+
+- **Tier 1 — CPU reference model** (`PeripheralModel`, `src/sim/models/*.rs`,
+  exists). The semantic ground truth, the cross-backend equivalence oracle,
+  and the fallback for any (backend, peripheral) lacking a GPU kernel. Always
+  present.
+- **Tier 2 — hand-written GPU kernels for core peripherals** (now). Because
+  CUDA and HIP already share `kernel_v1_impl.cuh`, a core peripheral is **two
+  implementations, not three**: one shared `*_impl.cuh` (CUDA + HIP) and one
+  `.metal`. Tractable for the small in-core set (flash, UART, bus-trace) and
+  matching the existing `simulate`-kernel precedent.
+- **Tier 3 — single-source peripheral compilation** (later; the
+  user-extensible peripheral API). Hand-written kernels don't scale to
+  user-defined peripherals; the endgame is a user writing a peripheral *once*
+  (restricted-Rust subset or a small peripheral-FSM IR) that compiles to CPU
+  + every GPU backend. This domain (peripheral FSMs) is far narrower than the
+  general cross-shader-tool port previously rejected, so an in-house IR is
+  the tractable route.
+
+The `GpuPeripheral` seam is defined at Tier 2 so Tier 3 slots in without
+reworking the orchestration.
+
+### Correctness contract
+
+The CPU `PeripheralModel` (Tier 1) is ground truth. The cross-backend
+equivalence harness ([#113](https://github.com/gpu-eda/Jacquard/pull/113),
+today sim-only) extends to cosim: every backend's output VCD must be
+byte-identical on the same reactive design, and every GPU-peripheral kernel
+(Tier 2) must match its CPU model. This is the backstop for the whole effort.
+
+### Considered alternative (not adopted as primary)
+
+**Speculative batching** — keep peripherals on the CPU, batch optimistically,
+and roll back on divergence (the multi-clock plan's MC.4 island run-ahead /
+MC.5 record-and-replay). It avoids writing GPU kernels but is
+non-deterministic in throughput and substantially more complex. Rejected as
+the primary path; retained as the natural fallback for *user* CPU
+peripherals that are not GPU-portable. Cross-shader tools (Slang, Ferrox)
+remain rejected for the design kernel; Tier 3's narrow peripheral-FSM IR is
+the cross-GPU answer for peripherals.
+
+### Relationship to the multi-clock plan
+
+The 102k JTAG single-edge round-trips are exactly the "cosim CPU↔GPU
+round-trip measured as the bottleneck" trigger for **MC.3** (streaming
+stimulus) and the motivation for **MC.4** (per-island multi-rate batching).
+Both are *orthogonal to and larger than* this seam (MC.4 needs the MC.1
+island partitioner) — the long-term fix for the per-edge tail, not a
+prerequisite here.
+
+### Consequences
+
+- The `sim` cooperative-launch model and the cosim per-edge/batch model
+  remain distinct *per backend*; this unifies the cosim *driver*, not the two
+  execution models.
+- `ScheduleBuffers` currently stores `metal::Buffer` pairs and the ops-update
+  helpers write Metal shared memory in place; these become backend-neutral
+  (`Vec<(StatePrepParams, Vec<BitOp>)>`) with each backend materializing its
+  native form. The in-place shared-memory mutation is the main refactor
+  friction — the trait's explicit ops-upload point is what removes it.
+- CUDA/HIP cosim is **per-edge (correctness/CI only) until Tier-2 GPU
+  peripherals land**; its real perf path depends on them. This is an
+  expected, documented throughput gap, not a regression.
 
 ## Cross-references
 

--- a/docs/adr/0017-cosim-execution-model.md
+++ b/docs/adr/0017-cosim-execution-model.md
@@ -202,16 +202,39 @@ and snapshotting each output slot to the ring"*, plus `state_prep`
 `input_state()/output_state()` accessors. `MetalSimulator` becomes
 `MetalBackend`; `CpuBackend` and `Cuda`/`HipBackend` are added.
 
+**The backend owns the schedule storage (opaque to the orchestration).** The
+edge ops are a tiny, fixed, repeating set (`edges_per_period` entries, =2 for
+single-clock) built *once*; the orchestration must not hold a parallel copy
+that the backend re-materialises each dispatch (that would add a per-dispatch
+copy and, on Metal, *regress* today's zero-copy unified-memory path). Instead:
+
+- `init_schedule(edges: Vec<(StatePrepParams, Vec<BitOp>)>)` hands the
+  backend-agnostic description to the backend *once*; the backend materialises
+  its native buffers and retains them. The orchestration keeps only scalars
+  (`edges_per_period`, `gcd_ps`).
+- `edge_ops_mut(edge_idx) -> &mut [BitOp]` is how reset / model-driven /
+  clock-edge patching mutates ops. **Metal** returns a slice straight over the
+  shared `MTLBuffer` — zero-copy, the write *is* the upload (exactly today's
+  behaviour). **CUDA/HIP** return a slice over a host mirror and mark the edge
+  dirty; `run_edges` uploads only dirty edges before launch. Ops change rarely
+  (reset transitions; only while a CPU-side model is active), so this is near
+  zero in practice — and the buffers are KB-scale regardless.
+
+This replaces the earlier "neutral `Vec` + backend re-materialises" sketch,
+which risked needless CPU↔GPU traffic and double bookkeeping.
+
 - **`MetalBackend`** runs N edges in one command buffer with GPU peripherals
   inside (today's `encode_and_commit_gpu_batch`).
 - **`CpuBackend`** runs the per-edge loop via `cpu_reference::simulate_block_v1`
   — the reference/oracle, and the unlock for **cosim regression on free
   Linux CI** (today Metal-only). N is effectively 1; throughput is not the
-  point.
-- **`Cuda`/`HipBackend`** run the existing `simulate` kernel **per-edge** —
-  sidestepping the `cooperative_groups` grid-sync that only the `sim`
-  command needs (the hardest CUDA feature to port). They reach true batching
-  only once GPU peripherals exist (Layer 3, Tier 2).
+  point. It also validates the per-edge orchestration path that the CUDA/HIP
+  fallback reuses.
+- **`Cuda`/`HipBackend`** run the existing `simulate` kernel, sidestepping the
+  `cooperative_groups` grid-sync that only the `sim` command needs (the
+  hardest CUDA feature to port). They ship **with** their Tier-2 GPU
+  peripherals (Layer 3) so reactive designs batch from the start; the per-edge
+  path is the permanent fallback for CPU-side models (e.g. JTAG replay).
 
 ### Layer 3 — the `GpuPeripheral` abstraction (3-tier, GPU peripherals primary)
 
@@ -279,13 +302,18 @@ prerequisite here.
   remain distinct *per backend*; this unifies the cosim *driver*, not the two
   execution models.
 - `ScheduleBuffers` currently stores `metal::Buffer` pairs and the ops-update
-  helpers write Metal shared memory in place; these become backend-neutral
-  (`Vec<(StatePrepParams, Vec<BitOp>)>`) with each backend materializing its
-  native form. The in-place shared-memory mutation is the main refactor
-  friction — the trait's explicit ops-upload point is what removes it.
-- CUDA/HIP cosim is **per-edge (correctness/CI only) until Tier-2 GPU
-  peripherals land**; its real perf path depends on them. This is an
-  expected, documented throughput gap, not a regression.
+  helpers write Metal shared memory in place. These move *into the backend*
+  (built once via `init_schedule`, mutated via `edge_ops_mut`) rather than
+  becoming an orchestration-owned `Vec` the backend re-materialises — which
+  keeps Metal zero-copy and lets CUDA/HIP upload only dirty edges. Converting
+  the in-place `*mut BitOp` shared-memory mutation to `edge_ops_mut` is the
+  main refactor friction (and resolves the closure-borrow issue too).
+- CUDA/HIP cosim ships **with Tier-2 GPU peripherals** so reactive designs
+  batch from the start (Phase 2 lands the backend + GPU peripherals together,
+  rather than a per-edge-only intermediate that would be unusably slow). The
+  per-edge path remains as the fallback for CPU-side models (e.g. JTAG
+  replay), where the per-edge tail is addressed later by the multi-clock
+  plan's MC.3/MC.4, not by this seam.
 
 ## Cross-references
 

--- a/docs/plans/cosim-backend-portability.md
+++ b/docs/plans/cosim-backend-portability.md
@@ -69,6 +69,25 @@ Metal does — it does **not** need the `sim` command's cooperative
 single-launch + `grid.sync`, the one CUDA feature hardest to port. See ADR
 0017 amendment, fact (1).
 
+### Batch granularity (measured refinement, 2026-06-07)
+
+The trait above reads as single-edge, but instrumentation of the real
+fixtures shows Metal's **production path is batched**: designs with
+GPU-side peripherals (`dual_uart`, `apb_trace`, `xprop_cosim`) run **100%
+batched** (handover at `BATCH_SIZE`-edge boundaries), and even the
+CPU-side-replay `jtag_minimal` batches 97% of edges. A literal per-edge
+`simulate_edge` would regress Metal ~1000× on those designs.
+
+So `state_prep` + `simulate_edge` are realised as a **batch-granular**
+backend method — "run N consecutive scheduler edges, snapshotting each
+output slot to the ring buffer." Metal implements it with its existing
+GPU-peripheral batched loop (`encode_and_commit_gpu_batch`); `CpuBackend` /
+`Cuda`/`HipBackend` implement it as a per-edge loop with CPU peripherals
+(N collapses toward 1 until their IO kernels land in Phase 3). The
+`force_single_edge` batch-size decision stays in the orchestration, above
+the seam. Full data + reasoning: ADR 0017 amendment, *Measured batch
+utilisation*.
+
 ## Phases
 
 ### Phase 0 — Extract the seam (Metal-only refactor, zero behaviour change)

--- a/docs/plans/cosim-backend-portability.md
+++ b/docs/plans/cosim-backend-portability.md
@@ -3,175 +3,212 @@
 **Status:** Active — design captured, not yet scheduled.
 **Issue:** [#105](https://github.com/gpu-eda/Jacquard/issues/105).
 **Architecture:** [ADR 0017 — Cosim execution model](../adr/0017-cosim-execution-model.md)
-(see the *Amendment 2026-06-05: backend portability* section).
+(see *Amendment 2026-06-07: backend-portable cosim — target architecture*).
 
 cosim is Metal-only today: `run_cosim` lives in `src/sim/cosim_metal.rs`
 (gated `#[cfg(feature = "metal")]`) and `cmd_cosim` hard-errors on other
-backends. This plan factors the driver into a backend-agnostic orchestration
-layer plus a `CosimBackend` trait, then adds a CPU implementation (Path A)
-and a CUDA/HIP implementation (Path B).
+backends. This plan is the **staging** to reach the target architecture in
+ADR 0017: a backend-agnostic orchestration layer, a batch-granular
+`CosimBackend` trait, and a 3-tier `GpuPeripheral` model — then CPU and
+CUDA/HIP backends.
 
 ## Goal & non-goals
 
-**Goal:** `jacquard cosim` runs on CPU (reference, no GPU) and on CUDA/HIP,
-not just Metal — reusing the existing scheduler, peripheral models, and VCD
-machinery unchanged.
+**Goal:** `jacquard cosim` runs on CPU (reference, no GPU) and on CUDA/HIP
+**with batching**, not just Metal — reusing the existing scheduler,
+peripheral models, and VCD machinery.
 
 **Non-goals:**
-- Changing the batch/scheduler execution model of ADR 0017 (untouched).
-- Matching Metal cosim throughput on the CPU path (it's a reference/oracle).
-- Porting the on-GPU IO-model kernels to CUDA/HIP up front — peripherals run
-  on the CPU first; GPU IO models are a later optimization (Phase 3).
+- Changing the batch/scheduler execution model of ADR 0017 (untouched; the
+  trait is made batch-granular to *preserve* it, not change it).
+- Matching Metal cosim throughput on the **CPU** path (it's a
+  reference/oracle).
+- The user-extensible single-source peripheral API (Tier 3) up front — core
+  peripherals get hand-written GPU kernels first (Phase 3); the portable
+  authoring path is Phase 4.
 
 ## What's already portable (no work needed)
 
-- **Peripheral protocol models** — `src/sim/models/*.rs` (gpio, uart, i2c,
-  spi, jtag, bus_trace) are pure CPU Rust implementing `PeripheralModel`
-  (`models/mod.rs:56`). Reusable as-is across all backends.
+- **Peripheral protocol models (Tier 1)** — `src/sim/models/*.rs` (gpio,
+  uart, i2c, spi, jtag, bus_trace) are pure CPU Rust implementing
+  `PeripheralModel` (`models/mod.rs:56`). The semantic ground truth and the
+  cross-backend equivalence oracle; reusable as-is across all backends.
 - **CPU design step** — `cpu_reference::simulate_block_v1` is the exact CPU
   equivalent of one `simulate_v1_stage` threadgroup. The existing
   `run_cosim` `--check-with-cpu` path (`cosim_metal.rs:4282–4504`) already
   runs `state_prep` + `apply_flash_din` + `simulate_block_v1` per block on
   the CPU — a working prototype of the Path A backend step.
-- **The scheduler / batching / VCD / event drain** logic is GPU-agnostic in
-  intent; it operates on `&[u32]` state and `Vec<BitOp>` ops.
+- **The scheduler / batch-size policy / VCD / event drain** logic is
+  GPU-agnostic in intent; it operates on `&[u32]` state and `Vec<BitOp>` ops.
 
-## The seam
+## The seam (batch-granular)
 
 ```rust
-/// Per-edge design execution + state ownership. One impl per backend.
-/// The orchestration layer (scheduler, models, VCD, drains) calls this.
+/// Design execution + state ownership. One impl per backend. The
+/// orchestration layer (scheduler, models, VCD, drains) calls this.
+///
+/// Batch-granular by construction: measurements (ADR 0017) show Metal runs
+/// 100% batched on GPU-peripheral designs, so a single-edge method would
+/// regress it ~1000×. The orchestration decides N (`force_single_edge`);
+/// the backend runs N edges however it likes.
 trait CosimBackend {
-    /// output→input copy + apply scheduled BitOps + clear driven X-mask.
+    /// output→input copy + apply that edge's BitOps + clear driven X-mask.
     fn state_prep(&mut self, ops: &[BitOp], xmask_state_offset: u32);
-    /// Run the design for one edge (all major stages).
-    fn simulate_edge(&mut self);
-    /// Read-only view of the design output slot (VCD, model step_edge, drains).
+    /// Run `edges` consecutive scheduler edges, applying each edge's ops and
+    /// snapshotting each output slot into the ring. Metal: one command buffer
+    /// with GPU peripherals inside. CPU/CUDA(pre-Phase-3): per-edge loop.
+    fn run_edges(&mut self, edges: &[EdgeOps], ring: &mut Ring);
+    /// Read-only view of the current output slot (VCD, model step_edge, drains).
     fn output_state(&self) -> &[u32];
     /// Mutable input slot (reset/constant init, flash MISO injection).
     fn input_state_mut(&mut self) -> &mut [u32];
-    // Phase 3 (optional, perf): on-GPU peripheral hooks.
-    //   fn apply_flash_din(&mut self, ...); fn flash_model_step(&mut self, ...);
-    //   fn io_step(&mut self) -> IoEvents;
+}
+
+/// GPU-side peripheral kernel (Tier 2). Runs inside the backend's batch so
+/// reactive designs can batch on a discrete GPU. CPU `PeripheralModel`
+/// (Tier 1) is the reference + fallback when no GpuPeripheral exists.
+trait GpuPeripheral {
+    fn encode_step(&self, /* backend-specific encoder */);
 }
 ```
 
 `MetalSimulator` becomes the `MetalBackend` impl; `CpuBackend` and
-`Cuda`/`HipBackend` are added. The orchestration keeps peripherals on the
-CPU (calling `PeripheralModel::step_edge` → `ModelOverrides` → BitOps) and
-only delegates the design step + state ownership to the backend.
+`Cuda`/`HipBackend` are added. The orchestration owns the neutral schedule
+(`Vec<(StatePrepParams, Vec<BitOp>)>`), the batch-size policy, and the CPU
+peripheral models; it delegates the design step + state ownership to the
+backend, and (Phase 3+) the GPU peripheral steps to `GpuPeripheral` impls.
 
-### Why this is tractable
+### Why batching must be a backend concern
 
-cosim is **per-edge dispatch on every backend** (reactive inputs), so the
-CUDA/HIP path dispatches the design kernel one edge at a time exactly as
-Metal does — it does **not** need the `sim` command's cooperative
-single-launch + `grid.sync`, the one CUDA feature hardest to port. See ADR
-0017 amendment, fact (1).
-
-### Batch granularity (measured refinement, 2026-06-07)
-
-The trait above reads as single-edge, but instrumentation of the real
-fixtures shows Metal's **production path is batched**: designs with
-GPU-side peripherals (`dual_uart`, `apb_trace`, `xprop_cosim`) run **100%
-batched** (handover at `BATCH_SIZE`-edge boundaries), and even the
-CPU-side-replay `jtag_minimal` batches 97% of edges. A literal per-edge
-`simulate_edge` would regress Metal ~1000× on those designs.
-
-So `state_prep` + `simulate_edge` are realised as a **batch-granular**
-backend method — "run N consecutive scheduler edges, snapshotting each
-output slot to the ring buffer." Metal implements it with its existing
-GPU-peripheral batched loop (`encode_and_commit_gpu_batch`); `CpuBackend` /
-`Cuda`/`HipBackend` implement it as a per-edge loop with CPU peripherals
-(N collapses toward 1 until their IO kernels land in Phase 3). The
-`force_single_edge` batch-size decision stays in the orchestration, above
-the seam. Full data + reasoning: ADR 0017 amendment, *Measured batch
-utilisation*.
+cosim is per-edge *dispatch* in the reactive sense (inputs depend on
+outputs), which is why CUDA/HIP avoid the `sim` command's cooperative
+single-launch + `grid.sync` — the hardest CUDA feature to port. But
+*reactive* and *per-command-buffer* are different axes: Metal batches up to
+`BATCH_SIZE` reactive edges into one command buffer because its peripherals
+run on the GPU inside the batch. On a discrete GPU, going per-command-buffer
+means a PCIe round-trip every edge, which is why batching (hence GPU
+peripherals, Phase 3) is *required* for CUDA/HIP perf, not optional. See ADR
+0017, *Layer 3* and *Consequences*.
 
 ## Phases
 
 ### Phase 0 — Extract the seam (Metal-only refactor, zero behaviour change)
 
-Refactor `cosim_metal.rs` into `cosim/mod.rs` (orchestration) + a
-`CosimBackend` trait + `cosim/metal.rs` (`MetalBackend`). No new backend
-yet — this is a pure restructuring that must leave Metal cosim
-bit-identical.
+Introduce the batch-granular `CosimBackend` trait and make the schedule
+backend-neutral; `MetalSimulator` becomes `MetalBackend`. The physical
+module split (`cosim/mod.rs` orchestration + `cosim/metal.rs`) is separable
+— the trait can land in-place in `cosim_metal.rs` first, split later. Must
+leave Metal cosim bit-identical.
 
-- Make `ScheduleBuffers.edge_buffers` backend-neutral: store
+- Make `ScheduleBuffers` backend-neutral: store
   `Vec<(StatePrepParams, Vec<BitOp>)>`; the backend materialises native
-  buffers (Metal buffers today). Currently it holds `metal::Buffer` pairs
-  (`cosim_metal.rs:3072`).
-- `update_model_driven_in_ops` / `update_reset_in_ops` write into
-  `Vec<BitOp>`, not Metal shared memory (`cosim_metal.rs:3643–3678`).
-- Consolidate the private `simulate_block_v1` copies in `cosim_metal.rs`
-  (`:2130–2413`) onto `cpu_reference`.
+  buffers (Metal buffers today). Currently holds `metal::Buffer` pairs.
+- The ops-update helpers (`update_model_driven_in_ops`,
+  `update_reset_in_ops`, `patch_model_clock_edges`) mutate the neutral
+  `Vec<BitOp>`, not Metal shared memory; the backend re-uploads. **This
+  in-place shared-memory mutation is the main refactor friction** — the
+  trait's explicit ops path is what removes it.
+- ~~Consolidate the private `simulate_block_v1` copies onto
+  `cpu_reference`.~~ **Done — #115.**
 - Move the ~20 ad-hoc `simulator.device.new_buffer(...)` allocations in
   `run_cosim` into `MetalBackend`.
 
-**Entry:** #113 (sim cross-backend equivalence) merged.
+**Entry:** #113 (sim cross-backend equivalence) merged. ✅
 **Exit:** Metal cosim CI (`dual_uart`, `apb_trace`, JTAG-minimal,
-`xprop_cosim`) all green, byte-identical output VCDs vs pre-refactor.
+`xprop_cosim`) all green, byte-identical output VCDs vs pre-refactor
+(harness: re-run the fixtures, `cmp` against a pre-refactor golden).
 
 ### Phase 1 — Path A: `CpuBackend` + Linux cosim CI
 
 - Implement `CpuBackend`: `state_prep` (output→input copy + BitOps +
-  X-mask clear — the loop at `cosim_metal.rs:4286–4301`), `simulate_edge`
-  via `cpu_reference::simulate_block_v1` per block, plain `Vec<u32>` state.
-- Peripherals stay on CPU (already are). The GPU flash kernel's FSM is a
-  simple SPI state machine; reimplement it as CPU Rust (or reuse the
-  existing `CppSpiFlash` FFI at `cosim_metal.rs:2493`) so flash cosim works
-  without Metal.
+  X-mask clear — the loop at `cosim_metal.rs:4286–4301`), `run_edges` via
+  `cpu_reference::simulate_block_v1` per block (N effectively 1), plain
+  `Vec<u32>` state.
+- Peripherals stay on CPU (Tier 1, already are). The GPU flash kernel's FSM
+  is a simple SPI state machine; reuse the existing `CppSpiFlash` FFI
+  (`cosim_metal.rs:2493`) rather than writing a third copy.
 - Wire `cmd_cosim` to select `CpuBackend` when `--features metal` is absent
   (or via an explicit `--backend cpu`), removing the hard-error.
-- **Move the cosim regression tests to a Linux CI job** — they're
-  Metal-only today; CPU cosim lets `xprop_cosim` (cosim mode), `dual_uart`,
-  and `apb_trace` run on free `ubuntu-latest`.
+- **Move the cosim regression tests to a Linux CI job** — Metal-only today;
+  CPU cosim lets `xprop_cosim` (cosim mode), `dual_uart`, and `apb_trace`
+  run on free `ubuntu-latest`.
 
 **Entry:** Phase 0 merged.
 **Exit:** `cargo run --bin jacquard -- cosim …` (no GPU features) runs the
 existing cosim fixtures on Linux CI and passes their checkers.
 
-### Phase 2 — Path B: `Cuda`/`HipBackend` (design on GPU, peripherals on CPU)
+### Phase 2 — Path B: `Cuda`/`HipBackend` — correctness (per-edge, CI gate)
 
 - Implement the backend over the existing CUDA/HIP `simulate` kernel,
   dispatched **per-edge** (not the cooperative single launch). State lives
-  in device memory exposed to the orchestration via host copy / pinned /
-  unified memory for the per-edge `output_state()` read.
-- Peripherals remain on the CPU (per-edge CPU↔GPU sync). Accept the
-  round-trip cost for the first cut; it's still the real Linux GPU path.
-- Gate the GPU-backed cosim CI on `tesla4-runner` (now available).
+  in device memory, read back per edge for `output_state()`.
+- Peripherals remain on the CPU (Tier 1, per-edge CPU↔GPU sync).
+- Gate GPU-backed cosim CI on `tesla4-runner` (now available).
+
+**This phase is a correctness/CI gate, NOT the perf path** — per-edge PCIe
+round-trips make it slow (potentially slower than `CpuBackend`); even the
+100%-batched-on-Metal fixtures run per-edge here because their peripherals
+are on the CPU. Real CUDA/HIP perf arrives in Phase 3.
 
 **Entry:** Phase 1 merged (seam + CPU reference proven).
 **Exit:** `cosim --features cuda` runs a fixture on the T4 and its output
 VCD matches the CPU/Metal backends (cross-backend equivalence, below).
 
-### Phase 3 — (Deferred, perf) port on-GPU IO models to CUDA/HIP
+### Phase 3 — GPU peripherals on CUDA/HIP (Tier 2) → the perf path
 
-Port `gpu_apply_flash_din` / `gpu_flash_model_step` / `gpu_io_step` to
-CUDA/HIP to eliminate the per-edge CPU↔GPU round-trip from Phase 2. Pure
-throughput optimization; correctness already established by Phase 2.
+Port the GPU peripheral kernels (`gpu_apply_flash_din`,
+`gpu_flash_model_step`, `gpu_io_step`) to CUDA/HIP so peripherals run
+*inside* the batch — unlocking batched CUDA/HIP cosim and eliminating the
+per-edge PCIe round-trip. **Required for the CUDA/HIP perf story, not an
+optional optimization** (ADR 0017, Layer 3).
+
+- Because CUDA and HIP already share `kernel_v1_impl.cuh`, each peripheral is
+  **two implementations**: a shared `*_impl.cuh` (CUDA + HIP) + the existing
+  `.metal`. Define the `GpuPeripheral` seam here.
+- Equivalence-test each Tier-2 kernel against its Tier-1 CPU model.
+
+**Entry:** Phase 2 merged.
+**Exit:** `cosim --features cuda` on a GPU-peripheral fixture runs batched
+(telemetry shows `batch > 1`) with output VCD matching all backends.
+
+### Phase 4 — (Future) single-source peripherals (Tier 3, user-extensible API)
+
+A user authors a peripheral *once* (restricted-Rust subset or a small
+peripheral-FSM IR) that compiles to the CPU model + each GPU backend's
+kernel — the user-extensible peripheral API. Slots into the `GpuPeripheral`
+seam defined in Phase 3 without reworking orchestration. Big effort; demand-
+driven (first external/user-defined peripheral type).
 
 ## Testing strategy
 
 - **Reuse existing fixtures**: `tests/xprop_cosim/` (cosim mode),
   `tests/dual_uart/`, `tests/apb_trace/`, `tests/jtag_minimal/`.
-- **Cross-backend equivalence**: extend the #113 harness
-  (`scripts/ci/compare_backend_vcds.py`) to a reactive design — run the same
-  cosim on CPU and Metal (and CUDA in Phase 2) and assert byte-identical
-  output VCDs. This is the correctness backstop for the whole effort.
+- **Cross-backend equivalence** (the correctness backstop): extend the #113
+  harness (`scripts/ci/compare_backend_vcds.py`) to reactive designs — run
+  the same cosim on CPU / Metal / CUDA and assert byte-identical output VCDs;
+  the CPU `PeripheralModel` is ground truth and each Tier-2 GPU kernel must
+  match it.
+- **Bit-identical Phase 0 gate**: capture a pre-refactor golden of all
+  fixtures, re-run + `cmp` after each refactor step.
 - **Linux CI**: Phase 1 is the unlock — cosim regression coverage on free
   `ubuntu-latest` instead of the single self-hosted Metal runner.
 
 ## Risks
 
 - **Refactor drift (Phase 0):** the bit-identical-Metal exit criterion is
-  load-bearing; the equivalence test + existing checkers guard it.
-- **Flash FSM reimplementation (Phase 1):** the GPU flash kernel and the
-  `CppSpiFlash` FFI must agree. Prefer reusing `CppSpiFlash` to avoid a
-  third copy of the SPI FSM.
-- **Per-edge device-memory read (Phase 2):** reading `output_state` every
-  edge across the PCIe boundary is slow; that's the motivation for Phase 3,
-  not a correctness risk.
+  load-bearing; the equivalence test + golden `cmp` + existing checkers
+  guard it.
+- **Shared-memory ops mutation (Phase 0):** the in-place `*mut BitOp` writes
+  are the trickiest part to de-Metal; the trait's explicit upload point is
+  the fix.
+- **Flash FSM (Phase 1):** the GPU flash kernel and the `CppSpiFlash` FFI
+  must agree. Prefer reusing `CppSpiFlash` to avoid a third copy.
+- **Per-edge device read (Phase 2):** slow by design; the motivation for
+  Phase 3, not a correctness risk. Don't mistake Phase 2's throughput for
+  the CUDA/HIP perf story.
+- **Tier-2 kernel divergence (Phase 3):** three kernel families (CUDA+HIP
+  shared, Metal) per peripheral; equivalence tests against the CPU model are
+  the guard, and Tier 3 eventually removes the hand-maintenance.
 
 ## Sequencing relative to other backend-alignment work
 
@@ -181,3 +218,6 @@ throughput optimization; correctness already established by Phase 2.
 - Complements the `sim` cross-backend equivalence test (#113) and the
   proposed single-source `simulate_block_v1` macro prelude — those harden
   the `sim` compute kernel; this plan adds the cosim *driver*.
+- **CDC/island batching** (multi-clock plan MC.1→MC.4) is the long-term fix
+  for the per-edge tail of CPU-side-model designs (e.g. JTAG) — orthogonal
+  to and larger than this seam; not a prerequisite.

--- a/docs/plans/cosim-backend-portability.md
+++ b/docs/plans/cosim-backend-portability.md
@@ -24,8 +24,8 @@ peripheral models, and VCD machinery.
 - Matching Metal cosim throughput on the **CPU** path (it's a
   reference/oracle).
 - The user-extensible single-source peripheral API (Tier 3) up front — core
-  peripherals get hand-written GPU kernels first (Phase 3); the portable
-  authoring path is Phase 4.
+  peripherals get hand-written GPU kernels first (Phase 2); the portable
+  authoring path is Phase 3.
 
 ## What's already portable (no work needed)
 
@@ -52,12 +52,20 @@ peripheral models, and VCD machinery.
 /// regress it ~1000×. The orchestration decides N (`force_single_edge`);
 /// the backend runs N edges however it likes.
 trait CosimBackend {
+    /// Build native schedule storage ONCE from the backend-agnostic
+    /// description; the backend retains+owns it (opaque to orchestration).
+    fn init_schedule(&mut self, edges: Vec<(StatePrepParams, Vec<BitOp>)>);
+    /// Mutable view of one edge's ops (reset/model/clock-edge patching).
+    /// Metal: slice over the shared MTLBuffer (zero-copy; write IS upload).
+    /// CUDA/HIP: slice over host mirror, marks edge dirty (uploaded lazily).
+    fn edge_ops_mut(&mut self, edge_idx: usize) -> &mut [BitOp];
     /// output→input copy + apply that edge's BitOps + clear driven X-mask.
-    fn state_prep(&mut self, ops: &[BitOp], xmask_state_offset: u32);
-    /// Run `edges` consecutive scheduler edges, applying each edge's ops and
-    /// snapshotting each output slot into the ring. Metal: one command buffer
-    /// with GPU peripherals inside. CPU/CUDA(pre-Phase-3): per-edge loop.
-    fn run_edges(&mut self, edges: &[EdgeOps], ring: &mut Ring);
+    fn state_prep(&mut self, edge_idx: usize, xmask_state_offset: u32);
+    /// Run N consecutive scheduler edges from `start_edge`, snapshotting each
+    /// output slot into the ring. Flushes dirty edges first (no-op on Metal).
+    /// Metal: one command buffer w/ GPU peripherals inside. CPU/CUDA-fallback:
+    /// per-edge loop with CPU peripherals.
+    fn run_edges(&mut self, start_edge: usize, n: usize, ring: &mut Ring);
     /// Read-only view of the current output slot (VCD, model step_edge, drains).
     fn output_state(&self) -> &[u32];
     /// Mutable input slot (reset/constant init, flash MISO injection).
@@ -73,10 +81,15 @@ trait GpuPeripheral {
 ```
 
 `MetalSimulator` becomes the `MetalBackend` impl; `CpuBackend` and
-`Cuda`/`HipBackend` are added. The orchestration owns the neutral schedule
-(`Vec<(StatePrepParams, Vec<BitOp>)>`), the batch-size policy, and the CPU
-peripheral models; it delegates the design step + state ownership to the
-backend, and (Phase 3+) the GPU peripheral steps to `GpuPeripheral` impls.
+`Cuda`/`HipBackend` are added. **The backend owns the schedule storage** —
+the orchestration hands it the description once via `init_schedule` and keeps
+only scalars (`edges_per_period`, `gcd_ps`); it does *not* hold a parallel
+`Vec` the backend re-materialises (that would add a per-dispatch copy and
+regress Metal's zero-copy path). Mutation goes through `edge_ops_mut`
+(zero-copy on Metal; host-mirror + dirty-flag + lazy upload on CUDA/HIP). The
+orchestration owns the batch-size policy and the CPU peripheral models; it
+delegates the design step, state, and (Phase 2+) GPU peripheral steps to the
+backend.
 
 ### Why batching must be a backend concern
 
@@ -87,8 +100,9 @@ single-launch + `grid.sync` — the hardest CUDA feature to port. But
 `BATCH_SIZE` reactive edges into one command buffer because its peripherals
 run on the GPU inside the batch. On a discrete GPU, going per-command-buffer
 means a PCIe round-trip every edge, which is why batching (hence GPU
-peripherals, Phase 3) is *required* for CUDA/HIP perf, not optional. See ADR
-0017, *Layer 3* and *Consequences*.
+peripherals) is *required* for CUDA/HIP perf, not optional — so the CUDA/HIP
+backend ships *with* its GPU peripherals (Phase 2), not as a later add-on.
+See ADR 0017, *Layer 3* and *Consequences*.
 
 ## Phases
 
@@ -100,14 +114,15 @@ module split (`cosim/mod.rs` orchestration + `cosim/metal.rs`) is separable
 — the trait can land in-place in `cosim_metal.rs` first, split later. Must
 leave Metal cosim bit-identical.
 
-- Make `ScheduleBuffers` backend-neutral: store
-  `Vec<(StatePrepParams, Vec<BitOp>)>`; the backend materialises native
-  buffers (Metal buffers today). Currently holds `metal::Buffer` pairs.
-- The ops-update helpers (`update_model_driven_in_ops`,
-  `update_reset_in_ops`, `patch_model_clock_edges`) mutate the neutral
-  `Vec<BitOp>`, not Metal shared memory; the backend re-uploads. **This
-  in-place shared-memory mutation is the main refactor friction** — the
-  trait's explicit ops path is what removes it.
+- Move the schedule storage *into* `MetalBackend` (built once via
+  `init_schedule`); the orchestration keeps only `edges_per_period` + `gcd_ps`.
+  Currently `ScheduleBuffers` holds `metal::Buffer` pairs at the call site.
+- Convert the ops-update helpers (`update_model_driven_in_ops`,
+  `update_reset_in_ops`, `patch_model_clock_edges`) from in-place `*mut BitOp`
+  writes over `contents()` to `backend.edge_ops_mut(edge_idx)`. On Metal this
+  returns a slice over the same shared buffer (zero-copy, identical
+  behaviour). **This conversion is the main refactor friction** (and resolves
+  the closure-borrow issue) — but it stays zero-copy on Metal.
 - ~~Consolidate the private `simulate_block_v1` copies onto
   `cpu_reference`.~~ **Done — #115.**
 - Move the ~20 ad-hoc `simulator.device.new_buffer(...)` allocations in
@@ -137,46 +152,43 @@ leave Metal cosim bit-identical.
 **Exit:** `cargo run --bin jacquard -- cosim …` (no GPU features) runs the
 existing cosim fixtures on Linux CI and passes their checkers.
 
-### Phase 2 — Path B: `Cuda`/`HipBackend` — correctness (per-edge, CI gate)
+### Phase 2 — Path B: `Cuda`/`HipBackend` with GPU peripherals (the perf path)
 
-- Implement the backend over the existing CUDA/HIP `simulate` kernel,
-  dispatched **per-edge** (not the cooperative single launch). State lives
-  in device memory, read back per edge for `output_state()`.
-- Peripherals remain on the CPU (Tier 1, per-edge CPU↔GPU sync).
-- Gate GPU-backed cosim CI on `tesla4-runner` (now available).
+Lands the CUDA/HIP backend **and** its Tier-2 GPU peripherals together —
+*not* a per-edge-only intermediate first. Per-edge-only CUDA would be an
+unusably-slow artifact (PCIe round-trip per edge, potentially slower than
+`CpuBackend`), and Phase 1 already proves the per-edge orchestration path, so
+a separate per-edge milestone would re-validate known-good code and then
+rework the same `run_edges`/dispatch path to add batching. One phase, with an
+internal checkpoint:
 
-**This phase is a correctness/CI gate, NOT the perf path** — per-edge PCIe
-round-trips make it slow (potentially slower than `CpuBackend`); even the
-100%-batched-on-Metal fixtures run per-edge here because their peripherals
-are on the CPU. Real CUDA/HIP perf arrives in Phase 3.
+- **Checkpoint 2a — design step on GPU (per-edge correctness).** Implement the
+  backend over the existing CUDA/HIP `simulate` kernel + `init_schedule` /
+  `edge_ops_mut` (device buffers, dirty-edge upload) + device state with
+  per-edge read-back. Peripherals on the CPU (Tier 1), reusing Phase 1's
+  per-edge orchestration. Validate via cross-backend equivalence on the T4.
+  *This is the permanent fallback path*, not a throwaway — CPU-side models
+  (e.g. JTAG replay) always run here.
+- **Checkpoint 2b — Tier-2 GPU peripherals → batched.** Port the GPU
+  peripheral kernels (`gpu_apply_flash_din`, `gpu_flash_model_step`,
+  `gpu_io_step`) to CUDA/HIP so peripherals run *inside* the batch. Because
+  CUDA and HIP share `kernel_v1_impl.cuh`, each is **two impls** (shared
+  `*_impl.cuh` + the existing `.metal`). Define the `GpuPeripheral` seam here;
+  equivalence-test each kernel against its Tier-1 CPU model.
 
-**Entry:** Phase 1 merged (seam + CPU reference proven).
-**Exit:** `cosim --features cuda` runs a fixture on the T4 and its output
-VCD matches the CPU/Metal backends (cross-backend equivalence, below).
+Gate GPU-backed cosim CI on `tesla4-runner` (now available).
 
-### Phase 3 — GPU peripherals on CUDA/HIP (Tier 2) → the perf path
+**Entry:** Phase 1 merged (seam + CPU reference + per-edge orchestration proven).
+**Exit:** `cosim --features cuda` on a GPU-peripheral fixture runs **batched**
+(telemetry shows `batch > 1`), output VCD matching all backends; the per-edge
+fallback (CPU-side-model fixture, e.g. JTAG) also matches.
 
-Port the GPU peripheral kernels (`gpu_apply_flash_din`,
-`gpu_flash_model_step`, `gpu_io_step`) to CUDA/HIP so peripherals run
-*inside* the batch — unlocking batched CUDA/HIP cosim and eliminating the
-per-edge PCIe round-trip. **Required for the CUDA/HIP perf story, not an
-optional optimization** (ADR 0017, Layer 3).
-
-- Because CUDA and HIP already share `kernel_v1_impl.cuh`, each peripheral is
-  **two implementations**: a shared `*_impl.cuh` (CUDA + HIP) + the existing
-  `.metal`. Define the `GpuPeripheral` seam here.
-- Equivalence-test each Tier-2 kernel against its Tier-1 CPU model.
-
-**Entry:** Phase 2 merged.
-**Exit:** `cosim --features cuda` on a GPU-peripheral fixture runs batched
-(telemetry shows `batch > 1`) with output VCD matching all backends.
-
-### Phase 4 — (Future) single-source peripherals (Tier 3, user-extensible API)
+### Phase 3 — (Future) single-source peripherals (Tier 3, user-extensible API)
 
 A user authors a peripheral *once* (restricted-Rust subset or a small
 peripheral-FSM IR) that compiles to the CPU model + each GPU backend's
 kernel — the user-extensible peripheral API. Slots into the `GpuPeripheral`
-seam defined in Phase 3 without reworking orchestration. Big effort; demand-
+seam defined in Phase 2 without reworking orchestration. Big effort; demand-
 driven (first external/user-defined peripheral type).
 
 ## Testing strategy
@@ -203,12 +215,17 @@ driven (first external/user-defined peripheral type).
   the fix.
 - **Flash FSM (Phase 1):** the GPU flash kernel and the `CppSpiFlash` FFI
   must agree. Prefer reusing `CppSpiFlash` to avoid a third copy.
-- **Per-edge device read (Phase 2):** slow by design; the motivation for
-  Phase 3, not a correctness risk. Don't mistake Phase 2's throughput for
-  the CUDA/HIP perf story.
-- **Tier-2 kernel divergence (Phase 3):** three kernel families (CUDA+HIP
-  shared, Metal) per peripheral; equivalence tests against the CPU model are
-  the guard, and Tier 3 eventually removes the hand-maintenance.
+- **Per-edge device read (Phase 2 fallback path):** the CPU-peripheral
+  fallback reads device state every edge — slow by design, used only for
+  CPU-side models; checkpoint 2b (GPU peripherals) is what keeps the common
+  case batched. Not a correctness risk.
+- **Tier-2 kernel divergence (Phase 2 checkpoint 2b):** two kernel families
+  (CUDA+HIP shared `*_impl.cuh`, Metal `.metal`) per peripheral; equivalence
+  tests against the CPU model are the guard, and Tier 3 eventually removes the
+  hand-maintenance.
+- **Phase 2 size:** merging the backend bring-up with the GPU-peripheral
+  ports makes Phase 2 large; the internal 2a/2b checkpoint keeps it
+  incrementally verifiable (per-edge equivalence before adding batching).
 
 ## Sequencing relative to other backend-alignment work
 

--- a/docs/plans/multi-clock-and-stimulus-architecture.md
+++ b/docs/plans/multi-clock-and-stimulus-architecture.md
@@ -114,6 +114,18 @@ this doc and should not be confused with the timing-IR phase numbering in
 | **MC.5** | Record-and-replay with divergence detection | Regression CI throughput becomes a release blocker |
 | **MC.6+** | Speculation staircase, AOT trace compilation, profile-guided kernel specialization | Demand-driven; deferred until measurement shows residual sync overhead after MC.4 |
 
+**MC.3/MC.4 trigger is now measured (2026-06-07).** Instrumenting the cosim
+loop's batch utilisation (see ADR 0017 amendment, *Measured batch
+utilisation*) shows GPU-peripheral designs run 100% batched, but
+`jtag_minimal` — CPU-side JTAG replay — emits **102,310 single-edge command
+buffers out of 106,117** (96% of all submits; 2.6% of edges). Those per-edge
+CPU↔GPU round-trips dominate its wall-clock: this is the MC.3
+"round-trip measured as the bottleneck" trigger. The structural fix is
+MC.4 — the fast `sys_clk` island runs ahead/batched while only the slow
+model-driven `tck` boundary needs per-edge handover — which is why MC.4
+depends on the MC.1 island partitioner. Both are orthogonal to the #105
+backend-portability seam (which preserves today's batch model unchanged).
+
 ### MC.1 — Static island partitioner
 
 Walk the AIG; for each gate compute the set of clock domains its transitive

--- a/src/sim/cosim_metal.rs
+++ b/src/sim/cosim_metal.rs
@@ -2727,8 +2727,8 @@ pub fn run_cosim(
     }
     for (name, _tx_gpio, rx_gpio, cpb) in &uart_configs {
         if let Some(&rx_pos) = gpio_map.input_bits.get(rx_gpio) {
-            let edges_per_sys_clk = (clock_period_ps / scheduler.gcd_ps) as u32;
-            let baud_div_edges = cpb * edges_per_sys_clk;
+            let sched_ticks_per_sys_clk = (clock_period_ps / scheduler.gcd_ps) as u32;
+            let baud_div_edges = cpb * sched_ticks_per_sys_clk;
             let driver = crate::sim::models::uart::UartRxDriver::new(
                 name.clone(),
                 rx_pos,
@@ -2868,17 +2868,23 @@ pub fn run_cosim(
     // (the main loop's `tick` variable, scheduler offsets, UART decoder
     // current_cycle) advance per scheduler edge (one GCD tick).
     //
-    // edges_per_sys_clk_cycle = how many scheduler ticks per one sys_clk
-    // cycle. For single-clock that's 2 (posedge + negedge). For multi-clock
-    // it's still 2 because sys_clk always has exactly one rising + one
-    // falling edge per period regardless of other clocks in the schedule.
-    let edges_per_sys_clk_cycle = clock_period_ps / schedule_buffers.gcd_ps;
-    let reset_edges = config.reset_cycles * edges_per_sys_clk_cycle as usize;
+    // sched_ticks_per_sys_clk_cycle = how many dense scheduler ticks (each
+    // `gcd_ps` long) fall in one sys_clk period. NOT the number of sys_clk
+    // *transitions* (which is always 2). It is 2 only when `gcd_ps` equals
+    // sys_clk's half-period — i.e. single-clock, or multi-clock whose other
+    // domains' half-periods and phase offsets are all integer multiples of
+    // it. With non-commensurate periods or phase offsets, `gcd_ps` shrinks
+    // below the half-period (`MultiClockScheduler::new`, where gcd folds in
+    // every half-period and offset) and this is >2. It is the user-cycles →
+    // internal-tick conversion factor (the codebase calls GCD ticks "edges",
+    // cf. `--max-clock-edges`).
+    let sched_ticks_per_sys_clk_cycle = clock_period_ps / schedule_buffers.gcd_ps;
+    let reset_edges = config.reset_cycles * sched_ticks_per_sys_clk_cycle as usize;
     // CLI --max-clock-edges is already in edges; config `num_cycles` is in
     // sys_clk cycles and gets multiplied here.
     let max_edges = opts
         .max_clock_edges
-        .unwrap_or(config.num_cycles * edges_per_sys_clk_cycle as usize);
+        .unwrap_or(config.num_cycles * sched_ticks_per_sys_clk_cycle as usize);
 
     // ── GPU Flash IO buffers ────────────────────────────────────────────
 
@@ -3045,7 +3051,7 @@ pub fn run_cosim(
                 .copied()
                 .unwrap_or(0);
             // GPU decoder counts scheduler edges, not clock cycles
-            p.channels[i].cycles_per_bit = cpb * edges_per_sys_clk_cycle as u32;
+            p.channels[i].cycles_per_bit = cpb * sched_ticks_per_sys_clk_cycle as u32;
         }
     }
 
@@ -3338,7 +3344,7 @@ pub fn run_cosim(
         writeln!(writer, "#").unwrap();
 
         // dump_dff_cycles is user-facing (sys_clk cycles); internal counter is in edges.
-        let max_dump_edges = opts.dump_dff_cycles * edges_per_sys_clk_cycle as usize;
+        let max_dump_edges = opts.dump_dff_cycles * sched_ticks_per_sys_clk_cycle as usize;
         clilog::info!(
             "DFF dump enabled: {} DFFs, {} cycles ({} edges) → {}",
             entries.len(),

--- a/src/sim/cosim_metal.rs
+++ b/src/sim/cosim_metal.rs
@@ -3535,6 +3535,12 @@ pub fn run_cosim(
     let mut prof_stimulus_vcd: u64 = 0;
     let mut prof_output_vcd: u64 = 0;
     let mut total_batches: u64 = 0;
+    // Batch-utilisation telemetry: how often the GPU-only batched fast path
+    // (batch>1) is exercised vs. forced single-edge dispatch. Informs the
+    // cosim-backend seam design (#105): edges run under batch=1 are the only
+    // ones that need a true per-edge CPU↔GPU handover.
+    let mut single_edge_batches: u64 = 0;
+    let mut max_batch_seen: usize = 0;
 
     // Per-tick tracing: run 1 tick at a time for first N ticks after reset
     let trace_ticks = if std::env::var("FLASH_TRACE").is_ok() {
@@ -4351,6 +4357,12 @@ pub fn run_cosim(
         prof_drain += t_drain.elapsed().as_nanos() as u64;
 
         total_batches += 1;
+        if batch == 1 {
+            single_edge_batches += 1;
+        }
+        if batch > max_batch_seen {
+            max_batch_seen = batch;
+        }
         tick += batch;
 
         // SRAM write dumper: snapshot per batch and accumulate
@@ -4537,6 +4549,19 @@ pub fn run_cosim(
     );
     println!();
     println!("  Total batches:                 {}", total_batches);
+    let total_edges = tick.max(1);
+    let batched_edges = total_edges.saturating_sub(single_edge_batches as usize);
+    let mean_batch = total_edges as f64 / total_batches.max(1) as f64;
+    println!(
+        "  Batch utilisation:             {}/{} edges batched ({:.1}%), \
+         {} single-edge commits, mean batch={:.1}, max batch={}",
+        batched_edges,
+        total_edges,
+        100.0 * batched_edges as f64 / total_edges as f64,
+        single_edge_batches,
+        mean_batch,
+        max_batch_seen,
+    );
 
     let sim_elapsed = sim_start.elapsed();
     clilog::finish!(timer_sim);


### PR DESCRIPTION
## Why

Before extracting the `CosimBackend` seam (#105 Phase 0), measure how the
cosim loop actually dispatches — specifically how often the GPU-only
batched fast path is used vs. forced single-edge (per-edge CPU↔GPU
handover). The answer reshapes the seam design.

## What

- **Telemetry** in the cosim run summary: single-edge commits, mean/max
  batch, % edges batched. Two `u64`/`usize` counters in the dispatch loop
  + one summary line. Behaviour-preserving — all 7 Metal cosim fixtures
  stay byte-identical (verified against a pre-change golden).
- **Doc findings** in ADR 0017 (amendment), the cosim-backend-portability
  plan, and the multi-clock plan.

## Measurements (this machine)

| Fixture | Edges | Batched (edges) | Single-edge commits | Total commits |
|---|---|---|---|---|
| dual_uart | 10,000 | 100% | 0 | 11 |
| apb_trace | 200 | 100% | 0 | 2 |
| xprop_cosim | 40 | 100% | 0 | 2 |
| jtag_minimal | 4,000,000 | 97.4% | 102,310 | 106,117 |

## Findings recorded

1. **The seam must be batch-capable, not naive per-edge.** Designs with
   GPU-side peripherals run 100% batched; Metal encodes up to `BATCH_SIZE`
   edges + GPU peripheral kernels + ring drain into one command buffer. A
   literal `simulate_edge`-per-edge trait would regress Metal ~1000×.
   Refines ADR 0017's "per-edge on every backend" framing; the batch model
   itself is unchanged (still a non-goal).
2. **JTAG's single-edge tail is the measured MC.3 trigger.** 102k
   single-edge commits (96% of submits, 2.6% of edges) dominate JTAG's
   wall-clock — the "CPU↔GPU round-trip measured as the bottleneck"
   trigger, and the motivation for MC.4 (per-island multi-rate batching).
   Both orthogonal to and larger than the #105 seam.

## Not in this PR

The seam refactor itself (Phase 0b/0c) is intentionally deferred — this
PR records the design corrections first. Telemetry is kept as useful
ongoing signal (it's the MC.3 bottleneck metric).