### PR TITLE
fix(dist): make prebuilt macOS install channels work without a build tree

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,13 @@ jobs:
             echo "version=${ver}-dryrun" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build jacquard (Metal) + opensta-to-ir
+      - name: Build jacquard + timing_analysis (Metal) + opensta-to-ir
         run: |
-          cargo build --release --features metal --bin jacquard
+          # timing_analysis is the jacquard package's *other* bin; cargo
+          # binstall requires every non-optional package bin to be in the
+          # archive, so it must ship alongside jacquard (it builds without the
+          # metal feature, but one invocation keeps the build cache shared).
+          cargo build --release --features metal --bin jacquard --bin timing_analysis
           cargo build --release --manifest-path crates/opensta-to-ir/Cargo.toml --bin opensta-to-ir
 
       - name: Package
@@ -88,12 +92,13 @@ jobs:
           PKG="jacquard-${{ steps.meta.outputs.version }}-macos-arm64-metal"
           mkdir -p "stage/${PKG}"
           cp target/release/jacquard "stage/${PKG}/"
+          cp target/release/timing_analysis "stage/${PKG}/"
           cp crates/opensta-to-ir/target/release/opensta-to-ir "stage/${PKG}/"
           cp LICENSE README.md CHANGELOG.md "stage/${PKG}/"
           # Binaries at the archive root → matches the cargo-binstall
           # `bin-dir = "{ bin }{ binary-ext }"` in Cargo.toml.
           tar -czf "${PKG}.tar.gz" -C "stage/${PKG}" \
-            jacquard opensta-to-ir LICENSE README.md CHANGELOG.md
+            jacquard timing_analysis opensta-to-ir LICENSE README.md CHANGELOG.md
           shasum -a 256 "${PKG}.tar.gz" | tee "${PKG}.tar.gz.sha256"
           echo "tarball=${PKG}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "sha=${PKG}.tar.gz.sha256" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate-install.yml
+++ b/.github/workflows/validate-install.yml
@@ -64,6 +64,15 @@ jobs:
             --strategies crate-meta-data \
             --disable-strategies compile,quick-install
 
+      # The prebuilt binary links Homebrew LLVM's libc++/libomp. The brew
+      # channel pulls LLVM via `depends_on "llvm"`, but binstall/raw-tarball
+      # users must install it themselves (docs/installation.md) — so the
+      # binstall gate installs it too, matching the documented prerequisite.
+      - name: Install LLVM runtime (binstall prerequisite)
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: brew install llvm
+
       - name: Verify the installed binary
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ the public contracts in `docs/release-process.md` follow stricter rules).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Prebuilt macOS install channels worked only with Homebrew LLVM present**
+  (caught by the new staging-validation pipeline). Two defects in the v0.2.1
+  artifact: (1) `cargo binstall` failed because the tarball omitted
+  `timing_analysis`, a non-optional `jacquard`-package bin — it now ships in
+  the tarball (and the Homebrew formula installs it); (2) the binary links
+  Homebrew LLVM's `libc++`/`libomp`, so it failed to launch on machines
+  without LLVM — the Homebrew formula now `depends_on "llvm"`, and the
+  binstall/raw-tarball LLVM runtime prerequisite is documented in
+  `docs/installation.md`.
+
 ### Added
 
 - **Staging install-validation pipeline** for release candidates. Tagging a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,24 +28,33 @@ Metal GPU.
 ### cargo binstall — prebuilt binary, no toolchain build
 
 ```sh
+brew install llvm     # runtime dependency — see note below
 cargo binstall --git https://github.com/gpu-eda/Jacquard jacquard
 ```
 
