### PR TITLE
ci+docs(dist): user-acceptance smoke gate, TestPyPI job, binstall --git

### DIFF
--- a/.github/workflows/publish-netlist-graph.yml
+++ b/.github/workflows/publish-netlist-graph.yml
@@ -4,8 +4,9 @@ name: Publish netlist-graph
 #
 # - Tagging `netlist-graph-v<X.Y.Z>` builds and publishes to PyPI via
 #   trusted publishing (OIDC — no stored token).
-# - `workflow_dispatch` is a dry-run: it builds + uploads the wheel as a
-#   workflow artifact but does NOT publish.
+# - `workflow_dispatch` builds + uploads the wheel as a workflow artifact AND
+#   publishes to TestPyPI (environment `testpypi`) — a real upload to validate
+#   the trusted-publisher wiring before cutting the production tag.
 #
 # The `v*` (Rust binary) release workflow uses a different tag prefix, so
 # the two never collide.
@@ -69,3 +70,25 @@ jobs:
           path: dist/
 
       - uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-testpypi:
+    name: Publish to TestPyPI (dry-run validation)
+    needs: build
+    runs-on: ubuntu-latest
+    # Manual dispatch only — a real upload to TestPyPI to validate the OIDC
+    # trusted-publisher wiring before cutting the production `netlist-graph-v*`
+    # tag. TestPyPI rejects re-uploads of an existing version, so bump the
+    # package version (or use a .devN suffix) if re-running for the same version.
+    if: github.event_name == 'workflow_dispatch'
+    environment: testpypi
+    permissions:
+      id-token: write   # trusted publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: netlist-graph-dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,22 +82,17 @@ jobs:
           echo "tarball=${PKG}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "sha=${PKG}.tar.gz.sha256" >> "$GITHUB_OUTPUT"
 
-      - name: Smoke-test the packaged binary (relocated)
+      - name: User-acceptance smoke (relocated tarball; docs/installation.md § Verify)
+        # Unpack the release tarball like a user would and run the documented
+        # install-verification flow (jacquard --version, sim, cosim) against the
+        # *relocated* binaries — no build tree, so it catches relocatability
+        # regressions. Shared with the standalone user-acceptance workflow.
         run: |
           set -euo pipefail
           dest="${RUNNER_TEMP}/relocate"
           rm -rf "$dest" && mkdir -p "$dest"
           tar -C "$dest" -xzf "${{ steps.package.outputs.tarball }}"
-          "$dest/jacquard" --version
-          "$dest/opensta-to-ir" --help >/dev/null
-          # Run the apb_trace cosim with the *relocated* binary against the
-          # checked-in fixtures — proves the embedded metallib loads.
-          "$dest/jacquard" cosim "${GITHUB_WORKSPACE}/tests/apb_trace/apb_trace_synth.gv" \
-            --config "${GITHUB_WORKSPACE}/tests/apb_trace/sim_config.json" \
-            --top-module apb_trace \
-            --max-clock-edges 200 \
-            --bus-trace-csv "${RUNNER_TEMP}/apb.csv"
-          python3 "${GITHUB_WORKSPACE}/tests/apb_trace/check.py" "${RUNNER_TEMP}/apb.csv"
+          bash scripts/ci/user_acceptance_smoke.sh "$dest" "${GITHUB_WORKSPACE}"
 
       - name: Extract release notes from CHANGELOG
         if: steps.meta.outputs.is_release == 'true'

