### PR TITLE
ci: fix docs-only gate filter (predicate-quantifier: every)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,14 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # `every`: a changed file counts toward `code` only if it matches
+          # ALL patterns — i.e. it is NOT under docs/ AND NOT a markdown file.
+          # `code` is then true iff at least one such non-docs file changed.
+          # (The default `some` quantifier OR-combines patterns, so a `'**'`
+          # catch-all would match every file and `code` would always be true.)
+          predicate-quantifier: 'every'
           filters: |
             code:
-              - '**'
               - '!docs/**'
               - '!**/*.md'
 


### PR DESCRIPTION
## Bug

The `changes` gate added in #145 never actually skipped docs-only PRs. Its `dorny/paths-filter` config combined `['**', '!docs/**', '!**/*.md']` with the **default `some` quantifier**, which OR-combines patterns — so the `'**'` catch-all matched every file and `code` was always `true`. The heavy GPU/macOS matrix ran on the docs PR (#146) regardless.

#145 didn't catch this because it edits `ci.yml` (a genuine code change → `code = true` either way). The flaw only surfaces on a truly docs-only diff, which is what #146 exposed.

## Fix

- Drop the `'**'` catch-all.
- Set `predicate-quantifier: 'every'`, so a changed file counts toward `code` only if it matches **all** patterns — i.e. it is NOT under `docs/**` **and** NOT `**/*.md`.
- `code` is true iff at least one such genuine source file changed; a docs-only PR yields `false` and the heavy jobs report **skipped**.

## Verification

- `actionlint`: clean (no new findings).
- This PR edits `ci.yml`, so the full matrix runs here (confirming the `code = true` path is unaffected).
- After merge, rebasing the docs PR (#146) should finally show the 7 required jobs as **skipped/green** — the real proof.