### PR TITLE
ci: skip the matrix on docs-only pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,14 @@ name: CI
 on:
   push:
     branches: [main, staged-aig-release]
+    # Docs-only pushes (e.g. handoff updates pushed straight to main) skip the
+    # full matrix — a push is ignored only when ALL changed files match. NOT
+    # applied to `pull_request` on purpose: the matrix jobs are required status
+    # checks, so a paths-ignored docs PR would never report them and could
+    # never merge (GitHub's required-checks-never-run deadlock).
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   # No base-branch filter: run CI on every PR regardless of its base, so
   # stacked PRs (based on other feature branches) get CI automatically.
   pull_request:


### PR DESCRIPTION
Adds `paths-ignore: [docs/**, **/*.md]` to the **push** trigger so docs/handoff updates pushed straight to `main` skip the full billed matrix (a push is ignored only when *all* changed files match, so mixed code+docs pushes still run).

**Deliberately not on `pull_request`:** the matrix jobs are required status checks, so a paths-ignored docs PR would never report them and could never merge (GitHub's required-checks-never-run deadlock). Docs PRs keep running CI and stay mergeable.

Motivation: the Stage-C handoff updates this session each triggered a full matrix on `main` for a markdown-only change, and forced an admin-bypass when a docs commit became a PR head with no checks. This makes docs-only pushes to `main` free.

`actionlint` clean (no new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)