--- a/.github/workflows/user-acceptance.yml
+++ b/.github/workflows/user-acceptance.yml
@@ -1,0 +1,55 @@
+name: User Acceptance (Metal)
+
+# On-demand user-acceptance smoke for the macOS/Metal binary: builds the
+# simulator, installs it to a clean directory (relocated — no build tree), and
+# runs the documented install-verification flow (docs/installation.md § Verify:
+# jacquard --version, sim, cosim) via scripts/ci/user_acceptance_smoke.sh.
+#
+# The same script gates the release in release.yml. This standalone workflow is
+# for validating the user-install experience on demand (e.g. after touching the
+# Metal kernel, packaging, or the install docs) without cutting a release.
+# ADR 0018 / docs/plans/distribution.md.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  metal-smoke:
+    name: Install-as-documented + smoke (macOS / Metal)
+    runs-on: macos-runner-1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Init required submodules
+        run: git submodule update --init vendor/eda-infra-rs
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install LLVM (OpenMP for the Metal build)
+        run: |
+          eval "$(/opt/homebrew/bin/brew shellenv)"
+          brew install llvm
+          LLVM_PREFIX=$(brew --prefix llvm)
+          echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=${LLVM_PREFIX}/lib/c++:${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
+
+      - name: Build jacquard (Metal) + opensta-to-ir
+        run: |
+          cargo build --release --features metal --bin jacquard
+          cargo build --release --manifest-path crates/opensta-to-ir/Cargo.toml --bin opensta-to-ir
+
+      - name: Install to a clean dir (relocated) + run user-acceptance smoke
+        run: |
+          set -euo pipefail
+          dest="${RUNNER_TEMP}/install"
+          rm -rf "$dest" && mkdir -p "$dest"
+          cp target/release/jacquard "$dest/"
+          cp crates/opensta-to-ir/target/release/opensta-to-ir "$dest/"
+          bash scripts/ci/user_acceptance_smoke.sh "$dest" "${GITHUB_WORKSPACE}"

--- a/docs/handoffs/distribution-release-handoff.md
+++ b/docs/handoffs/distribution-release-handoff.md
@@ -1,15 +1,14 @@
 # Handoff — distribution & release hardening
 
-**Created:** 2026-06-23 · **Branch:** `feat/user-acceptance-and-dist-docs`
-(in-flight) off `main`.
+**Created/updated:** 2026-06-23 · **In-flight: PR #133**
+(`feat/user-acceptance-and-dist-docs`), CI running.
 
 ## Goal & now
 
 Bring the ADR 0018 distribution layer to "actually works": ship a usable Metal
 binary, gate releases on a user-level install+smoke, and document the channel
-reality. **Now:** finish + merge the in-flight branch (PR pending), then **cut
-v0.2.1** (the first release whose `release.yml` produces an attached, working
-binary).
+reality. **Now:** merge **PR #133** once green, then **cut v0.2.1** (the first
+release whose `release.yml` produces an attached, working binary).
 
 ## State of the release
 
@@ -30,7 +29,7 @@ binary).
   roll a `[0.2.1]` "distribution fixes" CHANGELOG entry, bump `Cargo.toml`
   0.2.0→0.2.1, commit, tag after main CI green, confirm the asset attaches.
 
