### PR TITLE
docs(readme): getting-started polish + fix stale org links + correct status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jacquard
 
-![CI](https://github.com/ChipFlow/Jacquard/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/gpu-eda/Jacquard/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/badge/license-Apache--2.0-blue)
 ![Rust](https://img.shields.io/badge/rust-edition%202021-orange)
 
@@ -15,28 +15,12 @@ Jacquard builds on the excellent [GEM](https://github.com/NVlabs/GEM) research b
 - **Significant performance optimizations** to the partition mapping pipeline
 - **CI/CD** with automated testing across all three backends
 
-### Timing simulation status
-
-GPU-accelerated gate-level simulation with real cell timing. What ships
-today (Phase 1 closed 2026-05-02; see [`docs/plans/post-phase-0-roadmap.md`](docs/plans/post-phase-0-roadmap.md)):
-
-| Capability | Status |
-|---|---|
-| Liberty parsing | ✅ |
-| SDF back-annotation via `opensta-to-ir` | ✅ |
-| Per-DFF clock-arrival folding (Pillar B Stages 1+2) | ✅ |
-| GPU-side setup/hold violation detection | ✅ Metal; CUDA + HIP detect, route through `process_events` is a follow-up |
-| **Symbolic violation messages** (`top/cpu/regs[7][bit 22] [word=42]`) | ✅ Metal |
-| **`--timing-report <path.json>`** structured end-of-run report | ✅ Metal |
-| **`--timing-summary`** human-readable text summary | ✅ Metal |
-| OpenSTA detection + version check | ✅ |
-| Per-receiver wire delay (Pillar C Tier 1) | ❌ Phase 2 (blocked on ADR 0007) |
-| Multi-corner SDF (`--sdf-corner`) | ⚠ Single corner (typ) only; WS2.4 open |
-
-See [`docs/timing-violations.md`](docs/timing-violations.md) and
-[`docs/why-jacquard.md`](docs/why-jacquard.md) for the full output
-interface and positioning. [`CHANGELOG.md`](CHANGELOG.md) tracks
-released and unreleased changes.
+GPU-accelerated gate-level simulation with real cell timing is live across all
+three backends. For the per-backend feature status — Liberty parsing, SDF
+back-annotation, setup/hold violation detection, and the structured
+`--timing-report` — see **[Timing Simulation](https://gpu-eda.github.io/Jacquard/timing-simulation.html)**
+(or [`docs/timing-simulation.md`](docs/timing-simulation.md)).
+[`CHANGELOG.md`](CHANGELOG.md) tracks released and unreleased changes.
 
 ## Dependencies
 
@@ -54,10 +38,15 @@ Contributors editing only Rust / C++ / kernel sources do not need `flatc` or Ope
 
 ## Quick Start
 
-> **Just want to install Jacquard?** See **[docs/installation.md](docs/installation.md)**
-> for prebuilt binaries, Homebrew (macOS/Metal), and the `netlist-graph`
-> PyPI companion. The from-source build below is the contributor path —
-> and the route for Linux CUDA / HIP.
+> **Just want to install Jacquard?** On macOS (Apple Silicon / Metal):
+>
+> ```sh
+> brew install gpu-eda/homebrew-tap/jacquard
+> ```
+>
+> See **[docs/installation.md](docs/installation.md)** for `cargo binstall`,
+> the prebuilt tarball, and the `netlist-graph` PyPI companion. The from-source
+> build below is the contributor path — and the route for Linux CUDA / HIP.
 
 ```sh
 git clone https://github.com/gpu-eda/Jacquard.git
@@ -101,7 +90,7 @@ Partitioning (mapping the design to GPU blocks) happens automatically at startup
 
 ## Documentation
 
-Browse the full documentation [online](https://chipflow.github.io/Jacquard/) or build it locally with [mdbook](https://rust-lang.github.io/mdBook/):
+Browse the full documentation [online](https://gpu-eda.github.io/Jacquard/) or build it locally with [mdbook](https://rust-lang.github.io/mdBook/):
 
 ```sh
 mdbook serve   # opens at http://localhost:3000
@@ -109,9 +98,13 @@ mdbook serve   # opens at http://localhost:3000
 
 ## Limitations
 
-- Only supports non-interactive testbenches (static VCD input waveforms)
-- Synchronous logic only (no latches or async sequential logic)
-- Clock gates must use the `CKLNQD` module from `aigpdk.v`
+- `jacquard sim` takes a static VCD input waveform. For reactive testbenches,
+  `jacquard cosim` runs peripheral models (SPI flash, UART, JTAG — including an
+  interactive `--jtag-server` — and Wishbone / APB3 bus tracing) as GPU kernels
+  alongside the design, so inputs can depend on design outputs cycle-by-cycle.
+- Synchronous logic only (no latches or async sequential logic).
+- Clock gates must use `CKLNQD` (from `aigpdk.v`) or the equivalent clock-gate
+  cells from the SKY130 or GF180MCU PDKs.
 
 ## Benchmarks
 

--- a/book.toml
+++ b/book.toml
@@ -5,4 +5,4 @@ src = "docs"
 
 [output.html]
 default-theme = "light"
-git-repository-url = "https://github.com/ChipFlow/Jacquard"
+git-repository-url = "https://github.com/gpu-eda/Jacquard"

--- a/docs/timing-simulation.md
+++ b/docs/timing-simulation.md
@@ -4,6 +4,27 @@
 
 This document explains GEM's boomerang evaluation architecture and how timing simulation with per-gate delays can be implemented efficiently on GPU.
 
+## Current status (what ships today)
+
+Phase 1 closed 2026-05-02; see [`plans/post-phase-0-roadmap.md`](plans/post-phase-0-roadmap.md).
+
+| Capability | Status |
+|---|---|
+| Liberty parsing | ✅ |
+| SDF back-annotation via `opensta-to-ir` | ✅ |
+| Per-DFF clock-arrival folding (Pillar B Stages 1+2) | ✅ |
+| GPU-side setup/hold violation detection | ✅ Metal, CUDA, HIP (`sim`); the `cosim` path is a follow-up |
+| **Symbolic violation messages** (`top/cpu/regs[7][bit 22] [word=42]`) | ✅ Metal, CUDA, HIP (`sim`) |
+| **`--timing-report <path.json>`** structured end-of-run report | ✅ Metal, CUDA, HIP (`sim`); not yet wired for `cosim` |
+| **`--timing-summary`** human-readable text summary | ✅ Metal, CUDA, HIP (`sim`); not yet wired for `cosim` |
+| OpenSTA detection + version check | ✅ |
+| Multi-corner timing IR (`--timing-corner <name>`) | ✅ |
+| `--sdf-corner` (min/typ/max selection from one SDF) | ⚠ One corner at a time |
+| Per-receiver wire delay (Pillar C Tier 1) | ❌ Phase 2 (blocked on ADR 0007) |
+
+See [`timing-violations.md`](timing-violations.md) for the full violation-output
+interface and [`why-jacquard.md`](why-jacquard.md) for positioning.
+
 ## Background: The Simulation Challenge
 
 GEM simulates And-Inverter Graphs (AIGs) where every node is either:

--- a/docs/timing-violations.md
+++ b/docs/timing-violations.md
@@ -195,9 +195,9 @@ Top-level shape:
   violation) needs GPU-side near-miss instrumentation and is not in
   v1.0.0; for now, `worst_slack` is populated only from actual violation
   events.
-- `--timing-report` only produces output today on the Metal sim path.
-  The CUDA / HIP / cosim paths do not currently route runtime violations
-  through `process_events` — bringing them in is independent plumbing.
+- `--timing-report` is wired on all three `sim` backends (Metal, CUDA,
+  HIP). The `cosim` path does not yet route runtime violations through
+  `process_events` — bringing it in is independent plumbing.
 - The `violations` array is capped at 100,000 records by default
   (~8 MB JSON). Override or disable the cap with
   `--timing-report-max-violations <N>` (`0` = unbounded). Setup/hold

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,7 +107,7 @@ Download and install the Rust toolchain. This is as simple as a one-liner in you
 
 Clone Jacquard along with its dependencies.
 ``` sh
-git clone https://github.com/ChipFlow/Jacquard.git
+git clone https://github.com/gpu-eda/Jacquard.git
 cd Jacquard
 git submodule update --init --recursive
 ```


### PR DESCRIPTION
## What

README/docs polish surfaced while shipping v0.2.2.

- **Inline install one-liner** — `brew install gpu-eda/homebrew-tap/jacquard` now appears in Quick Start (the fastest path was previously only reachable by clicking through to `installation.md`).
- **Relocated the timing-feature status table** out of the README top into the generated docs (`docs/timing-simulation.md § Current status`), leaving a short pointer. README now reads intro → install → usage → docs.
- **Fixed stale org references** (repo is `gpu-eda`, not `ChipFlow`): CI badge, `book.toml` `git-repository-url`, `usage.md` clone URL → `gpu-eda/Jacquard`; docs-site link `chipflow.github.io` → `gpu-eda.github.io` (the actual Pages URL).
- **Corrected stale status claims** (fact-checked against the code):
  - CUDA + HIP `sim` now route setup/hold violations through `process_events` (symbolic messages, `--timing-report`/`--timing-summary`) — the "Metal only" rows were stale; `cosim` is the remaining gap (also corrected in `timing-violations.md`).
  - Multi-corner timing IR shipped via `--timing-corner` (was marked "WS2.4 open").
  - Limitations now distinguish `jacquard sim` (static VCD) from `jacquard cosim` (reactive peripherals — SPI/UART/JTAG/APB3), and note SKY130/GF180MCU clock-gate cells alongside `CKLNQD`.

## Note

Doc-only change. The status corrections were verified against `src/`/`csrc/` and the CHANGELOG (CUDA/HIP `sim` wiring landed in `24723b5`; `--timing-corner` in v0.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)