### PR TITLE
chore: unify first-party Rust crate versions via bump_version.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -800,6 +800,12 @@ jobs:
       - name: Init required submodules
         run: git submodule update --init vendor/eda-infra-rs vendor/sky130_fd_sc_hd
 
+      # Catch version drift on every PR, not just at release time: the
+      # first-party Rust crates must all carry the same version
+      # (docs/release-process.md, scripts/bump_version.py).
+      - name: Check Rust crate versions agree
+        run: python3 scripts/bump_version.py --check
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,17 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            tag_ver="${GITHUB_REF_NAME#v}"
+            # Verify-guard: the three first-party Rust crates must all carry
+            # the tagged version (see docs/release-process.md). Aborts the
+            # release before any publish if a version bump was missed.
+            python3 scripts/bump_version.py --check "${tag_ver}"
             echo "is_release=true" >> "$GITHUB_OUTPUT"
-            echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            echo "version=${tag_ver}" >> "$GITHUB_OUTPUT"
           else
-            ver=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+            # Dry-run: assert the crates agree and reuse their shared version
+            # (bump_version.py is the single TOML parser — no grep/sed re-derive).
+            ver=$(python3 scripts/bump_version.py --print-version)
             echo "is_release=false" >> "$GITHUB_OUTPUT"
             echo "version=${ver}-dryrun" >> "$GITHUB_OUTPUT"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the public contracts in `docs/release-process.md` follow stricter rules).
 
 ## [Unreleased]
 
+### Changed
+
+- **Unified the first-party Rust crate versions.** `jacquard`,
+  `opensta-to-ir`, and `timing-ir` ship together in one release tarball
+  and now carry a single shared version (the two helper crates move
+  `0.1.0` → `0.2.1` to match `jacquard`; both are `publish = false`, so no
+  external version contract changes). A new `scripts/bump_version.py` is
+  the single source of truth — `bump_version.py <X.Y.Z>` sets all three,
+  and `release.yml` runs `bump_version.py --check <tag>` as a verify-guard
+  that aborts a release if the tag and crate versions disagree.
+  `netlist-graph` continues to version independently.
+
 ## [0.2.1] - 2026-06-23
 
 Distribution fixes — the first release whose `release.yml` produces an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opensta-to-ir"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "flatbuffers",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "timing-ir"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "flatbuffers",

--- a/crates/opensta-to-ir/Cargo.toml
+++ b/crates/opensta-to-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensta-to-ir"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 description = "Preprocessing tool that drives OpenSTA and emits Jacquard timing IR. Lives outside the root cargo workspace; `cargo test --lib` from the repo root does NOT run its tests — use `cd crates/opensta-to-ir && cargo test` locally, or rely on the dedicated `opensta-to-ir-tests` CI job. See docs/plans/ws2-opensta-to-ir.md and docs/adr/0006-sdf-preprocessing-model.md."
 license = "Apache-2.0"

--- a/crates/timing-ir/Cargo.toml
+++ b/crates/timing-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timing-ir"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 description = "Jacquard timing intermediate representation (IR) for SDF-equivalent annotations. See docs/adr/0002-timing-ir.md."
 license = "Apache-2.0"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -54,8 +54,15 @@ For maintainers cutting a release:
    the link references at the bottom of the file. Leave a fresh empty
    `[Unreleased]` section at the top.
 