-## In-flight branch `feat/user-acceptance-and-dist-docs` (needs PR + merge)
+## In-flight: PR #133 (`feat/user-acceptance-and-dist-docs`) — open, CI running
 
 - `scripts/ci/user_acceptance_smoke.sh` — shared post-install verify
   (`--version`, **sim**, **cosim** apb_trace per `docs/installation.md` §
@@ -87,7 +86,7 @@ to the real release / PyPI / tap. **Build this as the next layer after v0.2.1.**
 
 ## Open follow-ups (priority order)
 
-1. PR + merge the in-flight branch, then **cut v0.2.1** (confirm the Metal
+1. Merge **PR #133** (once green), then **cut v0.2.1** (confirm the Metal
    tarball asset attaches via the fixed workflow).
 2. **Homebrew formula** bump → push to the tap (after v0.2.1).
 3. **netlist-graph** → dispatch to TestPyPI → verify → tag `netlist-graph-v0.1.0`.

--- a/docs/handoffs/distribution-release-handoff.md
+++ b/docs/handoffs/distribution-release-handoff.md
@@ -1,0 +1,104 @@
+# Handoff — distribution & release hardening
+
+**Created:** 2026-06-23 · **Branch:** `feat/user-acceptance-and-dist-docs`
+(in-flight) off `main`.
+
+## Goal & now
+
+Bring the ADR 0018 distribution layer to "actually works": ship a usable Metal
+binary, gate releases on a user-level install+smoke, and document the channel
+reality. **Now:** finish + merge the in-flight branch (PR pending), then **cut
+v0.2.1** (the first release whose `release.yml` produces an attached, working
+binary).
+
+## State of the release
+
+- **v0.1.0** tagged at `7fed695` (2026-06-04 snapshot) + GitHub release — **no
+  binary asset** (the release workflow failed; see below).
+- **v0.2.0** tagged at `a9308d4` (2026-06-23) + GitHub release — **no binary
+  asset** either.
+- Both failed to attach a binary because `release.yml`'s publish step ran
+  `gh release create` and **`gh` is not on PATH on `macos-runner-1`**. The
+  binary *was* built + smoke-tested; only publish died.
+- **Fixed in #131 (merged):** publish now uses `softprops/action-gh-release`
+  (token API, no `gh`); the `sim` Metal kernel is now embedded
+  (`include_bytes!`, was loading a build-tree path → broken on relocated
+  binaries); `crates/timing-ir/Cargo.toml` repo URL → `gpu-eda`.
+- **v0.2.1 not yet cut.** Tag-triggered workflows use the workflow file *at the
+  tag*, so v0.1.0/v0.2.0 can't be cleanly re-run; v0.2.1 is the first tag with
+  the fixed `release.yml` + relocatable `sim` → first real binary. Plan:
+  roll a `[0.2.1]` "distribution fixes" CHANGELOG entry, bump `Cargo.toml`
+  0.2.0→0.2.1, commit, tag after main CI green, confirm the asset attaches.
+
+## In-flight branch `feat/user-acceptance-and-dist-docs` (needs PR + merge)
+
+- `scripts/ci/user_acceptance_smoke.sh` — shared post-install verify
+  (`--version`, **sim**, **cosim** apb_trace per `docs/installation.md` §
+  Verify). Tested locally against a relocated binary. The `sim` coverage is the
+  gap that let v0.2.0 ship broken.
+- `.github/workflows/release.yml` — its relocated-smoke step now calls that
+  script (gates publish).
+- `.github/workflows/user-acceptance.yml` — new standalone `workflow_dispatch`:
+  build → install to a clean dir → run the smoke script.
+- `.github/workflows/publish-netlist-graph.yml` — added a `publish-testpypi`
+  job (`workflow_dispatch`, environment `testpypi`, `repository-url`
+  test.pypi.org) so a dispatch validates the OIDC wiring before the real tag.
+- `docs/installation.md` — `cargo binstall jacquard` → `cargo binstall --git …`
+  (jacquard isn't on crates.io; see Findings).
+- `docs/plans/distribution.md` — added **Phase 7** (eda-infra-rs upstreaming).
+
+## Channel state (what actually works)
+
+- **Prebuilt tarball + `cargo binstall --git`**: live from **v0.2.1** (binstall
+  metadata in `Cargo.toml` is correct; `--git` form required, not crates.io).
+- **Homebrew**: tap `gpu-eda/homebrew-tap` exists but is **empty** (README
+  only). Source-of-truth formula `packaging/homebrew/jacquard.rb` points at
+  **v0.1.0** with a **placeholder sha256**. To go live: after v0.2.1, bump the
+  formula `url`/`version`/`sha256` to the v0.2.1 tarball and push it to the tap
+  as `Formula/jacquard.rb`.
+- **PyPI `netlist-graph`** (version `0.1.0`): trusted publishers configured by
+  the maintainer for env `pypi` (real) and `testpypi`. Not published yet.
+  Validate via dispatch → TestPyPI, then tag `netlist-graph-v0.1.0` for real
+  PyPI.
+
+## Staging-validation design (agreed direction, not built)
+
+Docs keep the standard install commands; a **pre-release** test runs *those
+commands against staging*: Python via **Test PyPI** (`--index-url`); the two
+GitHub-release channels (binstall + brew) via a **prerelease GitHub release**
+(RC tag) — there is no "test crates registry", a prerelease *is* the staging
+tier — with `cargo binstall --git --version <rc>` and
+`brew install --formula packaging/homebrew/jacquard.rb`. A green run promotes
+to the real release / PyPI / tap. **Build this as the next layer after v0.2.1.**
+
+## Findings
+
+- **No crates.io** for `jacquard`: (1) version-less path deps `opensta-to-ir` /
+  `timing-ir` (timing-ir is `publish = false`) — but those are *ours* to fix;
+  (2) the real blocker is the **vendored fork** `vendor/eda-infra-rs`
+  (`ChipFlow/eda-infra-rs`) — `version+path` deps resolve to the fork's patched
+  code, and the fork has diverged from the declared versions. Hence
+  `cargo binstall` needs `--git`.
+- **eda-infra-rs upstreaming audit** — full table + tasks now in
+  `docs/plans/distribution.md` Phase 7. TL;DR: fork is 13 ahead / 1 behind;
+  ANSI-ports = open PR gzz2000#3, Metal = **draft** gzz2000#1, **HIP backend
+  (~9 commits) + unary-NOT not PR'd**, and we haven't pulled the upstream
+  license fix `026070c`.
+
+## Open follow-ups (priority order)
+
+1. PR + merge the in-flight branch, then **cut v0.2.1** (confirm the Metal
+   tarball asset attaches via the fixed workflow).
+2. **Homebrew formula** bump → push to the tap (after v0.2.1).
+3. **netlist-graph** → dispatch to TestPyPI → verify → tag `netlist-graph-v0.1.0`.
+4. **Staging install-validation** (RC-prerelease pipeline) per the design above.
+5. **eda-infra-rs upstreaming** (plan Phase 7): pull `026070c` + re-pin first.
+6. **Stale upstream PRs** #94/#57/#53/#17 are not safely mergeable (2 conflict,
+   2 are ~110 commits behind with stale CI) — triage/rebase or close, don't
+   blind-merge onto the freshly-released main.
+
+## References
+
+- ADR 0018 (`docs/adr/0018-distribution-and-installation.md`), plan
+  (`docs/plans/distribution.md`), `packaging/README.md`.
+- Merged: #131 (release/sim/url fixes). Releases v0.1.0 / v0.2.0 (binary-less).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,13 +28,17 @@ Metal GPU.
 ### cargo binstall — prebuilt binary, no toolchain build
 
 ```sh
-cargo binstall jacquard
+cargo binstall --git https://github.com/gpu-eda/Jacquard jacquard
 ```
 
-Fetches the release binary on **macOS/Metal**. Linux is **not**
-binstall-able: there are two GPU backends (CUDA, HIP) for one target
-triple, so it can't be auto-selected — use the release tarball for your
-backend, a container, or build from source.
+Fetches the release binary on **macOS/Metal**. The `--git` form is
+required: `jacquard` is **not on crates.io** (its dependencies are a
+vendored fork carrying in-flight patches), so binstall reads the
+`[package.metadata.binstall]` pkg-url straight from the repo rather than
+looking the crate up on the registry. Linux is **not** binstall-able:
+there are two GPU backends (CUDA, HIP) for one target triple, so it can't
+be auto-selected — use the release tarball for your backend, a container,
+or build from source.
 
 ### Prebuilt release tarball
 

--- a/docs/plans/distribution.md
+++ b/docs/plans/distribution.md
@@ -116,6 +116,39 @@ package metadata. Remaining (needs maintainer action):
 - `ghcr.io/gpu-eda/jacquard:cuda` for reproducible Linux/CUDA runs.
   Deferred per ADR 0018; revisit if CUDA release binaries prove awkward.
 
+## Phase 7 — Upstream the `eda-infra-rs` fork (de-fork prerequisite)
+
+The simulator can't be published to crates.io while its core deps are a
+**vendored fork** (`vendor/eda-infra-rs` → `ChipFlow/eda-infra-rs`) carrying
+patches not on the registry (the path deps declare a version but resolve to the
+fork's patched code; ADR 0018). De-forking — getting every fork change
+upstreamed + released so jacquard can depend on published
+`gzz2000/eda-infra-rs` crates — is the long-term unblock. **Not** required for
+the binary-distribution channels (those work today); tracked here as the path to
+crates.io / dependency hygiene. (`opensta-to-ir` / `timing-ir` are ours to
+version + name as we like, so they are not a blocker.)
+
+**Audit (2026-06-23):** the fork (`e4e3db0`, branch `master`) is **13 commits
+ahead, 1 behind** upstream `gzz2000/eda-infra-rs`. Upstream merged none of ours;
+it only added the license-string fix (`026070c`). Status of our 13 commits:
+
+| Fork change | Upstream PR | Status |
+|---|---|---|
+| sverilogparse: ANSI-style ports (`e4e3db0`) | gzz2000#3 | OPEN — awaiting merge |
+| Apple Metal support (`139a696`) | gzz2000#1 | **DRAFT** — never submitted |
+| sverilogparse: unary NOT `~` (`d7df6e8`) | — | not PR'd |
+| HIP/AMD + HIP-on-NVIDIA backend (~9 commits, `c89d426`..`8b1bc63`) | — | **not PR'd** (largest gap) |
+| rustfmt + .gitignore (`fb436ed`) | — | housekeeping; fold into a PR |
+
+**Tasks (priority order):**
+- [ ] Pull upstream's license fix (`026070c`) into the fork + bump the submodule
+      pin → closes the release-process checklist item + the `NOTICE` footnote.
+- [ ] File the **HIP backend** PR(s) upstream (the ~9-commit gap).
+- [ ] Mark Metal PR gzz2000#1 **ready for review** (un-draft).
+- [ ] File the **unary-NOT** sverilogparse PR.
+- [ ] Once all merged + released: drop the fork, point deps at published
+      `gzz2000/eda-infra-rs` versions — removes the core "no crates.io" blocker.
+
 ## Verification
 
 - A clean checkout-free install on a second macOS machine (or a fresh

--- a/scripts/ci/user_acceptance_smoke.sh
+++ b/scripts/ci/user_acceptance_smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# User-acceptance smoke test (issue: distribution / ADR 0018).
+#
+# Runs the *documented* install-verification flow against an already-installed
+# (relocated) binary — i.e. what a user gets from `brew install`, `cargo
+# binstall`, or the prebuilt release tarball, NOT a from-source build tree.
+# Mirrors docs/installation.md § Verify, plus a `sim` run (the path that shipped
+# broken in v0.2.0 because the relocated smoke only exercised `cosim`).
+#
+# This is the shared logic behind the release gate (release.yml) and the
+# standalone user-acceptance workflow (user-acceptance.yml). It deliberately
+# uses ONLY the binaries in BIN_DIR and the checked-in fixtures under REPO — it
+# must not touch the cargo build tree, so it catches relocatability regressions
+# (e.g. a kernel loaded from a compile-time path).
+#
+# Usage: user_acceptance_smoke.sh <BIN_DIR> [REPO_ROOT]
+#   BIN_DIR    dir containing the installed `jacquard` + `opensta-to-ir`
+#   REPO_ROOT  checkout providing tests/ fixtures (default: $PWD)
+set -euo pipefail
+
+BIN_DIR="${1:?usage: user_acceptance_smoke.sh <BIN_DIR> [REPO_ROOT]}"
+REPO="${2:-$PWD}"
+JACQUARD="$BIN_DIR/jacquard"
+OPENSTA="$BIN_DIR/opensta-to-ir"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+step() { printf '\n=== %s ===\n' "$1"; }
+
+[ -x "$JACQUARD" ] || { echo "error: no jacquard at $JACQUARD" >&2; exit 2; }
+
+# 1. --version (docs/installation.md § Verify, line 1)
+step "jacquard --version"
+"$JACQUARD" --version
+pass "version reported"
+
+# 2. opensta-to-ir present (ships alongside jacquard, installation.md)
+step "opensta-to-ir --help"
+"$OPENSTA" --help >/dev/null
+pass "opensta-to-ir runs"
+
+# 3. sim — the documented quickstart (usage.md). Proves the Metal kernel is
+#    embedded (relocatable): a build-tree-path load would fail here.
+step "jacquard sim (relocated)"
+"$JACQUARD" sim \
+    "$REPO/tests/timing_test/dff_test_synth.gv" \
+    "$REPO/tests/timing_test/dff_test.vcd" \
+    "$WORK/sim_out.vcd" 1 --max-clock-edges 5
+[ -s "$WORK/sim_out.vcd" ] || { echo "error: sim produced no output VCD" >&2; exit 1; }
+pass "sim ran + wrote output VCD"
+
+# 4. cosim — the exact docs/installation.md § Verify command (lines 92-95).
+step "jacquard cosim apb_trace (docs Verify)"
+"$JACQUARD" cosim \
+    "$REPO/tests/apb_trace/apb_trace_synth.gv" \
+    --config "$REPO/tests/apb_trace/sim_config.json" \
+    --top-module apb_trace --max-clock-edges 200 \
+    --bus-trace-csv "$WORK/apb.csv"
+python3 "$REPO/tests/apb_trace/check.py" "$WORK/apb.csv"
+pass "cosim ran + APB bus trace verified"
+
+printf '\n\033[32mUser-acceptance smoke passed\033[0m (version, opensta-to-ir, sim, cosim).\n'


### PR DESCRIPTION
Pre-release **user-level validation** + distribution-doc accuracy (ADR 0018). Root cause this addresses: v0.1.0/v0.2.0 shipped broken because nothing validated the *user's* install-and-run path (the old smoke ran on the build machine and only exercised `cosim`).

## Changes
- **`scripts/ci/user_acceptance_smoke.sh`** — shared post-install verify: `jacquard --version`, **`sim`**, **`cosim`** apb_trace (per `docs/installation.md` § Verify), with output assertions, against a *relocated* binary. Adds the `sim` coverage that was the gap. ✅ tested locally (`Simulation completed`, APB trace verified).
- **`release.yml`** — relocated-smoke step now calls the shared script (gates publish).
- **`user-acceptance.yml`** (new) — standalone `workflow_dispatch`: build → install to a clean dir → run the smoke. On-demand "user-style install works?" check.
- **`publish-netlist-graph.yml`** — `workflow_dispatch` → **TestPyPI** publish job (env `testpypi`) to validate OIDC trusted-publishing before the real tag.
- **`installation.md`** — `cargo binstall --git …` (jacquard isn't on crates.io — vendored fork deps).
- **`distribution.md`** — Phase 7: eda-infra-rs fork upstreaming audit (13 ahead/1 behind; HIP backend + unary-NOT not PR'd; Metal PR is draft) + tasks.
- **handoff** — in-flight distribution/release state.

Workflow changes can't be dry-run locally; the smoke script is verified locally and the release gate exercises it on the next tag (v0.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)