### PR TITLE
fix(partition): drop empty partitions before flatten (panic hardening)

### DIFF
--- a/src/sim/setup.rs
+++ b/src/sim/setup.rs
@@ -621,7 +621,7 @@ fn generate_partitions(
 
             let (parts_indices_good, prebuilt): (Vec<_>, Vec<_>) =
                 parts_good.into_iter().unzip();
-            let effective_parts = process_partitions(
+            let mut effective_parts = process_partitions(
                 aig,
                 staged,
                 parts_indices_good,
@@ -629,6 +629,16 @@ fn generate_partitions(
                 max_stage_degrad,
             )
             .unwrap();
+            // Drop any empty (zero-boomerang-stage) partition before it reaches
+            // the flattener. mt-kahypar can leave a requested part-id with no
+            // vertices when the part count is high relative to the graph's
+            // structure; such a partition realizes no endpoints (no work), but
+            // `FlattenedScriptV1::from` indexes `part.stages[0]` unconditionally
+            // (flatten.rs) and panics with "index out of bounds: len is 0" on it.
+            // Dropping them is correctness-neutral and hardens the partition →
+            // flatten boundary for any high-part-count path (finer partitioning,
+            // large `--num-blocks`).
+            effective_parts.retain(|p| !p.stages.is_empty());
             clilog::info!("after merging: {} parts.", effective_parts.len());
             effective_parts
         })


### PR DESCRIPTION
## Problem

`FlattenedScriptV1::from` indexes `part.stages[0]` unconditionally (`flatten.rs:908`), so a partition with **zero boomerang stages** panics:

```
thread '<unnamed>' panicked at src/flatten.rs:908:33:
index out of bounds: the len is 0 but the index is 0
```

mt-kahypar can leave a requested part-id with **no vertices** when the partition count is high relative to the graph's structure — reachable via finer partitioning or a large `--num-blocks` (> #partitions). Such a partition realizes no endpoints (does no work).

## Fix

Filter zero-stage partitions in `generate_partitions` after merging. Correctness-neutral (empty partitions do nothing) and hardens the partition → flatten boundary for any high-part-count path.

## Verification

- **Repro:** forcing ~80+ working partitions on `mcu_soc` panicked deterministically at `flatten.rs:908`; with the fix it flattens + runs cleanly.
- **No production regression:** `mcu_soc` cosim still partitions to 8 parts and builds its script identically (the `retain` is a no-op when no empty partitions exist — the common case).

Surfaced while measuring CUDA cosim occupancy (#122).

🤖 Generated with [Claude Code](https://claude.com/claude-code)