-3. **Bump `version` in [`Cargo.toml`](../Cargo.toml)** to match.
-   `cargo build` to update `Cargo.lock`.
+3. **Bump the Rust crate version** to match:
+   `python3 scripts/bump_version.py <X.Y.Z>`. The three first-party
+   Rust crates (`jacquard`, `opensta-to-ir`, `timing-ir`) ship together
+   in one tarball and carry a single shared version, so this script sets
+   all three at once — never edit their `[package].version` by hand.
+   Then `cargo build` to update `Cargo.lock`. (`netlist-graph` versions
+   independently — see its own `netlist-graph-v*` tag flow.) The release
+   workflow re-runs `bump_version.py --check <tag>` as a verify-guard and
+   aborts before publishing if the tag and the crates disagree.
 
 4. **Commit:** `chore: release v<X.Y.Z>` with the standard
    `Co-developed-by` trailer.

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Single source of truth for the Rust crate versions.
+
+The first-party Rust crates ship together in one release tarball
+(`jacquard` + the `opensta-to-ir` / `timing-ir` helpers it bundles), so they
+carry one shared version. They are NOT a Cargo workspace (the crates build
+into their own `target/` dirs, which several CI/release steps depend on — see
+`docs/release-process.md`), so the version cannot be inherited via
+`[workspace.package]`. This script keeps the `[package].version` fields locked
+together instead, and the release workflow calls it in `--check` mode as a
+verify-guard so a mistagged release fails before publishing.
+
+`netlist-graph` (the Python companion) versions independently — it is not a
+Cargo crate, so it never appears in the discovered manifest set below.
+
+Usage:
+    python3 scripts/bump_version.py 0.2.2          # set all crates to 0.2.2
+    python3 scripts/bump_version.py --check 0.2.2   # assert all == 0.2.2
+    python3 scripts/bump_version.py --check         # assert all agree
+    python3 scripts/bump_version.py --print-version  # assert agree, print it
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The first-party Rust crates that share one version: the root crate plus every
+# crate under `crates/`. Discovered rather than enumerated so a new first-party
+# crate is enrolled automatically instead of being silently left un-bumped.
+MANIFESTS = [
+    REPO_ROOT / "Cargo.toml",
+    *sorted((REPO_ROOT / "crates").glob("*/Cargo.toml")),
+]
+
+SEMVER = re.compile(r"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")
+# Captures the version value inside a `version = "..."` line; group 2 is the
+# value. Applied only to lines inside the `[package]` table (see _find_version),
+# so inline dependency `version = "..."` fields are never matched.
+VERSION_LINE = re.compile(r'(\s*version\s*=\s*")([^"]*)(")')
+
+
+def _find_version(lines: list[str]) -> tuple[int, re.Match[str]]:
+    """Return (line index, match) for the `[package].version` line."""
+    in_package = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            in_package = stripped == "[package]"
+            continue
+        if in_package:
+            m = VERSION_LINE.match(line)
+            if m:
+                return i, m
+    raise ValueError("no [package].version found")
+
+
+def read_version(manifest: Path) -> str:
+    _, m = _find_version(manifest.read_text().splitlines(keepends=True))
+    return m.group(2)
+
+
+def set_version(manifest: Path, version: str) -> str:
+    lines = manifest.read_text().splitlines(keepends=True)
+    i, m = _find_version(lines)
+    current = m.group(2)
+    if current != version:
+        lines[i] = lines[i][: m.start(2)] + version + lines[i][m.end(2) :]
+        manifest.write_text("".join(lines))
+    return current
+
+
+def _agreed_version(expected: str | None) -> tuple[str | None, str]:
+    """Return (version, '') if the crates agree (and match expected), else
+    (None, error message)."""
+    versions = {m: read_version(m) for m in MANIFESTS}
+    distinct = set(versions.values())
+    if len(distinct) != 1:
+        detail = "\n".join(
+            f"  {m.relative_to(REPO_ROOT)}: {v}" for m, v in versions.items()
+        )
+        return None, f"Rust crate versions disagree:\n{detail}"
+    (found,) = distinct
+    if expected is not None and found != expected:
+        return None, f"expected all Rust crates at {expected}, found {found}"
+    return found, ""
+
+
+def cmd_set(version: str) -> int:
+    if not SEMVER.match(version):
+        print(f"error: {version!r} is not a valid semantic version", file=sys.stderr)
+        return 2
+    for manifest in MANIFESTS:
+        old = set_version(manifest, version)
+        rel = manifest.relative_to(REPO_ROOT)
+        print(f"  {rel}: {'already ' + version if old == version else old + ' -> ' + version}")
+    return 0
+
+
+def cmd_check(expected: str | None) -> int:
+    found, err = _agreed_version(expected)
+    if found is None:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+    print(f"ok: all {len(MANIFESTS)} Rust crates at {found}")
+    return 0
+
+
+def cmd_print_version(expected: str | None) -> int:
+    found, err = _agreed_version(expected)
+    if found is None:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+    print(found)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the crates agree (and equal VERSION if given) instead of writing",
+    )
+    mode.add_argument(
+        "--print-version",
+        action="store_true",
+        help="like --check, but print only the agreed version to stdout",
+    )
+    parser.add_argument("version", nargs="?", help="target version, e.g. 0.2.2")
+    args = parser.parse_args(argv)
+
+    if args.print_version:
+        return cmd_print_version(args.version)
+    if args.check:
+        return cmd_check(args.version)
+    if not args.version:
+        parser.error("a target VERSION is required unless --check is given")
+    return cmd_set(args.version)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

The three first-party Rust crates (`jacquard`, `opensta-to-ir`, `timing-ir`) ship together in one release tarball but had drifted: `jacquard` at `0.2.1`, the two helpers stuck at `0.1.0`. This locks them to **one shared version**.

They are deliberately **not** a Cargo workspace — the crates build into separate `crates/*/target/` dirs that ~7 CI/release/script steps depend on — so the version can't be inherited via `[workspace.package]`. Instead, a small single-source-of-truth script keeps the `[package].version` fields in sync.

## Changes

- **`scripts/bump_version.py`** — sets/checks the `[package].version` of every first-party crate (root + `crates/*`, discovered by glob so a new crate is enrolled automatically rather than silently left un-bumped). Aligns `opensta-to-ir` + `timing-ir` `0.1.0` → `0.2.1` (both `publish = false`, so no external version contract changes).
- **`release.yml`** — runs `bump_version.py --check <tag>` as a **verify-guard** that aborts before publishing if the tag and crate versions disagree; the dry-run reuses `--print-version` instead of a `grep`/`sed` re-derive (script is the single TOML parser).
- **`ci.yml`** (Lint job) — runs `bump_version.py --check` so version drift surfaces on **every PR**, not just at release time. Zero-cost (no toolchain/GPU).
- **`docs/release-process.md`** — step 3 now documents the bump script.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

`netlist-graph` (Python) continues to version independently.

## Why this approach

Chosen over true workspace inheritance to avoid relocating `opensta-to-ir`'s build output (which would rewrite all ~7 CI/release/script touch points and need a full CI run to de-risk). This is the smaller, lower-risk diff that delivers the same "one version + verify guard" outcome.

## Validation

- `bump_version.py` exercised across all modes (set / `--check` / `--check VERSION` / `--print-version` / invalid-version / disagreement); roundtrip set preserves manifest formatting (only the version line changes).
- `ruff` clean; `actionlint` clean on the added steps (pre-existing SC2129/SC2046 warnings elsewhere untouched).
- `cargo build -p jacquard` resolves with the helpers at `0.2.1`.
- CI's new verify-guard + the release `workflow_dispatch` dry-run will exercise the guard end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)