### PR TITLE
ci(dist): staging install-validation pipeline for release candidates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,15 @@ jobs:
             python3 scripts/bump_version.py --check "${tag_ver}"
             echo "is_release=true" >> "$GITHUB_OUTPUT"
             echo "version=${tag_ver}" >> "$GITHUB_OUTPUT"
+            # A SemVer pre-release suffix (e.g. 0.2.2-rc.1) marks a staging
+            # release candidate — publish it as a GitHub *prerelease* so it
+            # never shows as "Latest". Validate it with validate-install.yml,
+            # then promote by cutting the final tag. See docs/release-process.md.
+            if [[ "${tag_ver}" == *-* ]]; then
+              echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            fi
           else
             # Dry-run: assert the crates agree and reuse their shared version
             # (bump_version.py is the single TOML parser — no grep/sed re-derive).
@@ -131,6 +140,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           draft: false
+          prerelease: ${{ steps.meta.outputs.is_prerelease == 'true' }}
           body_path: notes.md
           generate_release_notes: ${{ steps.notes.outputs.AUTO == 'true' }}
           files: |

--- a/.github/workflows/validate-install.yml
+++ b/.github/workflows/validate-install.yml
@@ -1,0 +1,122 @@
+name: Validate install (staging)
+
+# Runs the *documented* end-user install commands against an already-published
+# release (or release candidate) and is the promotion gate for the staging
+# flow (ADR 0018, docs/release-process.md § Staging validation).
+#
+# Cut an RC: `bump_version.py X.Y.Z-rc.N`, commit, tag `vX.Y.Z-rc.N` —
+# release.yml publishes a GitHub *prerelease* with the Metal tarball. Then
+# dispatch this workflow with that tag. A green run means the real install
+# commands work against the staging artifact; promote by cutting the final
+# `vX.Y.Z` tag.
+#
+# Scope: this validates the *install channels* (asset naming, the binstall
+# pkg-url override, the Homebrew formula + sha256) — that the published
+# artifact installs and runs. Binary *functionality* (sim/cosim) is already
+# smoke-tested against the relocated tarball at release-build time
+# (release.yml), so this runs on GitHub-hosted macos-latest (Apple Silicon),
+# where `jacquard --version` needs no GPU and validation never contends for
+# the single shared Metal runner. The Python/TestPyPI channel
+# (`netlist-graph`) versions independently and is not gated here.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Published release tag to validate (e.g. v0.2.2-rc.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-install-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  binstall:
+    name: cargo binstall
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          submodules: false
+
+      # No submodule init: binstall's crate-meta-data strategy only TOML-parses
+      # the manifest header (name / version / [package.metadata.binstall]); it
+      # never resolves the path deps into the vendored fork.
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: cargo-bins/cargo-binstall@main
+
+      - name: Install jacquard from the release tarball (no source fallback)
+        # `cargo binstall --git` can't pin a tag (it reads the default branch),
+        # so we pin by checking out the tag and using --manifest-path: it reads
+        # `version` from the tag's Cargo.toml and exercises the
+        # [package.metadata.binstall] pkg-url override. Disabling the compile +
+        # quick-install strategies makes a missing/misnamed asset a hard
+        # failure instead of a silent source build — which is the whole point.
+        run: |
+          cargo binstall jacquard \
+            --manifest-path Cargo.toml \
+            --no-confirm \
+            --strategies crate-meta-data \
+            --disable-strategies compile,quick-install
+
+      - name: Verify the installed binary
+        run: |
+          set -euo pipefail
+          ver="${TAG#v}"
+          got="$("${HOME}/.cargo/bin/jacquard" --version)"
+          echo "installed: ${got}"
+          [[ "${got}" == *"${ver}"* ]] || {
+            echo "version mismatch: want ${ver}, got ${got}" >&2; exit 1; }
+        env:
+          TAG: ${{ inputs.tag }}
+
+  brew:
+    name: brew install
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_FROM_API: "1"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Build an RC formula pointed at the release tarball
+        # Repoint the source-of-truth formula's url/version/sha256 at the
+        # dispatched tag's published tarball + .sha256, so we validate the
+        # formula *mechanism* against the staging asset without touching the
+        # production tap. We rewrite from the asset (not from the formula as
+        # committed at the tag, which may still point at an older release).
+        run: |
+          set -euo pipefail
+          ver="${TAG#v}"
+          base="https://github.com/gpu-eda/Jacquard/releases/download/${TAG}"
+          tarball="jacquard-${ver}-macos-arm64-metal.tar.gz"
+          sha="$(curl -fsSL "${base}/${tarball}.sha256" | awk '{print $1}')"
+          test -n "${sha}"
+          sed -e "s|url \".*\"|url \"${base}/${tarball}\"|" \
+              -e "s|version \".*\"|version \"${ver}\"|" \
+              -e "s|sha256 \".*\"|sha256 \"${sha}\"|" \
+              packaging/homebrew/jacquard.rb > /tmp/jacquard-rc.rb
+          echo "--- generated RC formula ---"; cat /tmp/jacquard-rc.rb
+        env:
+          TAG: ${{ inputs.tag }}
+
+      - name: Install from a local tap + verify
+        # Fully-qualified install (`<org>/<tap>/<formula>`) trusts only this
+        # formula — no `brew trust` needed. The local tap is never pushed, so
+        # the production gpu-eda/homebrew-tap is untouched.
+        run: |
+          set -euo pipefail
+          eval "$(/opt/homebrew/bin/brew shellenv)"
+          # macos-latest is ephemeral — no prior tap/install state to clean up.
+          brew tap-new gpu-eda/rc-validate
+          cp /tmp/jacquard-rc.rb "$(brew --repository gpu-eda/rc-validate)/Formula/jacquard.rb"
+          brew install --formula gpu-eda/rc-validate/jacquard
+          brew test gpu-eda/rc-validate/jacquard
+          jacquard --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the public contracts in `docs/release-process.md` follow stricter rules).
 
 ## [Unreleased]
 
