### PR TITLE
ci: deploy docs on docs-only pushes; unify push/PR gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,13 @@ name: CI
 on:
   push:
     branches: [main, staged-aig-release]
-    # Docs-only pushes (e.g. handoff updates pushed straight to main) skip the
-    # full matrix — a push is ignored only when ALL changed files match.
-    # `pull_request` deliberately has NO paths-ignore: a workflow-level skip
-    # never creates the required check runs, so a docs-only PR would deadlock on
-    # GitHub's "required check never reported" rule. Docs-only PRs are instead
-    # gated per-job via the `changes` job below (a *skipped* required job counts
-    # as passing), which keeps the `docs` job running to validate the build.
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+    # No paths-ignore: docs-only pushes must still trigger the workflow so the
+    # `docs` job runs and deploys the mdBook to GitHub Pages — a workflow-level
+    # skip would block the deploy and leave the published site stale (e.g. a
+    # renamed page would 404). The heavy code/GPU jobs are skipped per-job via
+    # the `changes` job below — the same gate as pull requests — so a docs-only
+    # push runs just the cheap `changes` + `docs` jobs, while a code push runs
+    # the full matrix.
   # No base-branch filter: run CI on every PR regardless of its base, so
   # stacked PRs (based on other feature branches) get CI automatically.
   pull_request:


### PR DESCRIPTION
## Problem

Docs-only pushes to `main` triggered **no workflow** (the push `paths-ignore: ['docs/**', '**/*.md']`), so the `docs` job never ran and the mdBook was never redeployed to GitHub Pages. A docs-only change that renames a published page (as #146 did: `usage.html` → `getting-started.html` / `synthesis-flow.html`) therefore leaves the old URL live and the new ones 404ing until some unrelated code push happens to redeploy.

This was pre-existing but latent — it only bites when a published page is renamed or added without an accompanying code change.

## Fix

Remove the push `paths-ignore` and rely on the same `changes` gate already used for PRs:

- **Docs-only push to main** → `code = false` → heavy code/GPU jobs skip, but the (ungated) `docs` job runs and **deploys**. Site stays current.
- **Code push** → `code = true` → full matrix runs as before.

So a docs-only push now runs just the cheap `changes` + `docs` jobs instead of nothing, and push/PR gating share one mechanism.

## Verification

- `actionlint`: clean.
- This PR edits `ci.yml` (code change), so the full matrix runs here.
- Follow-up confirmation: after merge, this very PR's merge to main (a code change) will run the `docs` job and redeploy — publishing the getting-started/interop/synthesis-flow pages that #146 left unpublished.