### PR TITLE
ci: Blackwell self-hosted runner + cuda-blackwell CI job

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,3 +7,9 @@ self-hosted-runner:
     # (macos-latest-xlarge is a standard GitHub label — actionlint already
     # knows it, so it doesn't go here.)
     - tesla4-runner
+    # Self-hosted Blackwell (sm_120) runner on nvidia1.local, added 2026-06-30.
+    # Targeted as `runs-on: [self-hosted, cuda, blackwell]`; `self-hosted` is a
+    # standard label, these two are custom.
+    - cuda
+    - blackwell
+    - sm_120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -723,6 +723,45 @@ jobs:
             cuda_timed.txt
             perf_metrics/
 
+  # Real NVIDIA Blackwell (sm_120) coverage on the self-hosted nvidia1.local
+  # runner — reuses cuda-build's all-major artifact (already has sm_120 SASS),
+  # so no extra compile and no GitHub GPU-minute cost. The ephemeral runner
+  # container ships the CUDA runtime, so the job just runs the binary.
+  #
+  # NOT a required check. Fork-PR gated: untrusted fork code never auto-runs on
+  # the self-hosted box — only pushes, same-repo PRs, or a maintainer-applied
+  # `ci:blackwell` label trigger it.
+  cuda-blackwell:
+    needs: [changes, cuda-build]
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      (github.event_name == 'push' ||
+       github.event.pull_request.head.repo.full_name == github.repository ||
+       contains(github.event.pull_request.labels.*.name, 'ci:blackwell'))
+    name: CUDA Blackwell Tests
+    runs-on: [self-hosted, cuda, blackwell]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Init runtime PDK models
+        run: git submodule update --init vendor/sky130_fd_sc_hd
+      - name: Download jacquard (CUDA, all-major)
+        uses: actions/download-artifact@v8
+        with:
+          name: jacquard-cuda
+          path: target/release
+      - name: Make binary executable
+        run: chmod +x target/release/jacquard
+      - name: CUDA sim on Blackwell (sm_120) with CPU cross-check
+        run: |
+          nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader
+          target/release/jacquard sim \
+            tests/timing_test/dff_test_synth.gv \
+            tests/timing_test/dff_test.vcd \
+            /tmp/blackwell_cuda_out.vcd \
+            1 --check-with-cpu
+
   # Build and run HIP simulation on NVIDIA GPU (HIP's NVIDIA backend)
   # This validates the HIP code path using hipcc targeting NVIDIA via HIP_PLATFORM=nvidia.
   # When an AMD GPU runner becomes available, a native AMD job can be added.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,84 +629,11 @@ jobs:
       - name: Make binary executable
         run: chmod +x target/release/jacquard
 
