### PR TITLE
fix(gf180): classify ID-stub and SRAM IP macros for cosim

### DIFF
--- a/src/gf180mcu.rs
+++ b/src/gf180mcu.rs
@@ -49,6 +49,13 @@ const GF180MCU_WS_PREFIX: &str = "gf180mcu_ws_";
 const SC_7T_PREFIX: &str = "gf180mcu_fd_sc_mcu7t5v0__";
 const SC_9T_PREFIX: &str = "gf180mcu_fd_sc_mcu9t5v0__";
 
+/// Prefix for the foundry SRAM IP macros (`gf180mcu_fd_ip_sram__sram512x8m8wm1`
+/// and friends). These are compiled hard macros, not standard cells — they
+/// have no `.functional.v` in the standard-cell submodule and are modelled
+/// as RAM blocks via the runtime `--cell-library` (ADR 0010 / 0011), so they
+/// must NOT route through the standard-cell decompose path.
+const IP_SRAM_PREFIX: &str = "gf180mcu_fd_ip_sram__";
+
 /// Prefixes for non-standard-cell families whose macro name *is* the
 /// base cell type (no drive-strength suffix). Strip these in
 /// [`extract_cell_type`] so [`crate::gf180mcu_pdk`]'s classifiers can
@@ -65,6 +72,18 @@ const NON_SC_PREFIXES: &[&str] = &[
 /// or wafer.space variant (`gf180mcu_ws_*`)?
 pub fn is_gf180mcu_cell(name: &str) -> bool {
     name.starts_with(GF180MCU_FD_PREFIX) || name.starts_with(GF180MCU_WS_PREFIX)
+}
+
+/// Is `name` a foundry SRAM IP macro (`gf180mcu_fd_ip_sram__*`)?
+///
+/// These are compiled hard macros with no standard-cell `.functional.v`;
+/// they are modelled as RAM blocks via the runtime `--cell-library`. They
+/// satisfy [`is_gf180mcu_cell`] (so the netlist parser accepts them and the
+/// library is detected as GF180MCU) but are excluded from the standard-cell
+/// decompose dispatch in [`crate::pdk::PdkVariant::classify`] so they reach
+/// the cell-library RAM path instead of the std-cell functional.v lookup.
+pub fn is_sram_macro(name: &str) -> bool {
+    name.starts_with(IP_SRAM_PREFIX)
 }
 
 /// Strip the GF180MCU library prefix and the trailing drive-strength
@@ -261,6 +280,20 @@ mod tests {
         assert!(is_gf180mcu_cell("gf180mcu_fd_io__bi_24t"));
         assert!(is_gf180mcu_cell("gf180mcu_fd_pr__nmos_3p3"));
         assert!(is_gf180mcu_cell("gf180mcu_fd_ip_sram__sram64x16m8wm1"));
+    }
+
+    #[test]
+    fn detects_sram_macros() {
+        // SRAM IP macros are GF180MCU cells but are also flagged as SRAM
+        // macros, so they bypass the std-cell decompose path (no
+        // functional.v) and route to the cell-library RAM model.
+        assert!(is_sram_macro("gf180mcu_fd_ip_sram__sram512x8m8wm1"));
+        assert!(is_sram_macro("gf180mcu_fd_ip_sram__sram256x8m8wm1"));
+        assert!(is_sram_macro("gf180mcu_fd_ip_sram__sram64x16m8wm1"));
+        // Standard cells / pads / primitives are not SRAM macros.
+        assert!(!is_sram_macro("gf180mcu_fd_sc_mcu7t5v0__nand2_1"));
+        assert!(!is_sram_macro("gf180mcu_fd_io__bi_24t"));
+        assert!(!is_sram_macro("sky130_fd_sc_hd__inv_2"));
     }
 
     #[test]

--- a/src/gf180mcu_pdk.rs
+++ b/src/gf180mcu_pdk.rs
@@ -359,8 +359,13 @@ pub fn is_filler_cell(cell_type: &str) -> bool {
         | "asig_5p0"
         // wafer.space power pads.
         | "dvdd" | "dvss"
-        // wafer.space empty IP stubs (id / logo are `module X; endmodule`).
+        // wafer.space empty IP stubs (`module X; endmodule`, no ports — pure
+        // layout die-marks contributing no logic). The pre-1.5.0 single `id`
+        // cell was split into four ID domains in project-template 1.5.0
+        // (marker / shuttle_id / project_id / qrcode_id); `id` is kept for
+        // pre-1.5.0 netlists.
         | "id" | "logo"
+        | "marker" | "shuttle_id" | "project_id" | "qrcode_id"
     )
 }
 
