### PR TITLE
build: JACQUARD_CUDA_ARCH for Blackwell (native local / all-major distribution)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ Requires CUDA toolkit installed.
 cargo build -r --features cuda --bin jacquard
 ```
 
+#### CUDA target architecture
+
+By default the kernel is built with PTX for `compute_50` plus SASS for `sm_70`
+and `sm_80`; newer GPUs run via PTX JIT at first load. To target a specific
+architecture, set `JACQUARD_CUDA_ARCH`, which is passed straight to `nvcc` as
+`-arch=<value>`:
+
+```sh
+# Local dev — build native SASS for the GPU in THIS machine (fastest, no
+# first-load JIT). Example: an sm_120 Blackwell card.
+JACQUARD_CUDA_ARCH=native cargo build -r --features cuda --bin jacquard
+
+# Distribution — portable SASS for every major arch the toolkit knows, plus
+# PTX for the newest (needs CUDA ≥ 12.8 to include Blackwell sm_100/sm_120).
+JACQUARD_CUDA_ARCH=all-major cargo build -r --features cuda --bin jacquard
+```
+
+Any `nvcc` `-arch` value works (`native`, `all-major`, `all`, `sm_120`, …).
+Leave it unset to keep the default behavior.
+
 ## Usage
 
 Simulate a gate-level netlist with a VCD input waveform:

--- a/build.rs
+++ b/build.rs
@@ -57,7 +57,29 @@ fn main() {
     {
         println!("Building CUDA source files for GEM...");
         let csrc_headers = ucc::import_csrc();
-        let mut cl_cuda = ucc::cl_cuda();
+        // CUDA target architecture.
+        //
+        // `JACQUARD_CUDA_ARCH`, when set, is passed straight through to nvcc as
+        // `-arch=<value>` and overrides ucc's numeric gencode/PTX defaults.
+        // Accepts any nvcc `-arch` value:
+        //   - `native`     — build SASS for the GPU(s) in THIS machine. Best for
+        //                    local dev (e.g. an `sm_120` Blackwell box); fastest
+        //                    kernel, no first-load JIT, but not portable.
+        //   - `all-major`  — SASS for every major arch the toolkit knows plus PTX
+        //                    for the newest. Portable; use for distribution.
+        //   - `sm_120` / `compute_90` / … — an explicit single target.
+        // Unset → ucc defaults (PTX compute_50 + SASS sm_70/sm_80), which run on
+        // newer GPUs via PTX JIT.
+        println!("cargo:rerun-if-env-changed=JACQUARD_CUDA_ARCH");
+        let mut cl_cuda = match std::env::var("JACQUARD_CUDA_ARCH") {
+            Ok(arch) if !arch.is_empty() => {
+                println!("Using CUDA -arch={arch} (JACQUARD_CUDA_ARCH)");
+                let mut b = ucc::cl_cuda_arch(None, None);
+                b.flag(&format!("-arch={arch}"));
+                b
+            }
+            _ => ucc::cl_cuda(),
+        };
         cl_cuda.ccbin(false);
         cl_cuda.flag("-lineinfo");
         cl_cuda.flag("-maxrregcount=128");

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -126,6 +126,13 @@ These items are tracked in [`docs/plans/post-phase-0-roadmap.md`](plans/post-pha
 - [ ] **HIP CI** on the AMD runner green on main. Currently disabled
       in `.github/workflows/ci.yml` (`if: ${{ false }}`, ~line 357).
       Re-enable when the AMD runner is online.
+- [ ] **Prebuilt CUDA/HIP binaries** (ADR 0018 Phase 4), when produced, must
+      build with `JACQUARD_CUDA_ARCH=all-major` so the kernel ships portable
+      SASS for every major arch (`sm_50`…`sm_120` on CUDA ≥ 12.8, Blackwell
+      included) plus PTX for the newest — see the README § CUDA target
+      architecture. Local dev uses `JACQUARD_CUDA_ARCH=native` instead. The
+      `nvidia1.local` Blackwell box (`sm_120`, CUDA 12.8) is a candidate
+      self-hosted CUDA release runner.
 - [x] Vendored-dep license posture confirmed
       ([gzz2000/eda-infra-rs#2](https://github.com/gzz2000/eda-infra-rs/issues/2#issuecomment-4363789319)
       — sverilogparse AGPL declaration acknowledged as a typo; workspace


### PR DESCRIPTION
## Why

The CUDA kernel was always built with ucc's numeric defaults — PTX `compute_50` + SASS `sm_70`/`sm_80`. On a Blackwell GPU (`sm_120`) there's **no native SASS**: it runs only via first-load JIT of the `compute_50` PTX (suboptimal), and the build breaks entirely once the toolkit drops the legacy targets (CUDA 13).

## What

Add an opt-in **`JACQUARD_CUDA_ARCH`** env var in `build.rs`, passed straight to `nvcc` as `-arch=<value>` via the already-public `ucc::cl_cuda_arch` — no forked-submodule change. Unset preserves today's behavior.

- `JACQUARD_CUDA_ARCH=native` — local dev; native SASS for the machine's GPU.
- `JACQUARD_CUDA_ARCH=all-major` — distribution; portable SASS for every major arch + PTX for the newest.
- Any nvcc `-arch` value works (`native`, `all-major`, `all`, `sm_120`, …).

Docs: README § *CUDA target architecture*; `release-process.md` records that Phase-4 prebuilt CUDA/HIP binaries (ADR 0018) build with `all-major`.

## Verified on real Blackwell hardware (`nvidia1.local`: RTX 5060 Ti, sm_120, CUDA 12.8)

| Build | Result |
|---|---|
| `native` (debug) | kernel SASS = **sm_120**; `jacquard 0.2.4` binary built |
| `all-major` (debug) | SASS = **sm_50, 60, 70, 80, 90, sm_100, sm_120**; `sim --check-with-cpu` → `sanity test passed`, VCD matches golden |
| `all-major` (**release**, the distribution command) | optimized binary, SASS `sm_50…sm_120`, `--check-with-cpu` passed |

So the CUDA path compiles **and computes correctly** on Blackwell, cross-checked against the CPU reference.

## Follow-ups (not in this PR)

- Stand up a self-hosted CUDA release runner (nvidia1.local is a candidate) and add a Phase-4 CUDA distribution job that sets `JACQUARD_CUDA_ARCH=all-major`.
- `release-process.md` line ~123 says CUDA CI is disabled (`if: ${{ false }}`), but CUDA Tests currently run green on `tesla4-runner` — that note looks stale and is worth reconciling separately.