+### Added
+
+- **Staging install-validation pipeline** for release candidates. Tagging a
+  SemVer pre-release (`vX.Y.Z-rc.N`) now publishes a GitHub *prerelease*
+  (never "Latest"), and a new **Validate install (staging)** workflow
+  (`validate-install.yml`, `workflow_dispatch`) runs the documented end-user
+  install commands against that prerelease asset — `cargo binstall` (compile
+  fallback disabled, so a missing/misnamed asset fails hard) and
+  `brew install` (the formula repointed at the prerelease tarball, installed
+  from a throwaway local tap). A green run is the promotion gate. See
+  `docs/release-process.md` § Staging validation.
+
 ### Changed
 
 - **Unified the first-party Rust crate versions.** `jacquard`,

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -73,6 +73,35 @@ For maintainers cutting a release:
    section for that version. No artefacts attached unless someone has
    asked for them.
 
+## Staging validation (release candidates)
+
+Optional but recommended before a user-facing release: prove the
+*documented install commands* work against a staging artifact before
+promoting. There is no "test crates registry", so a **GitHub prerelease**
+is the staging tier for the binary channels.
+
+1. **Cut an RC.** `python3 scripts/bump_version.py <X.Y.Z>-rc.<N>`, commit,
+   tag `v<X.Y.Z>-rc.<N>`, push the tag. `release.yml` detects the SemVer
+   pre-release suffix and publishes a GitHub **prerelease** (never shown as
+   "Latest") with the Metal tarball attached.
+
+2. **Validate.** Dispatch the **Validate install (staging)** workflow
+   (`validate-install.yml`) with that tag. It runs the real install
+   commands against the prerelease asset on macOS:
+   - `cargo binstall` (asset-fetch via the `[package.metadata.binstall]`
+     override, compile fallback disabled so a missing asset fails hard);
+   - `brew install` of an RC formula (the source-of-truth formula repointed
+     at the prerelease tarball + its `.sha256`, installed from a throwaway
+     local tap).
+
+3. **Promote.** A green run means the channels work. Bump to the final
+   `<X.Y.Z>` (drop the `-rc.<N>`), commit, tag `v<X.Y.Z>`, push — the same
+   flow as a normal release below.
+
+The `netlist-graph` (PyPI) channel validates separately via its own
+`workflow_dispatch` → TestPyPI path (see `publish-netlist-graph.yml`); it
+versions independently of the Rust crates.
+
 ## What does NOT need to change at release time
 
 - Submodule pins (unless deliberately bumping a vendored dep).


### PR DESCRIPTION
## What

Adds the last unbuilt piece of the ADR 0018 distribution plan: a staging tier that runs the **documented end-user install commands against a published artifact before promoting**.

- **`release.yml`** — a SemVer pre-release tag (`vX.Y.Z-rc.N`) now publishes a GitHub **prerelease** (never "Latest") with the Metal tarball.
- **`validate-install.yml`** (new, `workflow_dispatch <tag>`) — on GitHub-hosted `macos-latest`:
  - **`cargo binstall`** via `--manifest-path` at the tag, with `compile` + `quick-install` strategies disabled so a missing/misnamed asset **fails hard** instead of silently building from source (cargo-binstall `--git` can't pin a tag — confirmed against its source — so we pin via checkout).
  - **`brew install`** of the source-of-truth formula repointed at the tag's tarball + `.sha256`, from a throwaway **local tap** (fully-qualified install needs no `brew trust`).
- **`docs/release-process.md`** — documents the RC → validate → promote flow.

## Scope

**Channel** validation (asset naming, binstall metadata, formula + sha256), not binary functionality — `sim`/`cosim` are already smoke-tested against the relocated tarball at release-build time, so no GPU is needed here and the shared Metal runner stays free. `netlist-graph` (PyPI) validates via its own TestPyPI dispatch; it versions independently.

## Validation

Both jobs validated **locally** against the real v0.2.1 release (a `workflow_dispatch` workflow can't be dispatched before it's on the default branch). Post-merge I'll dispatch it against `v0.2.1` to confirm in-CI. The workflow is dispatch-only — inert until invoked — so merging is low-risk.

Built with `/simplify` applied (dropped an unneeded submodule init, removed ephemeral-runner idempotency cruft, added a concurrency group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)