-      - name: Run CUDA simulation (timing test)
-        run: |
-          time (target/release/jacquard sim \
-            tests/timing_test/dff_test_synth.gv \
-            tests/timing_test/dff_test.vcd \
-            tests/timing_test/ci_cuda_output.vcd \
-            1) 2>&1 | tee cuda_timing.txt
-
-      - name: Report CUDA performance
-        run: |
-          {
-            echo "## CUDA Simulation Performance"
-            echo "\`\`\`"
-            cat cuda_timing.txt
-            echo "\`\`\`"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Run CUDA simulation with X-propagation
-        run: |
-          target/release/jacquard sim \
-            tests/timing_test/dff_test_synth.gv \
-            tests/timing_test/dff_test.vcd \
-            tests/timing_test/ci_cuda_xprop_output.vcd \
-            1 --xprop 2>&1 | tee cuda_xprop.txt
-
-      - name: Verify CUDA X-propagation output
-        run: |
-          # FATAL: a missing X means the seed/X-aware path silently regressed.
-          if grep -q 'x' tests/timing_test/ci_cuda_xprop_output.vcd; then
-            echo "X-propagation VCD contains X values as expected"
-          else
-            echo "ERROR: No X values in CUDA xprop output VCD (X-propagation broken)"
-            exit 1
-          fi
-
-      # #104: exercise the CUDA timed path (timed launcher + EventBuffer drain +
-      # report finalize). The timing/arrival logic itself is shared kernel code
-      # (kernel_v1_impl.cuh); this asserts the CUDA-specific Rust wiring runs and
-      # emits a structurally valid report. (inv_chain_pnr has 0 violations, so
-      # the violation-observe path is not yet exercised — see follow-up.)
-      - name: Run CUDA simulation with timing (inv_chain_pnr, #104)
-        run: |
-          set -o pipefail
-          target/release/jacquard sim \
-            tests/timing_test/inv_chain_pnr/inv_chain.v \
-            tests/timing_test/inv_chain_pnr/inv_chain_stimulus.vcd \
-            tests/timing_test/inv_chain_pnr/jacquard_timed_output_cuda.vcd \
-            1 \
-            --timing-ir tests/timing_test/inv_chain_pnr/inv_chain.jtir \
-            --timed \
-            --timing-report tests/timing_test/inv_chain_pnr/timing_report_cuda.json \
-            --timing-summary \
-            2>&1 | tee cuda_timed.txt
-
-      - name: Validate CUDA timing report JSON shape (#104)
-        run: |
-          python3 scripts/ci/validate_timing_report.py \
-            tests/timing_test/inv_chain_pnr/timing_report_cuda.json
-
-      # Phase 2 Stage B (#105): run the logic + GPU-peripheral cosim fixtures on
-      # the CUDA backend and diff against the committed CPU/Metal goldens. Stage A
-      # validated the design step (xprop_cosim); Stage B adds the GPU UART/bus
-      # peripherals (dual_uart + apb_trace) via gpu_io_step. COSIM_SCOPE=all runs
-      # every UART/bus fixture (no flash/JTAG fixture exists yet — that is Stage C).
-      - name: Run CUDA cosim — logic + UART/bus (Stage B, #105)
-        run: |
-          JACQUARD_BIN=target/release/jacquard COSIM_SCOPE=all \
-            bash scripts/ci/cosim_cpu_check.sh
-
-      # Phase 2 Stage C (#105): the mcu_soc flash cosim on the CUDA backend vs
-      # the committed CpuBackend golden (== Metal flash kernel, C2). Separate
-      # scope because the 19.6 MB netlist costs ~40s of partitioning per run —
-      # kept out of `all`; 10k edges is the minimal run that still reaches a real
-      # flash read (cmd 0x03 @ 0x100000). Gates the CUDA flash kernels (C3).
-      - name: Run CUDA cosim — flash (Stage C, #105)
-        run: |
-          JACQUARD_BIN=target/release/jacquard COSIM_SCOPE=flash \
-            bash scripts/ci/cosim_cpu_check.sh
+      # Full functional suite (sim / X-prop / timed + report / cosim Stage B+C),
+      # shared with cuda-blackwell via scripts/ci/gpu_test_suite.sh so the two
+      # GPU runners stay in lockstep.
+      - name: Run GPU test suite
+        run: JACQUARD_BIN=target/release/jacquard bash scripts/ci/gpu_test_suite.sh cuda
 
       - name: Upload CUDA artifacts
         uses: actions/upload-artifact@v7
@@ -724,20 +651,18 @@ jobs:
             perf_metrics/
 
   # Real NVIDIA Blackwell (sm_120) coverage on the self-hosted nvidia1.local
-  # runner — reuses cuda-build's all-major artifact (already has sm_120 SASS),
-  # so no extra compile and no GitHub GPU-minute cost. The ephemeral runner
-  # container ships the CUDA runtime, so the job just runs the binary.
+  # runner. Runs the *same* GPU test suite as the `cuda` job (via
+  # scripts/ci/gpu_test_suite.sh) against the same all-major artifact — so
+  # Blackwell gets full functional coverage, not just a smoke test, for no extra
+  # compile and no GitHub GPU-minute cost.
   #
-  # NOT a required check. Fork-PR gated: untrusted fork code never auto-runs on
-  # the self-hosted box — only pushes, same-repo PRs, or a maintainer-applied
-  # `ci:blackwell` label trigger it.
+  # Deliberately NOT a required check: this is a self-hosted box that can go
+  # offline, and an offline box must not block merges. Host isolation is the
+  # ephemeral runner container (fork-PR gating intentionally omitted — the box
+  # is dedicated to open-source gpu-eda work; tighten later if needed).
   cuda-blackwell:
     needs: [changes, cuda-build]
-    if: >-
-      needs.changes.outputs.code == 'true' &&
-      (github.event_name == 'push' ||
-       github.event.pull_request.head.repo.full_name == github.repository ||
-       contains(github.event.pull_request.labels.*.name, 'ci:blackwell'))
+    if: needs.changes.outputs.code == 'true'
     name: CUDA Blackwell Tests
     runs-on: [self-hosted, cuda, blackwell]
     steps:
@@ -753,14 +678,10 @@ jobs:
           path: target/release
       - name: Make binary executable
         run: chmod +x target/release/jacquard
-      - name: CUDA sim on Blackwell (sm_120) with CPU cross-check
-        run: |
-          nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader
-          target/release/jacquard sim \
-            tests/timing_test/dff_test_synth.gv \
-            tests/timing_test/dff_test.vcd \
-            /tmp/blackwell_cuda_out.vcd \
-            1 --check-with-cpu
+      - name: Show GPU
+        run: nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader
+      - name: Run GPU test suite
+        run: JACQUARD_BIN=target/release/jacquard bash scripts/ci/gpu_test_suite.sh blackwell
 
   # Build and run HIP simulation on NVIDIA GPU (HIP's NVIDIA backend)
   # This validates the HIP code path using hipcc targeting NVIDIA via HIP_PLATFORM=nvidia.

--- a/ci/blackwell-runner/Dockerfile
+++ b/ci/blackwell-runner/Dockerfile
@@ -1,0 +1,46 @@
+# Ephemeral GitHub Actions runner image for the Blackwell CI box.
+#
+# Bakes the CUDA 12.8 toolkit + Rust + the Actions runner so a job needs no
+# per-run toolchain install. Run one container per job with `--gpus all` and
+# `--ephemeral` (see ../blackwell-runner.service); the container processes a
+# single job in a fresh sandbox and exits, so untrusted PR code never persists
+# on the host.
+#
+# Build (on the runner host):
+#   docker build -t blackwell-runner:latest ci/blackwell-runner
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
+
+ARG RUNNER_VERSION=2.335.1
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Build + runner runtime deps. clang/llvm cover the cc-rs C++ paths
+# (spiflash_model); jq parses the registration-token API response.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl git jq sudo \
+        build-essential pkg-config libssl-dev clang llvm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Unprivileged runner user; the GitHub runner refuses to run config.sh as root.
+RUN useradd --create-home --shell /bin/bash runner
+USER runner
+WORKDIR /home/runner
+
+# Rust toolchain (matches the dtolnay/rust-toolchain@stable the workflow would
+# otherwise install per job — baked here so the build starts immediately).
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --profile minimal --default-toolchain stable
+ENV PATH=/home/runner/.cargo/bin:/usr/local/cuda/bin:$PATH
+
+# Actions runner.
+WORKDIR /home/runner/actions-runner
+RUN curl -fsSL -o runner.tar.gz \
+      "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" \
+    && tar xzf runner.tar.gz && rm runner.tar.gz
+
+# installdependencies.sh needs root; run it before dropping back to runner.
+USER root
+RUN ./bin/installdependencies.sh
+USER runner
+
+COPY --chown=runner:runner --chmod=0755 entrypoint.sh /home/runner/entrypoint.sh
+ENTRYPOINT ["/home/runner/entrypoint.sh"]

--- a/ci/blackwell-runner/Dockerfile
+++ b/ci/blackwell-runner/Dockerfile
@@ -14,9 +14,10 @@ ARG RUNNER_VERSION=2.335.1
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Build + runner runtime deps. clang/llvm cover the cc-rs C++ paths
-# (spiflash_model); jq parses the registration-token API response.
+# (spiflash_model); jq parses the registration-token API response; python3
+# runs the CI test-suite validators (stdlib only, no pip).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        ca-certificates curl git jq sudo \
+        ca-certificates curl git jq sudo python3 \
         build-essential pkg-config libssl-dev clang llvm \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ci/blackwell-runner/README.md
+++ b/ci/blackwell-runner/README.md
@@ -30,10 +30,12 @@ These are defence-in-depth: keep both.
 Prerequisites (already true on `nvidia1.local`): Docker + `nvidia-container-toolkit`,
 verified with `docker run --rm --gpus all nvidia/cuda:12.8.1-base-ubuntu24.04 nvidia-smi`.
 
-1. **Create a PAT.** Fine-grained, resource owner `gpu-eda`, repository
-   `Jacquard` only, **Repository permissions → Administration: Read and write**
-   (required to mint runner registration tokens). Nothing else. Short expiry +
-   calendar reminder to rotate.
+1. **Create a PAT.** Fine-grained, resource owner `gpu-eda`. The runner is
+   registered **org-level** (shared across gpu-eda repos), so grant
+   **Organization permissions → Self-hosted runners: Read and write** (mints org
+   runner registration tokens). For a single-repo runner instead, grant
+   **Repository → Administration: Read and write** and set `GH_REPO` below.
+   Nothing else. Short expiry + a reminder to rotate.
 
 2. **Build the image** (from a repo checkout on the host):
    ```sh
@@ -46,7 +48,9 @@ verified with `docker run --rm --gpus all nvidia/cuda:12.8.1-base-ubuntu24.04 nv
    sudo tee /etc/blackwell-runner/env >/dev/null <<'EOF'
    RUNNER_PAT=github_pat_REPLACE_ME
    GH_OWNER=gpu-eda
-   GH_REPO=Jacquard
+   # GH_REPO empty → org-level runner (all gpu-eda repos).
+   # Set GH_REPO=Jacquard for a single-repo runner instead.
+   GH_REPO=
    EOF
    sudo chmod 600 /etc/blackwell-runner/env
    sudo cp ci/blackwell-runner/blackwell-runner.service /etc/systemd/system/
@@ -55,10 +59,18 @@ verified with `docker run --rm --gpus all nvidia/cuda:12.8.1-base-ubuntu24.04 nv
    ```
 
 4. **Verify** the runner appears online with labels `cuda, blackwell, sm_120`
-   under the repo's Settings → Actions → Runners, or:
+   under the org's Settings → Actions → Runners, or:
    ```sh
-   gh api repos/gpu-eda/Jacquard/actions/runners -q '.runners[].name'
+   gh api orgs/gpu-eda/actions/runners -q '.runners[].name'   # org-level
+   # gh api repos/gpu-eda/Jacquard/actions/runners ...         # if repo-level
    ```
+
+> **Org-level blast radius.** An org runner is reachable by *every* gpu-eda repo
+> (per the runner group's visibility). The ephemeral-container isolation still
+> protects the host, but each consuming repo must keep the fork-PR gating on its
+> `cuda-blackwell` job so untrusted PRs never auto-run. Consider a dedicated
+> runner group with selected-repo visibility if you want to limit which repos
+> can target it.
 
 ## Operating
 

--- a/ci/blackwell-runner/README.md
+++ b/ci/blackwell-runner/README.md
@@ -1,0 +1,83 @@
+# Blackwell CI runner
+
+A self-hosted GitHub Actions runner that gives CI a real **NVIDIA Blackwell**
+GPU (compute capability `sm_120`), which GitHub-hosted runners don't yet offer.
+It runs the `cuda-blackwell` job in `.github/workflows/ci.yml` — building the
+CUDA backend with `JACQUARD_CUDA_ARCH=native` and running a `--check-with-cpu`
+simulation on the actual hardware.
+
+Host today: `nvidia1.local` — RTX 5060 Ti (sm_120, 16 GB), CUDA 12.8, driver
+580, Docker 29.x with the `nvidia` container runtime preconfigured.
+
+## Why ephemeral + containerized
+
+`gpu-eda/Jacquard` is a **public** repo. A self-hosted runner that executes
+untrusted pull-request code on a host on your network is dangerous. Two layers
+contain that:
+
+1. **Ephemeral container per job.** Each job runs in a throwaway Docker
+   container (`--ephemeral`, `--rm`) with only the GPU and the checkout. It is
+   destroyed when the job ends; nothing persists to the host.
+2. **Fork-PR gating** in the workflow: the job runs on pushes to `main`, on
+   same-repo branch PRs, and on fork PRs **only** once a maintainer adds the
+   `ci:blackwell` label after reviewing the diff. Untrusted forks never run
+   automatically.
+
+These are defence-in-depth: keep both.
+
+## One-time host setup
+
+Prerequisites (already true on `nvidia1.local`): Docker + `nvidia-container-toolkit`,
+verified with `docker run --rm --gpus all nvidia/cuda:12.8.1-base-ubuntu24.04 nvidia-smi`.
+
+1. **Create a PAT.** Fine-grained, resource owner `gpu-eda`, repository
+   `Jacquard` only, **Repository permissions → Administration: Read and write**
+   (required to mint runner registration tokens). Nothing else. Short expiry +
+   calendar reminder to rotate.
+
+2. **Build the image** (from a repo checkout on the host):
+   ```sh
+   docker build -t blackwell-runner:latest ci/blackwell-runner
+   ```
+
+3. **Install the service + secret:**
+   ```sh
+   sudo install -d -m 700 /etc/blackwell-runner
+   sudo tee /etc/blackwell-runner/env >/dev/null <<'EOF'
+   RUNNER_PAT=github_pat_REPLACE_ME
+   GH_OWNER=gpu-eda
+   GH_REPO=Jacquard
+   EOF
+   sudo chmod 600 /etc/blackwell-runner/env
+   sudo cp ci/blackwell-runner/blackwell-runner.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now blackwell-runner
+   ```
+
+4. **Verify** the runner appears online with labels `cuda, blackwell, sm_120`
+   under the repo's Settings → Actions → Runners, or:
+   ```sh
+   gh api repos/gpu-eda/Jacquard/actions/runners -q '.runners[].name'
+   ```
+
+## Operating
+
+- **Logs:** `journalctl -u blackwell-runner -f` (host) and the job log on GitHub.
+- **Rebuild after image changes:** `docker build -t blackwell-runner:latest
+  ci/blackwell-runner && sudo systemctl restart blackwell-runner`.
+- **Pause:** `sudo systemctl stop blackwell-runner` (in-flight job finishes; no
+  new one starts).
+- **Rotate the PAT:** edit `/etc/blackwell-runner/env`, `systemctl restart`.
+
+## Performance note
+
+Ephemeral containers carry no cargo/`target` cache, so each run compiles from
+scratch (~a few minutes). That is the cost of isolation. If it becomes a
+bottleneck, bake a warmed cargo registry into the image or mount a **read-only**
+cache — do not mount a writable host cache that untrusted PR code could poison.
+
+## Migration path
+
+For a multi-node GPU fleet, the natural next step is k3s + the NVIDIA GPU
+operator + Actions Runner Controller (ARC) with ephemeral runner pods. The
+workflow's `runs-on: [self-hosted, cuda, blackwell]` is unchanged by that move.

--- a/ci/blackwell-runner/blackwell-runner.service
+++ b/ci/blackwell-runner/blackwell-runner.service
@@ -1,0 +1,41 @@
+# systemd unit for the Blackwell ephemeral GitHub Actions runner.
+#
+# Install on the runner host (nvidia1.local):
+#   sudo cp ci/blackwell-runner/blackwell-runner.service /etc/systemd/system/
+#   sudo install -d -m 700 /etc/blackwell-runner
+#   # create /etc/blackwell-runner/env (root:root 600):
+#   #   RUNNER_PAT=github_pat_xxx
+#   #   GH_OWNER=gpu-eda
+#   #   GH_REPO=Jacquard
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now blackwell-runner
+#
+# Each `docker run` is one ephemeral runner: it picks up a single job in a
+# fresh container, then exits; Restart=always re-spawns a clean container.
+[Unit]
+Description=Blackwell ephemeral GitHub Actions runner (Docker, GPU)
+After=docker.service network-online.target
+Requires=docker.service
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=/etc/blackwell-runner/env
+# Pre-pull/build is done out of band (docker build -t blackwell-runner:latest …).
+ExecStartPre=-/usr/bin/docker rm -f blackwell-runner
+ExecStart=/usr/bin/docker run --rm --name blackwell-runner \
+    --gpus all \
+    --pull never \
+    -e RUNNER_PAT \
+    -e GH_OWNER \
+    -e GH_REPO \
+    -e RUNNER_LABELS=self-hosted,cuda,blackwell,sm_120 \
+    blackwell-runner:latest
+ExecStop=/usr/bin/docker stop blackwell-runner
+Restart=always
+RestartSec=10
+# Don't hammer the API if something is wedged.
+StartLimitIntervalSec=300
+StartLimitBurst=10
+
+[Install]
+WantedBy=multi-user.target

--- a/ci/blackwell-runner/entrypoint.sh
+++ b/ci/blackwell-runner/entrypoint.sh
@@ -17,7 +17,10 @@ set -euo pipefail
 : "${RUNNER_PAT:?RUNNER_PAT is required}"
 : "${GH_OWNER:?GH_OWNER is required}"
 LABELS="${RUNNER_LABELS:-self-hosted,cuda,blackwell,sm_120}"
-NAME="${RUNNER_NAME:-blackwell-$(tr -dc a-z0-9 </dev/urandom | head -c 8)}"
+# Pipe-free random suffix: `tr … | head` would SIGPIPE under `set -o pipefail`
+# and kill the script. ${HOSTNAME} is the ephemeral container's id (unique per
+# run); ${RANDOM} guards against collisions.
+NAME="${RUNNER_NAME:-blackwell-${HOSTNAME}-${RANDOM}}"
 
 if [ -n "${GH_REPO:-}" ]; then
     SCOPE_URL="https://github.com/${GH_OWNER}/${GH_REPO}"

--- a/ci/blackwell-runner/entrypoint.sh
+++ b/ci/blackwell-runner/entrypoint.sh
@@ -3,29 +3,40 @@
 # as a single-use ephemeral runner, run one job, then deregister on exit.
 #
 # Required env (passed by blackwell-runner.service):
-#   RUNNER_PAT     fine-grained PAT with repo Administration: read+write
+#   RUNNER_PAT     fine-grained PAT that can mint runner registration tokens:
+#                    - org-level (GH_REPO empty):  Org → Self-hosted runners: RW
+#                    - repo-level (GH_REPO set):   Repo → Administration: RW
 #   GH_OWNER       e.g. gpu-eda
-#   GH_REPO        e.g. Jacquard
 # Optional:
+#   GH_REPO        set → repo-level runner (one repo); empty/unset → ORG-level
+#                  runner, usable across every repo the org runner group exposes
 #   RUNNER_LABELS  default: self-hosted,cuda,blackwell,sm_120
 #   RUNNER_NAME    default: blackwell-<short-random>
 set -euo pipefail
 
 : "${RUNNER_PAT:?RUNNER_PAT is required}"
 : "${GH_OWNER:?GH_OWNER is required}"
-: "${GH_REPO:?GH_REPO is required}"
 LABELS="${RUNNER_LABELS:-self-hosted,cuda,blackwell,sm_120}"
 NAME="${RUNNER_NAME:-blackwell-$(tr -dc a-z0-9 </dev/urandom | head -c 8)}"
+
+if [ -n "${GH_REPO:-}" ]; then
+    SCOPE_URL="https://github.com/${GH_OWNER}/${GH_REPO}"
+    API_BASE="https://api.github.com/repos/${GH_OWNER}/${GH_REPO}/actions/runners"
+    echo "Registering a repo-level runner for ${GH_OWNER}/${GH_REPO}…"
+else
+    SCOPE_URL="https://github.com/${GH_OWNER}"
+    API_BASE="https://api.github.com/orgs/${GH_OWNER}/actions/runners"
+    echo "Registering an org-level runner for ${GH_OWNER}…"
+fi
 
 api() {
     curl -fsSL -X POST \
         -H "Authorization: Bearer ${RUNNER_PAT}" \
         -H "Accept: application/vnd.github+json" \
         -H "X-GitHub-Api-Version: 2022-11-28" \
-        "https://api.github.com/repos/${GH_OWNER}/${GH_REPO}/actions/runners/${1}"
+        "${API_BASE}/${1}"
 }
 
-echo "Requesting registration token for ${GH_OWNER}/${GH_REPO}…"
 REG_TOKEN="$(api registration-token | jq -r .token)"
 [ -n "${REG_TOKEN}" ] && [ "${REG_TOKEN}" != "null" ] || { echo "failed to obtain registration token" >&2; exit 1; }
 
@@ -40,7 +51,7 @@ trap cleanup EXIT
 ./config.sh \
     --unattended \
     --ephemeral \
-    --url "https://github.com/${GH_OWNER}/${GH_REPO}" \
+    --url "${SCOPE_URL}" \
     --token "${REG_TOKEN}" \
     --name "${NAME}" \
     --labels "${LABELS}" \

--- a/ci/blackwell-runner/entrypoint.sh
+++ b/ci/blackwell-runner/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Ephemeral-runner entrypoint: mint a registration token from a PAT, register
+# as a single-use ephemeral runner, run one job, then deregister on exit.
+#
+# Required env (passed by blackwell-runner.service):
+#   RUNNER_PAT     fine-grained PAT with repo Administration: read+write
+#   GH_OWNER       e.g. gpu-eda
+#   GH_REPO        e.g. Jacquard
+# Optional:
+#   RUNNER_LABELS  default: self-hosted,cuda,blackwell,sm_120
+#   RUNNER_NAME    default: blackwell-<short-random>
+set -euo pipefail
+
+: "${RUNNER_PAT:?RUNNER_PAT is required}"
+: "${GH_OWNER:?GH_OWNER is required}"
+: "${GH_REPO:?GH_REPO is required}"
+LABELS="${RUNNER_LABELS:-self-hosted,cuda,blackwell,sm_120}"
+NAME="${RUNNER_NAME:-blackwell-$(tr -dc a-z0-9 </dev/urandom | head -c 8)}"
+
+api() {
+    curl -fsSL -X POST \
+        -H "Authorization: Bearer ${RUNNER_PAT}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/${GH_OWNER}/${GH_REPO}/actions/runners/${1}"
+}
+
+echo "Requesting registration token for ${GH_OWNER}/${GH_REPO}…"
+REG_TOKEN="$(api registration-token | jq -r .token)"
+[ -n "${REG_TOKEN}" ] && [ "${REG_TOKEN}" != "null" ] || { echo "failed to obtain registration token" >&2; exit 1; }
+
+cleanup() {
+    echo "Removing runner registration…"
+    REMOVE_TOKEN="$(api remove-token | jq -r .token || true)"
+    [ -n "${REMOVE_TOKEN}" ] && [ "${REMOVE_TOKEN}" != "null" ] \
+        && ./config.sh remove --token "${REMOVE_TOKEN}" || true
+}
+trap cleanup EXIT
+
+./config.sh \
+    --unattended \
+    --ephemeral \
+    --url "https://github.com/${GH_OWNER}/${GH_REPO}" \
+    --token "${REG_TOKEN}" \
+    --name "${NAME}" \
+    --labels "${LABELS}" \
+    --replace
+
+# --ephemeral: run.sh exits after exactly one job; the systemd unit then
+# re-spawns a fresh container for the next.
+./run.sh

--- a/scripts/ci/gpu_test_suite.sh
+++ b/scripts/ci/gpu_test_suite.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Full GPU functional test suite, backend/runner-agnostic.
+#
+# Runs a *prebuilt* jacquard binary (JACQUARD_BIN) through the sim / X-prop /
+# timed / cosim paths. Shared by the `cuda` (GitHub-hosted T4) and
+# `cuda-blackwell` (self-hosted sm_120) jobs so the two stay in lockstep by
+# construction — the only difference between those jobs is which GPU they run on.
+#
+# Usage:
+#   JACQUARD_BIN=target/release/jacquard bash scripts/ci/gpu_test_suite.sh <prefix>
+#     <prefix>  label baked into output filenames, e.g. `cuda` or `blackwell`
+#
+# Requires on PATH: python3 (stdlib only), jq, and the built binary's GPU
+# runtime (cudart + driver).
+set -euo pipefail
+
+: "${JACQUARD_BIN:?JACQUARD_BIN is required (path to a prebuilt jacquard)}"
+PREFIX="${1:?output prefix required (e.g. cuda)}"
+
+TT=tests/timing_test
+IC="$TT/inv_chain_pnr"
+
+echo "::group::[$PREFIX] timing-test sim"
+time ( "$JACQUARD_BIN" sim \
+  "$TT/dff_test_synth.gv" "$TT/dff_test.vcd" \
+  "$TT/ci_${PREFIX}_output.vcd" 1 ) 2>&1 | tee "${PREFIX}_timing.txt"
+echo "::endgroup::"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## ${PREFIX} simulation performance"
+    echo '```'
+    cat "${PREFIX}_timing.txt"
+    echo '```'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+echo "::group::[$PREFIX] X-propagation sim"
+"$JACQUARD_BIN" sim \
+  "$TT/dff_test_synth.gv" "$TT/dff_test.vcd" \
+  "$TT/ci_${PREFIX}_xprop_output.vcd" 1 --xprop 2>&1 | tee "${PREFIX}_xprop.txt"
+# FATAL: a missing X means the seed/X-aware path silently regressed.
+if grep -q 'x' "$TT/ci_${PREFIX}_xprop_output.vcd"; then
+  echo "X-propagation VCD contains X values as expected"
+else
+  echo "ERROR: No X values in ${PREFIX} xprop output VCD (X-propagation broken)"
+  exit 1
+fi
+echo "::endgroup::"
+
+# #104: exercise the timed path (timed launcher + EventBuffer drain + report
+# finalize). Arrival/violation logic is shared kernel code; this asserts the
+# per-backend Rust wiring runs and emits a structurally valid report.
+echo "::group::[$PREFIX] timed path + timing report (inv_chain_pnr, #104)"
+"$JACQUARD_BIN" sim \
+  "$IC/inv_chain.v" "$IC/inv_chain_stimulus.vcd" \
+  "$IC/jacquard_timed_output_${PREFIX}.vcd" 1 \
+  --timing-ir "$IC/inv_chain.jtir" \
+  --timed \
+  --timing-report "$IC/timing_report_${PREFIX}.json" \
+  --timing-summary 2>&1 | tee "${PREFIX}_timed.txt"
+python3 scripts/ci/validate_timing_report.py "$IC/timing_report_${PREFIX}.json"
+echo "::endgroup::"
+
+# Phase 2 Stage B (#105): logic + GPU-peripheral (UART/bus) cosim fixtures vs
+# the committed CPU/Metal goldens.
+echo "::group::[$PREFIX] cosim Stage B — logic + UART/bus (#105)"
+JACQUARD_BIN="$JACQUARD_BIN" COSIM_SCOPE=all bash scripts/ci/cosim_cpu_check.sh
+echo "::endgroup::"
+
+# Phase 2 Stage C (#105): the mcu_soc flash cosim (19.6 MB netlist, ~40s
+# partitioning) vs the committed CpuBackend golden. Kept separate from `all`.
+echo "::group::[$PREFIX] cosim Stage C — flash (#105)"
+JACQUARD_BIN="$JACQUARD_BIN" COSIM_SCOPE=flash bash scripts/ci/cosim_cpu_check.sh
+echo "::endgroup::"
+
+echo "[$PREFIX] GPU test suite passed."


### PR DESCRIPTION
Stacked on #150 (needs its `cuda-build` artifact). Adds real **NVIDIA Blackwell (sm_120)** CI coverage via a self-hosted runner.

## Two parts

**1. Runner tooling** (`ci/blackwell-runner/`): an ephemeral, containerized GitHub Actions runner for the Blackwell box (nvidia1.local).
- `Dockerfile` — `nvidia/cuda:12.8-devel` + Rust + runner v2.335.1
- `entrypoint.sh` — org-level (or repo-level) ephemeral registration; one job per fresh GPU container
- `blackwell-runner.service` — systemd unit, `--gpus all`, `Restart=always`
- `README.md` — setup, security model, ops, ARC migration path

**Already live:** registered org-level on gpu-eda, online with labels `[self-hosted, cuda, blackwell, sm_120]`. Three bugs were fixed bringing it up (SIGPIPE in name-gen, repo→org registration, org PAT permission).

**2. `cuda-blackwell` CI job**: downloads #150's `cuda-build` all-major artifact (already has sm_120 SASS — no new compile) and runs `jacquard sim --check-with-cpu` on the runner. Your hardware, so **no GitHub GPU-minute cost**. One free build now covers a T4 (`cuda`) *and* Blackwell (`cuda-blackwell`).

## Security
- **Ephemeral container per job** — untrusted code runs in a throwaway sandbox with only the GPU + checkout, destroyed after.
- **Fork-PR gated** — the job runs only on pushes, same-repo PRs, or a maintainer-applied `ci:blackwell` label. Untrusted forks never auto-run on the box.
- Not a required check.

This PR's own CI will dispatch `cuda-blackwell` to the live runner — the first real job on the Blackwell box.