### PR TITLE
fix(ci): authenticate cargo binstall's GitHub API calls in validate-install

### DIFF
--- a/.github/workflows/validate-install.yml
+++ b/.github/workflows/validate-install.yml
@@ -57,6 +57,12 @@ jobs:
         # [package.metadata.binstall] pkg-url override. Disabling the compile +
         # quick-install strategies makes a missing/misnamed asset a hard
         # failure instead of a silent source build — which is the whole point.
+        #
+        # GITHUB_TOKEN authenticates binstall's GitHub API calls (release
+        # lookup): unauthenticated is 60 req/hr/IP and 403s under load, which
+        # then times out the fetcher and aborts.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cargo binstall jacquard \
             --manifest-path Cargo.toml \


### PR DESCRIPTION
validate-install's binstall job 403'd querying the GitHub releases API unauthenticated (60 req/hr/IP) under session load — a rate-limit artifact, not a v0.2.2 defect (brew job green; rc.2 binstall passed with the identical tarball). Pass GITHUB_TOKEN so binstall authenticates (5000/hr). Re-running validate-install against v0.2.2 after merge should be fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)