### PR TITLE
ci: split CUDA build (free runner) from test (GPU runner)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,7 +601,11 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: false
-      # Test fixtures live in the main repo; submodules are build-time only.
+      # Test fixtures live in the main repo, but sky130-cell sims (inv_chain_pnr)
+      # read the PDK functional models at runtime, so that submodule is needed
+      # here too. (eda-infra-rs is build-time only — not needed in the test job.)
+      - name: Init runtime PDK models
+        run: git submodule update --init vendor/sky130_fd_sc_hd
       - name: Install CUDA runtime for the prebuilt binary
         run: |
           nvidia-smi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,34 +528,33 @@ jobs:
             perf_metrics/
 
   # Build and run CUDA simulation on NVIDIA GPU
-  cuda:
+  # Compile the CUDA backend on a FREE standard runner. nvcc cross-compiles
+  # SASS without a GPU present, so the expensive part (Rust deps + kernel
+  # compile) costs no paid GPU-runner minutes — the `cuda` job below only runs
+  # the resulting binary. `all-major` SASS keeps the artifact portable across
+  # the GPU test runners (T4 sm_75 today, Blackwell sm_120 later). Built on
+  # ubuntu-22.04 (glibc 2.35) so the binary runs on the GPU runner regardless of
+  # its (>= 22.04) image.
+  cuda-build:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
-    name: CUDA Tests
-    # Re-enabled 2026-06-05 on the GitHub-hosted T4 GPU runner
-    # (`tesla4-runner`, 4 vCPU + 1 NVIDIA T4). Runs on every push — CUDA
-    # had no CI coverage from 2026-05-01 (when self-hosted nvidia-runner-1
-    # went offline) until this runner landed.
-    runs-on: tesla4-runner
+    name: CUDA Build
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
         run: git submodule update --init vendor/eda-infra-rs vendor/sky130_fd_sc_hd
-
-      - name: Install CUDA Toolkit (driver already present on GPU runner)
+      - name: Install CUDA Toolkit (no GPU needed to compile)
         run: |
-          nvidia-smi
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends cuda-toolkit-12-8
-          echo "PATH=/usr/local/cuda-12.8/bin:$PATH" >> $GITHUB_ENV
-          echo "CUDA_PATH=/usr/local/cuda-12.8" >> $GITHUB_ENV
+          echo "PATH=/usr/local/cuda-12.8/bin:$PATH" >> "$GITHUB_ENV"
+          echo "CUDA_PATH=/usr/local/cuda-12.8" >> "$GITHUB_ENV"
           /usr/local/cuda-12.8/bin/nvcc --version
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
       - name: Cache cargo
         uses: actions/cache@v5
         with:
@@ -565,16 +564,57 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-cuda-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-cuda-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-cuda-
+            ${{ runner.os }}-cargo-cuda-build-
+      - name: Build jacquard (CUDA, all-major)
+        run: JACQUARD_CUDA_ARCH=all-major cargo build --release --features cuda --bin jacquard
+      - name: Upload jacquard-cuda binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: jacquard-cuda
+          path: target/release/jacquard
+          retention-days: 1
 
-      - name: Build jacquard (CUDA)
-        run: cargo build --release --features cuda --bin jacquard
+  cuda:
+    needs: [changes, cuda-build]
+    # always() + the code=='true' guard so a *failed* cuda-build surfaces as a
+    # FAILED "CUDA Tests" (via the gate step) rather than a skip — a skipped
+    # required check counts as passing and would hide build breakage. Docs-only
+    # PRs (code=='false') still skip the whole job.
+    if: always() && needs.changes.outputs.code == 'true'
+    name: CUDA Tests
+    # Runs the prebuilt binary on the GitHub-hosted T4 GPU runner
+    # (`tesla4-runner`); only the actual GPU execution spends paid minutes here.
+    runs-on: tesla4-runner
+    steps:
+      - name: Gate on the build
+        if: needs.cuda-build.result != 'success'
+        run: |
+          echo "cuda-build did not succeed (result: ${{ needs.cuda-build.result }})" >&2
+          exit 1
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      # Test fixtures live in the main repo; submodules are build-time only.
+      - name: Install CUDA runtime for the prebuilt binary
+        run: |
+          nvidia-smi
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cuda-cudart-12-8 \
+            || sudo apt-get install -y --no-install-recommends cuda-toolkit-12-8
+          echo "LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+      - name: Download jacquard (CUDA)
+        uses: actions/download-artifact@v8
+        with:
+          name: jacquard-cuda
+          path: target/release
+      - name: Make binary executable
+        run: chmod +x target/release/jacquard
 
       - name: Run CUDA simulation (timing test)
         run: |