@@ -484,6 +489,11 @@ mod tests {
         assert!(is_filler_cell("dvss"));
         assert!(is_filler_cell("id"));
         assert!(is_filler_cell("logo"));
+        // Post-1.5.0 four-way ID split (replaces the single `id`).
+        assert!(is_filler_cell("marker"));
+        assert!(is_filler_cell("shuttle_id"));
+        assert!(is_filler_cell("project_id"));
+        assert!(is_filler_cell("qrcode_id"));
         // Negatives.
         assert!(!is_filler_cell("hold"));
         assert!(!is_filler_cell("buf"));

--- a/src/pdk.rs
+++ b/src/pdk.rs
@@ -170,6 +170,16 @@ impl PdkVariant {
     pub fn classify(celltype: &str) -> Option<PdkVariant> {
         if is_sky130_cell(celltype) {
             Some(PdkVariant::Sky130)
+        } else if crate::gf180mcu::is_sram_macro(celltype) {
+            // SRAM IP macros (`gf180mcu_fd_ip_sram__*`) are compiled hard
+            // macros, not standard cells: they have no `.functional.v` and
+            // are modelled as RAM blocks via the runtime `--cell-library`
+            // (ADR 0010 / 0011). Return `None` so they fall through the
+            // std-cell decompose dispatch to the cell-library RAM path,
+            // instead of panicking in `load_pdk_models`'s functional.v
+            // lookup. They still satisfy `is_gf180mcu_cell`, so
+            // `detect_library` keeps reporting GF180MCU (not Mixed).
+            None
         } else if is_gf180mcu_cell(celltype) {
             Some(PdkVariant::Gf180Mcu)
         } else {
@@ -302,6 +312,21 @@ mod tests {
         );
         assert_eq!(PdkVariant::classify("AND2_00_0"), None);
         assert_eq!(PdkVariant::classify("DFF"), None);
+        // SRAM IP macros are GF180MCU cells (parser-accepted, GF180MCU-
+        // detected) but classify as `None` so they route to the
+        // cell-library RAM path rather than the std-cell functional.v
+        // decompose (which has no model for them — would panic).
+        assert!(crate::gf180mcu::is_gf180mcu_cell(
+            "gf180mcu_fd_ip_sram__sram512x8m8wm1"
+        ));
+        assert_eq!(
+            PdkVariant::classify("gf180mcu_fd_ip_sram__sram512x8m8wm1"),
+            None
+        );
+        assert_eq!(
+            PdkVariant::classify("gf180mcu_fd_ip_sram__sram256x8m8wm1"),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Two surgical fixes so `jacquard cosim` runs on a real post-P&R **GF180MCU**
chip-top netlist (one that includes the project-template's shuttle-ID stub IPs
and the foundry SRAM IP macros). Both are GF180 cell-classification gaps:

1. **ID-stub filler cells.** The gf180mcu project-template split its single
   `gf180mcu_ws_ip__id` stub into four ID domains
   (`marker` / `shuttle_id` / `project_id` / `qrcode_id`). These remain
   port-less `(* blackbox *) module X; endmodule` GDS-only IPs, but
   `is_filler_cell` only knew the older `id`/`logo`, so cosim panicked on
   `marker`. Added the four names (kept `id`/`logo` for older netlists).

2. **SRAM IP macros.** `gf180mcu_fd_ip_sram__*` are compiled hard macros with no
   `.functional.v`; they're modelled as RAM blocks via the runtime
   `--cell-library` (manifest `kind = "ram"`). But they match the `gf180mcu_fd_`
   prefix, so `PdkVariant::classify` routed them to the standard-cell decompose
   path and panicked in `load_pdk_models`. `classify`'s own docs already said it
   *"Returns None ... if the cell is an SRAM macro"* — the exclusion was
   documented but never implemented. Added an `is_sram_macro()` predicate and
   return `None`, so they reach the existing cell-library RAM path. They still
   satisfy `is_gf180mcu_cell`, so `detect_library` keeps reporting GF180MCU.

## Why

`jacquard cosim` previously panicked during setup on any post-P&R GF180MCU
chip-top carrying these IPs (ID stubs + SRAM macros), so the GF180 cosim path
couldn't run end-to-end.

## Verification

- `cargo build --release --features metal --bin jacquard` clean.
- `cargo test --lib --features metal` green, incl. new `is_sram_macro` /
  `classify` / filler assertions.
- `jacquard cosim` on a real post-P&R GF180MCU chip-top now runs clean: SRAM
  modelled as RAM (`sram size 131072`), JTAG firmware load replays, UART
  decodes `Hello, world!`, `SIMULATION: PASSED`. No panic.

The RAM-construction machinery (opaque `kind=ram` + explicit-port paths) was
untouched — the fix only stops the SRAM/ID macros from being mis-routed before
they reach it.
