### PR TITLE
perf(cosim/cuda): CUDA Graphs for the per-edge launch chain (#122)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -62,7 +62,10 @@ fn main() {
             .debug(false)
             .opt_level(3)
             .include(&csrc_headers)
-            .files(["csrc/kernel_v1.cu"]);
+            // cosim_cuda_graph.cu: CUDA Graphs capture/replay for the cosim
+            // per-edge launch chain (#122). The cosim launchers in kernel_v1.cu
+            // target cudaStreamPerThread explicitly so they are capturable.
+            .files(["csrc/kernel_v1.cu", "csrc/cosim_cuda_graph.cu"]);
         cl_cuda.compile("gemcu");
         println!("cargo:rustc-link-lib=static=gemcu");
         println!("cargo:rustc-link-lib=dylib=cudart");

--- a/csrc/cosim_cuda_graph.cu
+++ b/csrc/cosim_cuda_graph.cu
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// CUDA Graphs capture/replay helpers for the cosim per-edge launch chain.
+//
+// The cosim CUDA backend issues a long sequence of tiny, strictly-dependent
+// kernel launches per scheduler edge (state_prep -> apply_flash_din ->
+// simulate_stage x N -> flash_model_step -> io_step -> snapshot). ncu on the T4
+// (#122) showed cosim_simulate_stage is latency / under-utilisation bound
+// (Waves/SM 0.80, SM throughput 7.9%): the grid underfills the GPU and the
+// kernel chain is dominated by per-launch overhead, not work. Capturing the
+// repeating chain into a cudaGraph and replaying it removes per-launch host
+// submission cost and lets the driver schedule the dependent chain back to back.
+//
+// The cosim launchers in kernel_v1.cu issue on cudaStreamPerThread explicitly
+// (each `<<<g, b, 0, cudaStreamPerThread>>>` plus the `cudaMemcpyAsync(...,
+// cudaStreamPerThread)` snapshot), so we capture exactly that stream here.
+//
+// These helpers take no UVec arguments, so they are intentionally NOT run
+// through ucc::bindgen (whose convention maps pointer args to UVecs and appends
+// a Device arg). The Rust side declares them via a hand-written `extern "C"`
+// block (src/sim/cosim/cuda.rs).
+
+#include <cstdio>
+#include <cstdlib>
+#include <cuda_runtime.h>
+
+// Mirrors the macro in csrc/kernel_v1.cu — extract to a shared csrc header if a
+// third CUDA TU ever needs it.
+#define checkCudaErrors(call)                                 \
+  do {                                                        \
+    cudaError_t err = call;                                   \
+    if (err != cudaSuccess) {                                 \
+      printf("CUDA error at %s %d: %s\n", __FILE__, __LINE__, \
+             cudaGetErrorString(err));                        \
+      exit(EXIT_FAILURE);                                     \
+    }                                                         \
+  } while (0)
+
+extern "C" {
+
+// Begin capturing cudaStreamPerThread. Subsequent cosim launches (which target
+// that stream explicitly) are recorded into the graph instead of executed.
+void cosim_graph_begin_capture() {
+  checkCudaErrors(cudaStreamBeginCapture(
+      cudaStreamPerThread, cudaStreamCaptureModeThreadLocal));
+}
+
+// End capture, instantiate the captured graph into an executable graph, and
+// return it as an opaque handle. The intermediate cudaGraph_t is destroyed; the
+// caller owns the returned cudaGraphExec_t and frees it via
+// cosim_graph_exec_destroy.
+void *cosim_graph_end_capture() {
+  cudaGraph_t graph = nullptr;
+  checkCudaErrors(cudaStreamEndCapture(cudaStreamPerThread, &graph));
+  cudaGraphExec_t exec = nullptr;
+  // CUDA 12 three-argument form: (pGraphExec, graph, flags).
+  checkCudaErrors(cudaGraphInstantiate(&exec, graph, 0));
+  checkCudaErrors(cudaGraphDestroy(graph));
+  return (void *)exec;
+}
+
+// Enqueue a previously-instantiated graph on cudaStreamPerThread. The caller
+// (run_edges) issues a single end-of-batch device synchronize, so this does not
+// block here.
+void cosim_graph_launch(void *exec) {
+  checkCudaErrors(cudaGraphLaunch((cudaGraphExec_t)exec, cudaStreamPerThread));
+}
+
+void cosim_graph_exec_destroy(void *exec) {
+  if (exec) checkCudaErrors(cudaGraphExecDestroy((cudaGraphExec_t)exec));
+}
+
+}  // extern "C"

--- a/csrc/kernel_v1.cu
+++ b/csrc/kernel_v1.cu
@@ -79,6 +79,10 @@ void simulate_v1_noninteractive_timed_cuda(
 
 // ── cosim launchers (non-cooperative; #105 Phase 2) ──────────────────────────
 // Ordinary launches (no cooperative grid.sync); the host loops major stages.
+// All cosim launches below target cudaStreamPerThread explicitly so the per-edge
+// chain is capturable into a CUDA graph (csrc/cosim_cuda_graph.cu, #122
+// launch-overhead work). The `sim` cooperative launchers above are untouched —
+// they keep the legacy default stream.
 
 extern "C"
 void cosim_state_prep_cuda(
@@ -89,7 +93,8 @@ void cosim_state_prep_cuda(
   const u32 *ops
   )
 {
-  cosim_state_prep<<<1, 256>>>(states, state_size, num_ops, xmask_state_offset, ops);
+  cosim_state_prep<<<1, 256, 0, cudaStreamPerThread>>>(
+    states, state_size, num_ops, xmask_state_offset, ops);
   checkCudaErrors(cudaGetLastError());
 }
 
@@ -108,7 +113,7 @@ void cosim_simulate_stage_cuda(
   i32 arrival_state_offset
   )
 {
-  cosim_simulate_stage<<<(unsigned int)num_blocks, 256>>>(
+  cosim_simulate_stage<<<(unsigned int)num_blocks, 256, 0, cudaStreamPerThread>>>(
     num_blocks, blocks_start, blocks_data, sram_data, sram_xmask,
     state_size, states, current_stage,
     timing_constraints, (EventBuffer *)event_buffer, arrival_state_offset);
@@ -116,8 +121,8 @@ void cosim_simulate_stage_cuda(
 }
 
 // gpu_io_step launcher (Stage B): UART + bus-trace capture for one edge. Single
-// block, thread-0 work like the Metal encode_io_step. Default-stream ordered
-// after this edge's cosim_simulate_stage launches.
+// block, thread-0 work like the Metal encode_io_step. On cudaStreamPerThread,
+// ordered after this edge's cosim_simulate_stage launches.
 // IO struct buffers cross FFI as untyped u8 (the proven event_buffer pattern):
 // ulib `UVec<T>` requires `T: UniversalCopy`, which the IO structs are not, so
 // the Rust side passes `UVec<u8>` byte buffers and the launcher casts to the
@@ -134,7 +139,7 @@ void gpu_io_step_cuda(
   const u8 *bus_params
   )
 {
-  gpu_io_step<<<1, 256>>>(
+  gpu_io_step<<<1, 256, 0, cudaStreamPerThread>>>(
     states,
     (UartDecoderState *)uart_state,
     (const UartParams *)uart_params,
@@ -157,7 +162,7 @@ void gpu_apply_flash_din_cuda(
   const u8 *flash_din_params
   )
 {
-  gpu_apply_flash_din<<<1, 256>>>(
+  gpu_apply_flash_din<<<1, 256, 0, cudaStreamPerThread>>>(
     states,
     (const FlashState *)flash_state,
     (const FlashDinParams *)flash_din_params);
@@ -176,7 +181,7 @@ void gpu_flash_model_step_cuda(
   const u8 *flash_data
   )
 {
-  gpu_flash_model_step<<<1, 256>>>(
+  gpu_flash_model_step<<<1, 256, 0, cudaStreamPerThread>>>(
     states,
     (FlashState *)flash_state,
     (const FlashModelParams *)flash_model_params,
@@ -188,8 +193,8 @@ void gpu_flash_model_step_cuda(
 // (`two_slot_words` = 2*state_size u32s) into ring slot `edge_offset`, so each
 // batched edge's [input|output] snapshot survives the next edge overwriting
 // `states`. The CUDA analog of Metal's per-edge blit (cosim/metal.rs blit copy).
-// Default-stream (stream 0) ordered with the kernel launches; the host syncs
-// once at end-of-batch.
+// On cudaStreamPerThread, ordered with the kernel launches (and captured into
+// the same graph); the host syncs once at end-of-batch.
 extern "C"
 void cosim_snapshot_cuda(
   const u32 *states,
@@ -203,5 +208,5 @@ void cosim_snapshot_cuda(
     states,
     two_slot_words * sizeof(u32),
     cudaMemcpyDeviceToDevice,
-    0));
+    cudaStreamPerThread));
 }

--- a/src/sim/cosim/cuda.rs
+++ b/src/sim/cosim/cuda.rs
@@ -62,6 +62,18 @@ mod ucci {
 /// The CUDA device this backend runs on. Single-GPU like `sim_cuda`.
 const DEVICE: Device = Device::CUDA(0);
 
+// CUDA Graphs capture/replay helpers (csrc/cosim_cuda_graph.cu). Declared by
+// hand rather than via ucc::bindgen: they take no UVec arguments, so the
+// bindgen convention (map pointers -> UVec, append a Device arg) does not apply.
+// The cosim launchers in kernel_v1.cu target cudaStreamPerThread explicitly, so
+// the per-edge chain records on that stream, which these capture and replay.
+extern "C" {
+    fn cosim_graph_begin_capture();
+    fn cosim_graph_end_capture() -> *mut std::ffi::c_void;
+    fn cosim_graph_launch(exec: *mut std::ffi::c_void);
+    fn cosim_graph_exec_destroy(exec: *mut std::ffi::c_void);
+}
+
 /// CUDA cosim backend — design step + GPU UART/bus peripherals (Stage B).
 struct CudaBackend {
     /// Full design state `[input_state | output_state]`, `2 × state_size`
@@ -137,6 +149,11 @@ struct CudaBackend {
     /// until `enable_vcd_ring`.
     vcd_ring: UnsafeCell<Option<Vec<Vec<u32>>>>,
     enable_vcd: bool,
+    /// False until the first `run_edges` batch has run eagerly. The first batch
+    /// runs eager to materialise every device buffer (a lazy H2D inside a CUDA
+    /// graph capture is illegal); subsequent batches capture + replay the
+    /// per-edge launch chain as a graph. See `run_edges`.
+    graph_warmed: UnsafeCell<bool>,
 }
 
 impl CudaBackend {
@@ -362,6 +379,7 @@ impl CosimBackend for CudaBackend {
             vcd_ring_dev: UnsafeCell::new(UVec::default()),
             vcd_ring: UnsafeCell::new(None),
             enable_vcd: false,
+            graph_warmed: UnsafeCell::new(false),
         };
         (backend, bus_lanes)
     }
@@ -531,15 +549,18 @@ impl CosimBackend for CudaBackend {
         let xmask_off = self.xmask_state_offset as u32;
 
         // Grow the VCD device ring to hold this batch's per-edge snapshots.
+        // Done BEFORE capture — buffer allocation is not legal inside a graph
+        // capture region.
         if self.enable_vcd && vcd_dev.len() < batch * two_slot {
             *vcd_dev = UVec::<u32>::new_zeroed(batch * two_slot, DEVICE);
         }
 
+        // Pre-flush any dirty per-edge ops to the device BEFORE capture: the H2D
+        // upload + UVec (re)allocation are not capture-legal, and a captured
+        // graph would otherwise bake a since-freed ops pointer. Dirty only right
+        // after a reset/model patch (all edges on the first batch); ~zero after.
         for e in 0..batch {
             let sched_idx = (schedule_offset + e) % self.edges_per_period;
-
-            // (Re)upload this edge's ops to the device only if dirty — a
-            // one-time cost after the reset patch, so the batch stays async.
             if ops_dirty[sched_idx] {
                 let ops = &self.schedule[sched_idx];
                 // SAFETY: BitOp is #[repr(C)] of two u32 fields → 2*len u32s.
@@ -552,6 +573,26 @@ impl CosimBackend for CudaBackend {
                 ops_uvecs[sched_idx] = u;
                 ops_dirty[sched_idx] = false;
             }
+        }
+
+        // The first batch runs eagerly to materialise every device buffer (a
+        // lazy H2D would be illegal inside a capture); subsequent batches capture
+        // the structurally-identical per-edge launch chain into a CUDA graph and
+        // replay it, removing per-launch host overhead (the #122 latency /
+        // under-utilisation finding). The launches below target cudaStreamPerThread
+        // (kernel_v1.cu), exactly the stream captured here.
+        //
+        // `capture` is false on the first batch (warmup) and true thereafter:
+        // fetch-and-set graph_warmed in one step.
+        // SAFETY: sequential dispatch; sole accessor of graph_warmed.
+        let capture = unsafe { std::mem::replace(&mut *self.graph_warmed.get(), true) };
+        if capture {
+            // SAFETY: FFI to csrc/cosim_cuda_graph.cu; balanced by end_capture.
+            unsafe { cosim_graph_begin_capture() };
+        }
+
+        for e in 0..batch {
+            let sched_idx = (schedule_offset + e) % self.edges_per_period;
             let num_ops = self.schedule[sched_idx].len() as u32;
 
             // ── GPU state_prep ─────────────────────────────────────────────
@@ -625,7 +666,23 @@ impl CosimBackend for CudaBackend {
             }
         }
 
-        // Single end-of-batch barrier (mirrors Metal's one signal/commit).
+        if capture {
+            // End capture -> instantiate -> replay -> free. No-cache (instantiate
+            // per batch): correct by construction, the graph always reflects the
+            // current pointers/offsets. Caching keyed on (batch, phase) is the
+            // follow-up if instantiate cost proves material.
+            // SAFETY: FFI; `exec` is freshly instantiated here and freed after
+            // the single replay below.
+            let exec = unsafe { cosim_graph_end_capture() };
+            unsafe {
+                cosim_graph_launch(exec);
+                cosim_graph_exec_destroy(exec);
+            }
+        }
+
+        // Single end-of-batch barrier (mirrors Metal's one signal/commit) — the
+        // only synchronize for both the eager warmup batch and the captured
+        // replay (cosim_graph_launch only enqueues, it does not block).
         DEVICE.synchronize();
 
         // Read the device ring back once (D2H) and slice into per-edge host

--- a/src/sim/cosim/cuda.rs
+++ b/src/sim/cosim/cuda.rs
@@ -575,7 +575,26 @@ impl CosimBackend for CudaBackend {
             }
         }
 
-        // The first batch runs eagerly to materialise every device buffer (a
+        // Force-materialise every mutable device buffer the captured loop touches
+        // BEFORE capture: a lazy H2D inside a graph capture region is illegal, and
+        // buffers get re-dirtied on the host between batches (e.g. `flash_state`
+        // via `flash_set_in_reset`, design state on reset). `as_mut_uptr` flushes
+        // any pending upload here and is a no-op once resident. The const-param
+        // buffers (blocks/flash params/firmware) are never host-dirtied after
+        // construction, so the first (eager) batch materialises them for good.
+        state.as_mut_uptr(DEVICE);
+        sram.as_mut_uptr(DEVICE);
+        sram_xmask.as_mut_uptr(DEVICE);
+        flash_state.as_mut_uptr(DEVICE);
+        uart_state.as_mut_uptr(DEVICE);
+        uart_channel.as_mut_uptr(DEVICE);
+        wb_channel.as_mut_uptr(DEVICE);
+        bus_channel.as_mut_uptr(DEVICE);
+        if self.enable_vcd {
+            vcd_dev.as_mut_uptr(DEVICE);
+        }
+
+        // The first batch runs eagerly to materialise the const-param buffers (a
         // lazy H2D would be illegal inside a capture); subsequent batches capture
         // the structurally-identical per-edge launch chain into a CUDA graph and
         // replay it, removing per-launch host overhead (the #122 latency /


### PR DESCRIPTION
## Why

ncu on the T4 (#122) found `cosim_simulate_stage` is **latency / under-utilisation bound**, not compute- or memory-bound:

| Metric | Value |
|---|---|
| Compute (SM) Throughput | 7.9% |
| Memory Throughput | 11.7% |
| **Waves Per SM** | **0.80** (< 1 → grid doesn't fill the GPU once) |

The per-edge work is a strictly-sequential chain of tiny kernels — `state_prep → apply_flash_din → simulate_stage×N → flash_model_step → io_step → snapshot` — each under-filling the 40-SM T4. The cost is dominated by **per-launch overhead**, not work. (The handoff's "cross-edge stage batching" lever is blocked by the strict edge→edge data dependency; the valid lever is cutting launch overhead.)

## What

Capture the repeating per-edge launch chain into a **cudaGraph** and replay it — removes per-launch host submission cost and lets the driver schedule the dependent chain back-to-back.

- **`csrc/cosim_cuda_graph.cu`** (new): thin capture/replay FFI over `cudaStreamPerThread` (`begin_capture` / `end_capture`+instantiate / `launch` / `exec_destroy`). Hand-declared in `cuda.rs` (no UVec args → not `ucc::bindgen`'d).
- **`kernel_v1.cu`**: cosim launchers now target `cudaStreamPerThread` **explicitly** (`<<<g,b,0,cudaStreamPerThread>>>` + the snapshot `cudaMemcpyAsync`) so the chain is capturable. The **`sim` cooperative path is untouched** (legacy default stream) — no global `--default-stream` flag, no `sim`-semantics change.
- **`cuda.rs` `run_edges`**: hoist the dirty-ops H2D pre-flush + VCD-ring grow out of the captured region (alloc / blocking copy aren't capture-legal). **First batch runs eager** to materialise all device buffers (a lazy H2D inside capture is illegal); subsequent batches capture + replay.

## Scope / caveats

- **First cut: no cross-batch graph caching** — instantiate per batch (correct by construction). Caching keyed on `(batch, phase)` is the follow-up if instantiate cost proves material.
- **CUDA/T4-only**; HIP stays on the eager path (no AMD runner to measure).
- Follow-up noted: a shared CUDA/HIP graph seam once a HIP runner exists.

## Verification

- **Correctness**: the existing `cuda` PR-CI job byte-diffs CUDA cosim flash (mcu_soc) + UART/bus against committed goldens (`cosim_cpu_check.sh`) — the exact design the profiler uses. `sim` in the same job catches any per-thread-stream regression.
- **Speedup**: measured with `scripts/ci/cuda_cosim_profile.sh` via `cuda-cosim-profile.yml` (workflow_dispatch). Baseline ~64 µs/edge, Waves/SM 0.80. A win raises Waves/SM-effective throughput and lowers µs/edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)