-Fetches the release binary on **macOS/Metal**. The `--git` form is
-required: `jacquard` is **not on crates.io** (its dependencies are a
-vendored fork carrying in-flight patches), so binstall reads the
-`[package.metadata.binstall]` pkg-url straight from the repo rather than
-looking the crate up on the registry. Linux is **not** binstall-able:
-there are two GPU backends (CUDA, HIP) for one target triple, so it can't
-be auto-selected — use the release tarball for your backend, a container,
-or build from source.
+Fetches the release binaries (`jacquard` + `timing_analysis`) on
+**macOS/Metal**. The `--git` form is required: `jacquard` is **not on
+crates.io** (its dependencies are a vendored fork carrying in-flight
+patches), so binstall reads the `[package.metadata.binstall]` pkg-url
+straight from the repo rather than looking the crate up on the registry.
+Linux is **not** binstall-able: there are two GPU backends (CUDA, HIP) for
+one target triple, so it can't be auto-selected — use the release tarball
+for your backend, a container, or build from source.
+
+> **Runtime dependency — Homebrew LLVM.** The prebuilt macOS binary links
+> Homebrew LLVM's `libc++` and `libomp` (the build uses LLVM clang for
+> OpenMP, via the mt-kahypar partitioner), so it needs `brew install llvm`
+> to run. The **Homebrew** install handles this automatically
+> (`depends_on "llvm"`); **binstall** and the **raw tarball** do not, so
+> install LLVM first.
 
 ### Prebuilt release tarball
 
 Download `jacquard-<version>-<target>.tar.gz` from the
 [releases page](https://github.com/gpu-eda/Jacquard/releases), extract,
-and put `jacquard` (and `opensta-to-ir`) on your `PATH`. The macOS/Metal
-binary is self-contained (the GPU kernel is embedded).
+and put `jacquard`, `timing_analysis`, and `opensta-to-ir` on your `PATH`.
+The GPU kernel is embedded, but the binary still needs Homebrew LLVM at
+runtime (`brew install llvm`) — see the note above.
 
 ### From source (any backend)
 

--- a/packaging/homebrew/jacquard.rb
+++ b/packaging/homebrew/jacquard.rb
@@ -20,10 +20,17 @@ class Jacquard < Formula
   license "Apache-2.0"
 
   depends_on arch: :arm64
+  # The prebuilt binary links Homebrew LLVM's libc++ and libomp (the build
+  # uses LLVM clang for OpenMP, via the mt-kahypar partitioner). Declaring the
+  # dependency makes `brew install` pull LLVM so the binary loads on a clean
+  # machine. (binstall / raw-tarball users must `brew install llvm` themselves
+  # — see docs/installation.md.)
+  depends_on "llvm"
   depends_on :macos
 
   def install
     bin.install "jacquard"
+    bin.install "timing_analysis"
     bin.install "opensta-to-ir"
   end
 


### PR DESCRIPTION
## What

The new staging-validation pipeline (#135) immediately earned its keep: dispatched against the real v0.2.1 release, **both jobs failed — as true positives**, exposing two defects that made v0.2.1's prebuilt channels broken on any Mac without Homebrew LLVM.

### Bug A — `cargo binstall` broken for everyone
`cargo binstall jacquard` requires every non-optional bin of the `jacquard` package (`jacquard` **and** `timing_analysis`). The tarball shipped `jacquard` + `opensta-to-ir` (a *different* crate) and omitted `timing_analysis` → `exit 94` before installing anything.
**Fix:** build + ship `timing_analysis` in the tarball; install it from the Homebrew formula too.

### Bug B — binary not portable
The binary links Homebrew LLVM's `libc++.1.dylib` + `libomp.dylib` (LLVM clang provides OpenMP for the `mt-kahypar` partitioner) → `dyld` failure on a clean machine. It passed `release.yml`'s smoke only because that runner has LLVM.
**Fix (per maintainer call — acceptable for this EDA/Apple-Silicon audience):** declare the dependency rather than static-link. The Homebrew formula now `depends_on "llvm"` (auto-installed). binstall + raw-tarball users `brew install llvm` themselves — documented in `installation.md`, and the binstall validation job installs it to mirror the real prerequisite.

## Why these slipped through
The release smoke runs on the build machine (which has LLVM) and never exercises binstall. Validating the documented commands on a **clean** runner is exactly what surfaced both.

## Validation
- Reproduced both failures against v0.2.1 (run 28097045951).
- `cargo build --release --features metal --bin jacquard --bin timing_analysis` ✓; `ruby -c` + `brew style` (DependencyOrder) ✓; actionlint ✓.
- After merge: cut `v0.2.2-rc.1`, dispatch `validate-install` against it → both channels should be **green**, then promote to v0.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)