-          time (cargo run --release --features cuda --bin jacquard -- sim \
+          time (target/release/jacquard sim \
             tests/timing_test/dff_test_synth.gv \
             tests/timing_test/dff_test.vcd \
             tests/timing_test/ci_cuda_output.vcd \
@@ -591,7 +631,7 @@ jobs:
 
       - name: Run CUDA simulation with X-propagation
         run: |
-          cargo run --release --features cuda --bin jacquard -- sim \
+          target/release/jacquard sim \
             tests/timing_test/dff_test_synth.gv \
             tests/timing_test/dff_test.vcd \
             tests/timing_test/ci_cuda_xprop_output.vcd \
@@ -615,7 +655,7 @@ jobs:
       - name: Run CUDA simulation with timing (inv_chain_pnr, #104)
         run: |
           set -o pipefail
-          cargo run --release --features cuda --bin jacquard -- sim \
+          target/release/jacquard sim \
             tests/timing_test/inv_chain_pnr/inv_chain.v \
             tests/timing_test/inv_chain_pnr/inv_chain_stimulus.vcd \
             tests/timing_test/inv_chain_pnr/jacquard_timed_output_cuda.vcd \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,31 +718,31 @@ jobs:
   # Build and run HIP simulation on NVIDIA GPU (HIP's NVIDIA backend)
   # This validates the HIP code path using hipcc targeting NVIDIA via HIP_PLATFORM=nvidia.
   # When an AMD GPU runner becomes available, a native AMD job can be added.
-  hip-on-nvidia:
+  # HIP (NVIDIA backend) build on a FREE runner — like cuda-build. hipcc here
+  # targets nvcc (HIP_PLATFORM=nvidia); neither needs a GPU to compile, so the
+  # whole CUDA-toolkit + ROCm install + compile moves off the paid GPU runner —
+  # the biggest single saving, since the ROCm install is the heaviest setup.
+  hip-build:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
-    name: HIP Tests (NVIDIA backend)
-    # Re-enabled 2026-06-05 on the GitHub-hosted T4 runner (`tesla4-runner`).
-    # This job builds the HIP code path with hipcc + HIP_PLATFORM=nvidia, so
-    # it validates the HIP backend on the same T4. A native AMD GPU job is
-    # still future work (needs an AMD/ROCm runner).
-    runs-on: tesla4-runner
+    name: HIP Build
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
         run: git submodule update --init vendor/eda-infra-rs vendor/sky130_fd_sc_hd
-
-      - name: Install CUDA Toolkit (driver already present on GPU runner)
+      - name: Install CUDA Toolkit (no GPU needed to compile)
         run: |
-          nvidia-smi
+          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          rm -f cuda-keyring_1.1-1_all.deb
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends cuda-toolkit-12-8
-          echo "PATH=/usr/local/cuda-12.8/bin:$PATH" >> $GITHUB_ENV
-          echo "CUDA_PATH=/usr/local/cuda-12.8" >> $GITHUB_ENV
+          echo "PATH=/usr/local/cuda-12.8/bin:$PATH" >> "$GITHUB_ENV"
+          echo "CUDA_PATH=/usr/local/cuda-12.8" >> "$GITHUB_ENV"
           /usr/local/cuda-12.8/bin/nvcc --version
-
       - name: Install ROCm/HIP (NVIDIA backend)
         run: |
           # Import ROCm GPG signing key
@@ -753,9 +753,9 @@ jobs:
           echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/6.2.4 ${CODENAME} main" | \
             sudo tee /etc/apt/sources.list.d/rocm.list
           sudo apt-get update
-          # hip-runtime-nvidia pulls nvidia driver packages that conflict with the
-          # server-variant drivers pre-installed on the GPU runner. Download the HIP
-          # .deb files individually and force-install, bypassing driver dep conflicts.
+          # hip-runtime-nvidia pulls nvidia driver packages; download the HIP
+          # .deb files individually and force-install, bypassing driver dep
+          # conflicts.
           DLDIR=$(mktemp -d)
           pushd "$DLDIR"
           for pkg in hip-runtime-nvidia hip-dev hipcc-nvidia rocm-core; do
@@ -766,18 +766,15 @@ jobs:
           ls -la *.deb 2>/dev/null || { echo "ERROR: No .deb files downloaded!"; exit 1; }
           sudo dpkg --force-depends --force-conflicts -i *.deb
           popd
-          # Verify hipcc is available
           /opt/rocm/bin/hipcc --version
-          echo "PATH=/opt/rocm/bin:$PATH" >> $GITHUB_ENV
-          echo "HIP_PLATFORM=nvidia" >> $GITHUB_ENV
-          echo "HIP_COMPILER=nvcc" >> $GITHUB_ENV
-          echo "HIP_RUNTIME=cuda" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH:-}" >> $GITHUB_ENV
-          echo "LIBRARY_PATH=/opt/rocm/lib:${LIBRARY_PATH:-}" >> $GITHUB_ENV
-
+          echo "PATH=/opt/rocm/bin:$PATH" >> "$GITHUB_ENV"
+          echo "HIP_PLATFORM=nvidia" >> "$GITHUB_ENV"
+          echo "HIP_COMPILER=nvcc" >> "$GITHUB_ENV"
+          echo "HIP_RUNTIME=cuda" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=/opt/rocm/lib:${LIBRARY_PATH:-}" >> "$GITHUB_ENV"
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
       - name: Cache cargo
         uses: actions/cache@v5
         with:
@@ -787,16 +784,57 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-hip-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-hip-build-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-hip-
-
+            ${{ runner.os }}-cargo-hip-build-
       - name: Build jacquard (HIP)
         run: cargo build --release --features hip --bin jacquard
+      - name: Upload jacquard-hip binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: jacquard-hip
+          path: target/release/jacquard
+          retention-days: 1
+
+  hip-on-nvidia:
+    needs: [changes, hip-build]
+    # See the cuda job: always() + the code guard so a failed build fails this
+    # required check instead of silently skipping.
+    if: always() && needs.changes.outputs.code == 'true'
+    name: HIP Tests (NVIDIA backend)
+    # Runs the prebuilt HIP-on-NVIDIA binary on the T4. HIP_PLATFORM=nvidia
+    # lowers HIP calls straight onto the CUDA runtime, so only cudart is needed
+    # at run time — no ROCm install on the paid runner.
+    runs-on: tesla4-runner
+    steps:
+      - name: Gate on the build
+        if: needs.hip-build.result != 'success'
+        run: |
+          echo "hip-build did not succeed (result: ${{ needs.hip-build.result }})" >&2
+          exit 1
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Init runtime PDK models
+        run: git submodule update --init vendor/sky130_fd_sc_hd
+      - name: Install CUDA runtime for the prebuilt binary
+        run: |
+          nvidia-smi
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends cuda-cudart-12-8 \
+            || sudo apt-get install -y --no-install-recommends cuda-toolkit-12-8
+          echo "LD_LIBRARY_PATH=/usr/local/cuda-12.8/lib64:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+      - name: Download jacquard (HIP)
+        uses: actions/download-artifact@v8
+        with:
+          name: jacquard-hip
+          path: target/release
+      - name: Make binary executable
+        run: chmod +x target/release/jacquard
 
       - name: Run HIP simulation (timing test)
         run: |
-          time (cargo run --release --features hip --bin jacquard -- sim \
+          time (target/release/jacquard sim \
             tests/timing_test/dff_test_synth.gv \
             tests/timing_test/dff_test.vcd \
             tests/timing_test/ci_hip_output.vcd \
@@ -813,7 +851,7 @@ jobs:
 
       - name: Run HIP simulation with X-propagation
         run: |
-          cargo run --release --features hip --bin jacquard -- sim \
+          target/release/jacquard sim \
             tests/timing_test/dff_test_synth.gv \
             tests/timing_test/dff_test.vcd \
             tests/timing_test/ci_hip_xprop_output.vcd \
@@ -833,7 +871,7 @@ jobs:
       - name: Run HIP simulation with timing (inv_chain_pnr, #104)
         run: |
           set -o pipefail
-          cargo run --release --features hip --bin jacquard -- sim \
+          target/release/jacquard sim \
             tests/timing_test/inv_chain_pnr/inv_chain.v \
             tests/timing_test/inv_chain_pnr/inv_chain_stimulus.vcd \
             tests/timing_test/inv_chain_pnr/jacquard_timed_output_hip.vcd \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,11 @@ jobs:
         run: git submodule update --init vendor/eda-infra-rs vendor/sky130_fd_sc_hd
       - name: Install CUDA Toolkit (no GPU needed to compile)
         run: |
+          # Standard ubuntu runners don't carry NVIDIA's CUDA apt repo (the
+          # tesla4 GPU image does), so add it before installing the toolkit.
+          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          rm -f cuda-keyring_1.1-1_all.deb
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends cuda-toolkit-12-8
           echo "PATH=/usr/local/cuda-12.8/bin:$PATH" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ Requires CUDA toolkit installed.
 cargo build -r --features cuda --bin jacquard
 ```
 
+#### CUDA target architecture
+
+By default the kernel is built with PTX for `compute_50` plus SASS for `sm_70`
+and `sm_80`; newer GPUs run via PTX JIT at first load. To target a specific
+architecture, set `JACQUARD_CUDA_ARCH`, which is passed straight to `nvcc` as
+`-arch=<value>`:
+
+```sh
+# Local dev — build native SASS for the GPU in THIS machine (fastest, no
+# first-load JIT). Example: an sm_120 Blackwell card.
+JACQUARD_CUDA_ARCH=native cargo build -r --features cuda --bin jacquard
+
+# Distribution — portable SASS for every major arch the toolkit knows, plus
+# PTX for the newest (needs CUDA ≥ 12.8 to include Blackwell sm_100/sm_120).
+JACQUARD_CUDA_ARCH=all-major cargo build -r --features cuda --bin jacquard
+```
+
+Any `nvcc` `-arch` value works (`native`, `all-major`, `all`, `sm_120`, …).
+Leave it unset to keep the default behavior.
+
 ## Usage
 
 Simulate a gate-level netlist with a VCD input waveform:

--- a/build.rs
+++ b/build.rs
@@ -54,7 +54,29 @@ fn main() {
     {
         println!("Building CUDA source files for GEM...");
         let csrc_headers = ucc::import_csrc();
-        let mut cl_cuda = ucc::cl_cuda();
+        // CUDA target architecture.
+        //
+        // `JACQUARD_CUDA_ARCH`, when set, is passed straight through to nvcc as
+        // `-arch=<value>` and overrides ucc's numeric gencode/PTX defaults.
+        // Accepts any nvcc `-arch` value:
+        //   - `native`     — build SASS for the GPU(s) in THIS machine. Best for
+        //                    local dev (e.g. an `sm_120` Blackwell box); fastest
+        //                    kernel, no first-load JIT, but not portable.
+        //   - `all-major`  — SASS for every major arch the toolkit knows plus PTX
+        //                    for the newest. Portable; use for distribution.
+        //   - `sm_120` / `compute_90` / … — an explicit single target.
+        // Unset → ucc defaults (PTX compute_50 + SASS sm_70/sm_80), which run on
+        // newer GPUs via PTX JIT.
+        println!("cargo:rerun-if-env-changed=JACQUARD_CUDA_ARCH");
+        let mut cl_cuda = match std::env::var("JACQUARD_CUDA_ARCH") {
+            Ok(arch) if !arch.is_empty() => {
+                println!("Using CUDA -arch={arch} (JACQUARD_CUDA_ARCH)");
+                let mut b = ucc::cl_cuda_arch(None, None);
+                b.flag(&format!("-arch={arch}"));
+                b
+            }
+            _ => ucc::cl_cuda(),
+        };
         cl_cuda.ccbin(false);
         cl_cuda.flag("-lineinfo");
         cl_cuda.flag("-maxrregcount=128");

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -126,6 +126,13 @@ These items are tracked in [`docs/plans/post-phase-0-roadmap.md`](plans/post-pha
 - [ ] **HIP CI** on the AMD runner green on main. Currently disabled
       in `.github/workflows/ci.yml` (`if: ${{ false }}`, ~line 357).
       Re-enable when the AMD runner is online.
+- [ ] **Prebuilt CUDA/HIP binaries** (ADR 0018 Phase 4), when produced, must
+      build with `JACQUARD_CUDA_ARCH=all-major` so the kernel ships portable
+      SASS for every major arch (`sm_50`…`sm_120` on CUDA ≥ 12.8, Blackwell
+      included) plus PTX for the newest — see the README § CUDA target
+      architecture. Local dev uses `JACQUARD_CUDA_ARCH=native` instead. The
+      `nvidia1.local` Blackwell box (`sm_120`, CUDA 12.8) is a candidate
+      self-hosted CUDA release runner.
 - [x] Vendored-dep license posture confirmed
       ([gzz2000/eda-infra-rs#2](https://github.com/gzz2000/eda-infra-rs/issues/2#issuecomment-4363789319)
       — sverilogparse AGPL declaration acknowledged as a typo; workspace


### PR DESCRIPTION
## Why

The `cuda` job compiled `jacquard` on the **paid** GitHub-hosted T4 GPU runner. `nvcc` cross-compiles SASS **without a GPU**, so most of those billed minutes were spent on a build that doesn't need the hardware. On a public repo, standard Linux runners are free — so move the compile there and reserve the GPU runner for execution.

This is the structural fix behind the spending-cap incident: GPU-runner minutes should track *test execution*, not compilation.

## What

- **New `cuda-build`** (`ubuntu-22.04`, free): installs the CUDA toolkit, builds `--features cuda` with `JACQUARD_CUDA_ARCH=all-major`, uploads the binary as an artifact.
- **`cuda` ("CUDA Tests", `tesla4-runner`)** now **downloads** that binary and runs the sim / xprop / timed / cosim steps — no compile. Installs only the CUDA *runtime* (`cuda-cudart`, with a fallback to the full toolkit).

`all-major` (from #149) is what makes the prebuilt artifact portable: one binary with SASS for the T4 (`sm_75`) *and* Blackwell (`sm_120`). The split and the arch flag reinforce each other.

## Correctness details

- **Required-check name preserved.** The test job stays `name: CUDA Tests`, so branch protection needs no change. The new `cuda-build` is a separate (non-required) job.
- **Build failures don't hide.** The test job uses `if: always() && needs.changes.outputs.code == 'true'` plus a gate step that fails if `cuda-build` didn't succeed — otherwise a skipped required check would count as passing and mask a broken build. Docs-only PRs still skip the whole thing.
- **glibc.** Built on `ubuntu-22.04` (glibc 2.35) so the artifact runs on the GPU runner's image.

## Assumptions CI will confirm

- `cuda-cudart-12-8` is installable on the T4 runner (fallback to `cuda-toolkit-12-8` if not).
- The ubuntu-22.04-built binary runs on the T4 runner image (glibc compatible).

## Follow-ups

- **HIP** (`hip-on-nvidia`, same `tesla4` pattern) gets the same split — its ROCm install is an even bigger chunk to move off the GPU runner. Deliberately a separate commit so this CUDA split validates first. Analysis says HIP-on-NVIDIA's runtime is just `cudart`+`cuda` (build.rs links those for `HIP_PLATFORM=nvidia`), so the test job won't need ROCm — CI will confirm.
- A future native AMD/ROCm runner slots straight into this model (build free, test on the AMD box).