### PR TITLE
chore(submodules): migrate eda-infra-rs + dataset to gpu-eda forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,10 @@
 [submodule "eda-infra-rs"]
 	path = vendor/eda-infra-rs
-	url = https://github.com/ChipFlow/eda-infra-rs.git
+	url = https://github.com/gpu-eda/eda-infra-rs.git
+	branch = jacquard-integration
 [submodule "benchmarks/dataset"]
 	path = benchmarks/dataset
-	url = https://github.com/ChipFlow/GEM-dataset.git
+	url = https://github.com/gpu-eda/GEM-dataset.git
 [submodule "sky130_fd_sc_hd"]
 	path = vendor/sky130_fd_sc_hd
 	url = https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hd.git


### PR DESCRIPTION
Migrates the two `ChipFlow/*` submodule forks to `gpu-eda/*` forks (admin-owned), completing the org rename, and pulls the outstanding upstream license fix into the eda-infra-rs integration branch.

## What changed
- **`vendor/eda-infra-rs`** → `gpu-eda/eda-infra-rs` @ `jacquard-integration`.
  - The fork tracks upstream `gzz2000/eda-infra-rs`.
  - The integration branch carries the 13 in-flight patches (Metal + HIP backend stack, ANSI-port + unary-NOT parser fixes), **rebased onto upstream/master** so it now includes the license-string fix `026070c` (gzz2000#2).
  - Gitlink `e4e3db0` → `b518f55`; `.gitmodules` adds `branch = jacquard-integration`.
- **`benchmarks/dataset`** → `gpu-eda/GEM-dataset` (same content/SHA `68aa63b`, fork URL only).

## Verification
- `cargo check -r --bin jacquard` passes against the rebased submodule.
- `b518f55` confirmed present on `gpu-eda/eda-infra-rs`; pinned dataset SHA present on `gpu-eda/GEM-dataset`.
- CI on this PR exercises a clean `git submodule update --init` from the new URLs.

## Not in this PR
- `vendor/chipflow-examples` still points at `ChipFlow/chipflow-examples` - this is the upstream
- Remaining upstream-PR work for the parser fixes (ANSI ports, unary-NOT) toward `gzz2000` is follow-up.