### PR TITLE
fix(dist): ship a working Metal binary — embed sim metallib, fix release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@ name: Release
 # Builds prebuilt binaries and attaches them to a GitHub Release.
 # See ADR 0018 and docs/plans/distribution.md.
 #
-# - Tagging `v<X.Y.Z>` builds + publishes a DRAFT release (you review the
-#   assets, then click Publish).
+# - Tagging `v<X.Y.Z>` builds, smoke-tests, and publishes the release with the
+#   macOS/Metal binary attached (or attaches it to an existing release of that
+#   tag). Notes come from the matching CHANGELOG section.
 # - `workflow_dispatch` is a dry-run: it builds, packages, smoke-tests,
 #   and uploads the tarball as a workflow artifact — no release created.
 #
@@ -116,20 +117,23 @@ jobs:
             echo "AUTO=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish draft release
+      - name: Publish release + attach binary
         if: steps.meta.outputs.is_release == 'true'
-        run: |
-          set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
-          args=(--draft --title "$tag" --repo "$GITHUB_REPOSITORY")
-          if [ "${{ steps.notes.outputs.AUTO }}" = "true" ]; then
-            args+=(--generate-notes)
-          else
-            args+=(--notes-file notes.md)
-          fi
-          gh release create "$tag" "${args[@]}" \
-            "${{ steps.package.outputs.tarball }}" \
-            "${{ steps.package.outputs.sha }}"
+        # softprops uses GITHUB_TOKEN via the API — no `gh` CLI, which isn't on
+        # PATH on the self-hosted macos-runner-1 (the old `gh release create`
+        # died with "gh: command not found", so v0.1.0/v0.2.0 shipped with no
+        # binary). Creates the release if missing, or attaches the asset to an
+        # existing one (e.g. re-running a tag whose release was cut by hand).
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+          body_path: notes.md
+          generate_release_notes: ${{ steps.notes.outputs.AUTO == 'true' }}
+          files: |
+            ${{ steps.package.outputs.tarball }}
+            ${{ steps.package.outputs.sha }}
 
       - name: Upload dry-run artifact
         if: steps.meta.outputs.is_release == 'false'

--- a/crates/timing-ir/Cargo.toml
+++ b/crates/timing-ir/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Jacquard timing intermediate representation (IR) for SDF-equivalent annotations. See docs/adr/0002-timing-ir.md."
 license = "Apache-2.0"
-repository = "https://github.com/chipflow/Jacquard"
+repository = "https://github.com/gpu-eda/Jacquard"
 publish = false
 
 [lib]

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -892,10 +892,15 @@ fn sim_metal(
     let mtl_device = MTLDevice::system_default().expect("No Metal device found");
     clilog::info!("Using Metal device: {}", mtl_device.name());
 
-    let metallib_path = env!("METALLIB_PATH");
+    // Embed the Metal kernel library at compile time (not a runtime build-tree
+    // path) so a shipped / `cargo binstall`ed binary is relocatable — the same
+    // pattern the cosim path uses (src/sim/cosim/metal.rs). Loading it from
+    // `env!("METALLIB_PATH")` at runtime breaks any relocated binary, whose
+    // build tree doesn't exist. See ADR 0018, distribution.md (Phase 1a).
+    const METALLIB_BYTES: &[u8] = include_bytes!(env!("METALLIB_PATH"));
     let library = mtl_device
-        .new_library_with_file(metallib_path)
-        .expect("Failed to load metallib");
+        .new_library_with_data(METALLIB_BYTES)
+        .expect("Failed to load embedded metallib");
     let kernel_function = library
         .get_function("simulate_v1_stage", None)
         .expect("Failed to get kernel function");


### PR DESCRIPTION
Three ADR 0018 distribution gaps surfaced while checking why v0.1.0/v0.2.0 shipped with **no binary asset**:

1. **`release.yml` never attached the binary.** The "Publish draft release" step died with **`gh: command not found`** on the self-hosted `macos-runner-1` — the Metal tarball was built + smoke-tested fine, then never published. Switched to `softprops/action-gh-release@v2` (uses `GITHUB_TOKEN` via the API, no `gh` CLI; also attaches to an already-created release of the same tag).
2. **`sim`'s Metal kernel wasn't relocatable.** It loaded the metallib from the compile-time build-tree path at runtime (`new_library_with_file(env!("METALLIB_PATH"))`) — a shipped binary's `sim` panics on any other machine. Now embedded via `include_bytes!`, mirroring the cosim path (ADR 0018 Phase 1a). **Verified:** a binary run from `/tmp` loads the embedded library and runs `sim` (`Simulation completed 5 cycles`).
3. **Stale repo URL** — `crates/timing-ir/Cargo.toml` pointed at `chipflow/Jacquard`; corrected to `gpu-eda` (ADR line 110; root + opensta-to-ir were already done).

Verified locally: `cargo build --features metal` clean; relocated `sim` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)