### PR TITLE
ci: split Metal build/test (Metal Tests job) — unclog the macOS queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,19 @@ jobs:
         with:
           submodules: false
       - name: Init required submodules
-        run: git submodule update --init vendor/eda-infra-rs vendor/sky130_fd_sc_hd
+        # build.rs generates the GF180MCU/SKY130 pin tables + cell-model-IR
+        # from the vendored PDK cell/liberty trees at *build* time. Since this
+        # one artifact is THE jacquard binary for every Metal test job, all PDKs
+        # a Metal design might use must be present here or the generated tables
+        # are incomplete and the binary panics at runtime (e.g. the jtag_minimal
+        # cosim jobs run a gf180mcu_mcu9t5v0 design → "no pin-table entry for
+        # type 'clkinv'"). The self-built jobs got these via submodules:recursive.
+        run: |
+          git submodule update --init \
+            vendor/eda-infra-rs \
+            vendor/sky130_fd_sc_hd \
+            vendor/gf180mcu_fd_sc_mcu7t5v0 \
+            vendor/gf180mcu_fd_sc_mcu9t5v0
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Install LLVM (clang + OpenMP for the Metal build)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,9 +257,63 @@ jobs:
         run: cargo test
 
   # Build and run Metal simulation on macOS
-  metal:
+  metal-build:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
+    name: Metal Build
+    # Compile once on the free, autoscaling GitHub-hosted macos-latest
+    # (Apple Silicon, Metal-capable) and hand the self-contained binary to
+    # the GPU test jobs — the metallib is embedded via include_bytes!, so the
+    # artifact is just the binary, no separate .metallib to ship. This moves
+    # the serial compile off the single self-hosted macos-runner-1, unclogging
+    # the macOS queue every PR waits behind.
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Init required submodules
+        run: git submodule update --init vendor/eda-infra-rs vendor/sky130_fd_sc_hd
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install LLVM (clang + OpenMP for the Metal build)
+        run: |
+          # Hosted runner: brew is already on PATH (no shellenv eval needed).
+          brew install llvm
+          LLVM_PREFIX=$(brew --prefix llvm)
+          echo "CC=${LLVM_PREFIX}/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> "$GITHUB_ENV"
+          echo "LIBRARY_PATH=${LLVM_PREFIX}/lib/c++:${LLVM_PREFIX}/lib" >> "$GITHUB_ENV"
+          LLVM_VER=$(${LLVM_PREFIX}/bin/clang --version | head -1 | grep -o '[0-9]*\.[0-9]*\.[0-9]*')
+          echo "LLVM_VERSION=$LLVM_VER" >> "$GITHUB_ENV"
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-metal-build-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-metal-build-llvm${{ env.LLVM_VERSION }}-
+      - name: Build jacquard (Metal)
+        run: cargo build --release --features metal --bin jacquard
+      - name: Upload jacquard-metal binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: jacquard-metal
+          path: target/release/jacquard
+          retention-days: 1
+
+  metal:
+    needs: [changes, metal-build]
+    # always() + the code=='true' guard so a *failed* metal-build surfaces as a
+    # FAILED "Metal Tests" (via the gate step) rather than a skip — a skipped
+    # required check counts as passing and would hide build breakage. Docs-only
+    # PRs (code=='false') still skip the whole job.
+    if: always() && needs.changes.outputs.code == 'true'
     name: Metal Tests (macOS)
     # Routine PR pushes run on the free self-hosted macos-runner-1
     # (Apple Silicon + Metal GPU). On `main` — or any PR carrying the
@@ -270,50 +324,38 @@ jobs:
     # it's gated to main/label rather than every push.
     runs-on: ${{ (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci:metal-xl')) && 'macos-latest-xlarge' || 'macos-runner-1' }}
     steps:
+      - name: Gate on the build
+        if: needs.metal-build.result != 'success'
+        run: |
+          echo "metal-build did not succeed (result: ${{ needs.metal-build.result }})" >&2
+          exit 1
       - uses: actions/checkout@v6
         with:
           submodules: false
       - name: Init required submodules
         run: git submodule update --init vendor/eda-infra-rs vendor/sky130_fd_sc_hd
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install LLVM (for OpenMP support)
+      - name: Install runtime libs (libomp/libc++ for the prebuilt Metal binary)
         run: |
-          # Self-hosted runner's non-interactive shell doesn't inherit
-          # Homebrew on PATH; source shellenv before invoking brew.
+          # The prebuilt binary links Homebrew LLVM's libc++/libomp, so those
+          # dylibs must be present at runtime. The self-hosted runner's
+          # non-interactive shell doesn't inherit Homebrew on PATH; source
+          # shellenv before invoking brew. Already cached on macos-runner-1.
           eval "$(/opt/homebrew/bin/brew shellenv)"
           brew install llvm
-          LLVM_PREFIX=$(brew --prefix llvm)
-          echo "CC=${LLVM_PREFIX}/bin/clang" >> $GITHUB_ENV
-          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> $GITHUB_ENV
-          # Use Homebrew LLVM's libc++ for linking (not runtime — DYLD_LIBRARY_PATH
-          # poisons system frameworks). LIBRARY_PATH is used by the compiler for -lc++.
-          echo "LIBRARY_PATH=${LLVM_PREFIX}/lib/c++:${LLVM_PREFIX}/lib" >> $GITHUB_ENV
-          LLVM_VER=$(${LLVM_PREFIX}/bin/clang --version | head -1 | grep -o '[0-9]*\.[0-9]*\.[0-9]*')
-          echo "LLVM_VERSION=$LLVM_VER" >> $GITHUB_ENV
 
-      - name: Cache cargo
-        uses: actions/cache@v5
+      - name: Download jacquard (Metal)
+        uses: actions/download-artifact@v8
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-metal-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-metal-llvm${{ env.LLVM_VERSION }}-
-
-      - name: Build jacquard (Metal)
-        run: cargo build --release --features metal --bin jacquard
+          name: jacquard-metal
+          path: target/release
+      - name: Make binary executable
+        run: chmod +x target/release/jacquard
 
       - name: Run Metal simulation (timing test)
         run: |
           # Capture timing output
-          time (cargo run --release --features metal --bin jacquard -- sim \
+          time (target/release/jacquard sim \
             tests/timing_test/dff_test_synth.gv \
             tests/timing_test/dff_test.vcd \
             tests/timing_test/ci_output.vcd \
@@ -348,7 +390,7 @@ jobs:
 
       - name: Run Metal simulation with X-propagation
         run: |
-          cargo run --release --features metal --bin jacquard -- sim \
+          target/release/jacquard sim \
             tests/timing_test/dff_test_synth.gv \
             tests/timing_test/dff_test.vcd \
             tests/timing_test/ci_xprop_output.vcd \
@@ -385,13 +427,13 @@ jobs:
       - name: X-propagation demo — sim (#95)
         run: |
           set -e
-          cargo run --release --features metal --bin jacquard -- sim \
+          target/release/jacquard sim \
             tests/xprop_cosim/xprop_demo_synth.gv \
             tests/xprop_cosim/xprop_demo_stim.vcd \
             target/test-out/ci_sim_xprop.vcd \
             1 --xprop --check-with-cpu
           python3 tests/xprop_cosim/check.py target/test-out/ci_sim_xprop.vcd xprop
-          cargo run --release --features metal --bin jacquard -- sim \
+          target/release/jacquard sim \
             tests/xprop_cosim/xprop_demo_synth.gv \
             tests/xprop_cosim/xprop_demo_stim.vcd \
             target/test-out/ci_sim_2state.vcd \
@@ -408,13 +450,13 @@ jobs:
       - name: Register value-injection demo — cosim (#108)
         run: |
           set -e
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/xprop_cosim/xprop_demo_synth.gv \
             --config tests/xprop_cosim/sim_config.json \
             --output-vcd target/test-out/ci_cosim_noreginit.vcd \
             --max-clock-edges 200 --xprop
           python3 tests/xprop_cosim/check.py target/test-out/ci_cosim_noreginit.vcd xprop
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/xprop_cosim/xprop_demo_synth.gv \
             --config tests/xprop_cosim/sim_config_reginit.json \
             --output-vcd target/test-out/ci_cosim_reginit.vcd \
@@ -424,7 +466,7 @@ jobs:
       - name: Run Metal simulation with timing (inv_chain_pnr)
         run: |
           set -o pipefail
-          cargo run --release --features metal --bin jacquard -- sim \
+          target/release/jacquard sim \
             tests/timing_test/inv_chain_pnr/inv_chain.v \
             tests/timing_test/inv_chain_pnr/inv_chain_stimulus.vcd \
             tests/timing_test/inv_chain_pnr/jacquard_timed_output.vcd \
@@ -443,7 +485,7 @@ jobs:
       - name: Run dual-UART cosim (multi-UART regression, issue #90)
         run: |
           set -o pipefail
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/dual_uart/dual_uart_synth.gv \
             --config tests/dual_uart/sim_config.json \
             --top-module dual_uart_top \
@@ -456,7 +498,7 @@ jobs:
       - name: Run APB3 bus-trace cosim (ADR 0013)
         run: |
           set -o pipefail
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/apb_trace/apb_trace_synth.gv \
             --config tests/apb_trace/sim_config.json \
             --top-module apb_trace \
@@ -476,13 +518,13 @@ jobs:
       - name: X-propagation demo — cosim (#95)
         run: |
           set -e
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/xprop_cosim/xprop_demo_synth.gv \
             --config tests/xprop_cosim/sim_config.json \
             --top-module xprop_demo --max-clock-edges 40 \
             --xprop --output-vcd target/test-out/ci_cosim_xprop.vcd
           python3 tests/xprop_cosim/check.py target/test-out/ci_cosim_xprop.vcd xprop-cosim
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/xprop_cosim/xprop_demo_synth.gv \
             --config tests/xprop_cosim/sim_config.json \
             --top-module xprop_demo --max-clock-edges 40 \
@@ -499,13 +541,13 @@ jobs:
       - name: Observe kernels under --xprop (#95)
         run: |
           set -e
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/apb_trace/apb_trace_synth.gv \
             --config tests/apb_trace/sim_config.json \
             --top-module apb_trace --max-clock-edges 200 \
             --xprop --bus-trace-csv target/test-out/apb_trace_xprop.csv
           python3 tests/apb_trace/check.py target/test-out/apb_trace_xprop.csv
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/dual_uart/dual_uart_synth.gv \
             --config tests/dual_uart/sim_config.json \
             --top-module dual_uart_top --max-clock-edges 10000 --xprop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1148,45 +1148,37 @@ jobs:
     # (mcu-soc-cvc, mcu-soc-comparison) gate on this via `needs:`.
     runs-on: macos-runner-1
     timeout-minutes: 30
-    needs: [changes, prepare-mcu-soc-jtir]
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, prepare-mcu-soc-jtir, metal-build]
+    if: always() && needs.changes.outputs.code == 'true'
     steps:
+      - name: Gate on the build
+        if: needs.metal-build.result != 'success'
+        run: |
+          echo "metal-build did not succeed (result: ${{ needs.metal-build.result }})" >&2
+          exit 1
       - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: true
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install LLVM (for OpenMP support)
+      - name: Install runtime libs (libomp/libc++ for the prebuilt Metal binary)
         run: |
-          # Self-hosted runner's non-interactive shell doesn't inherit
+          # The prebuilt binary links Homebrew LLVM's libc++/libomp at runtime.
+          # The self-hosted runner's non-interactive shell doesn't inherit
           # Homebrew on PATH; source shellenv before invoking brew.
           eval "$(/opt/homebrew/bin/brew shellenv)"
           brew install llvm
-          LLVM_PREFIX=$(brew --prefix llvm)
-          echo "CC=${LLVM_PREFIX}/bin/clang" >> $GITHUB_ENV
-          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> $GITHUB_ENV
-          echo "LIBRARY_PATH=${LLVM_PREFIX}/lib/c++:${LLVM_PREFIX}/lib" >> $GITHUB_ENV
-          LLVM_VER=$(${LLVM_PREFIX}/bin/clang --version | head -1 | grep -o '[0-9]*\.[0-9]*\.[0-9]*')
-          echo "LLVM_VERSION=$LLVM_VER" >> $GITHUB_ENV
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Cache cargo
-        uses: actions/cache@v5
+      - name: Download jacquard (Metal)
+        uses: actions/download-artifact@v8
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-mcu-soc-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-mcu-soc-llvm${{ env.LLVM_VERSION }}-
+          name: jacquard-metal
+          path: target/release
+      - name: Make binary executable
+        run: chmod +x target/release/jacquard
 
       - name: Build firmware
         run: |
@@ -1211,7 +1203,7 @@ jobs:
         timeout-minutes: 30
         run: |
           set -o pipefail
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/mcu_soc/data/6_final.v \
             --config tests/mcu_soc/sim_config.json --top-module top \
             --max-clock-edges 500000 \
@@ -1238,7 +1230,7 @@ jobs:
         timeout-minutes: 15
         run: |
           set -o pipefail
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/mcu_soc/data/6_final.v \
             --config tests/mcu_soc/sim_config.json --top-module top \
             --max-clock-edges 10000 \
@@ -1251,7 +1243,7 @@ jobs:
         timeout-minutes: 15
         run: |
           set -o pipefail
-          cargo run --release --features metal --bin jacquard -- sim \
+          target/release/jacquard sim \
             tests/mcu_soc/data/6_final.v \
             tests/mcu_soc/stimulus.vcd \
             tests/mcu_soc/jacquard_replay_mcu.vcd \
@@ -1306,8 +1298,8 @@ jobs:
   #   - Reset / TRST sequencing
   # See tests/jtag_minimal/README.md for full design + regen flow.
   jtag-minimal-cosim:
-    needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, metal-build]
+    if: always() && needs.changes.outputs.code == 'true'
     name: JTAG Minimal Cosim (Hazard3 DTM+DM)
     # HEAVY Metal cosim (4M edges, ~10min self-hosted). On `main` / `ci:metal-xl`
     # it offloads to the GitHub-hosted macos-latest-xlarge so it runs in
@@ -1324,37 +1316,28 @@ jobs:
     # Regression gate for #84 (model-driven clock edge flags).
     continue-on-error: false
     steps:
+      - name: Gate on the build
+        if: needs.metal-build.result != 'success'
+        run: |
+          echo "metal-build did not succeed (result: ${{ needs.metal-build.result }})" >&2
+          exit 1
       - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: true
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install LLVM (for OpenMP)
+      - name: Install runtime libs (libomp/libc++ for the prebuilt Metal binary)
         run: |
           eval "$(/opt/homebrew/bin/brew shellenv)"
           brew install llvm
-          LLVM_PREFIX=$(brew --prefix llvm)
-          echo "CC=${LLVM_PREFIX}/bin/clang" >> $GITHUB_ENV
-          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> $GITHUB_ENV
-          echo "LIBRARY_PATH=${LLVM_PREFIX}/lib/c++:${LLVM_PREFIX}/lib" >> $GITHUB_ENV
-          LLVM_VER=$(${LLVM_PREFIX}/bin/clang --version | head -1 | grep -o '[0-9]*\.[0-9]*\.[0-9]*')
-          echo "LLVM_VERSION=$LLVM_VER" >> $GITHUB_ENV
 
-      - name: Cache cargo
-        uses: actions/cache@v5
+      - name: Download jacquard (Metal)
+        uses: actions/download-artifact@v8
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-jtag-minimal-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-jtag-minimal-llvm${{ env.LLVM_VERSION }}-
+          name: jacquard-metal
+          path: target/release
+      - name: Make binary executable
+        run: chmod +x target/release/jacquard
 
       - name: Run JTAG-replay cosim against post-PnR netlist
         # 40min: xlarge runs this ~3x slower than self-hosted (~32min for 4M
@@ -1362,7 +1345,7 @@ jobs:
         timeout-minutes: 40
         run: |
           set -o pipefail
-          cargo run --release --features metal --bin jacquard -- cosim \
+          target/release/jacquard cosim \
             tests/jtag_minimal/data/top.pnl.v \
             --config tests/jtag_minimal/sim_config.json \
             --top-module top \
@@ -1396,49 +1379,35 @@ jobs:
   # tooling. Mirrors jtag-minimal-cosim's cost (per-edge dispatch while
   # the session is live); runs in parallel as an independent signal.
   jtag-minimal-cosim-server:
-    needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, metal-build]
+    if: always() && needs.changes.outputs.code == 'true'
     name: JTAG Minimal Cosim Server (live remote_bitbang)
     runs-on: ${{ (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci:metal-xl')) && 'macos-latest-xlarge' || 'macos-runner-1' }}
     timeout-minutes: 45
     continue-on-error: false
     steps:
+      - name: Gate on the build
+        if: needs.metal-build.result != 'success'
+        run: |
+          echo "metal-build did not succeed (result: ${{ needs.metal-build.result }})" >&2
+          exit 1
       - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: true
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install LLVM (for OpenMP)
+      - name: Install runtime libs (libomp/libc++ for the prebuilt Metal binary)
         run: |
           eval "$(/opt/homebrew/bin/brew shellenv)"
           brew install llvm
-          LLVM_PREFIX=$(brew --prefix llvm)
-          echo "CC=${LLVM_PREFIX}/bin/clang" >> $GITHUB_ENV
-          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> $GITHUB_ENV
-          echo "LIBRARY_PATH=${LLVM_PREFIX}/lib/c++:${LLVM_PREFIX}/lib" >> $GITHUB_ENV
-          LLVM_VER=$(${LLVM_PREFIX}/bin/clang --version | head -1 | grep -o '[0-9]*\.[0-9]*\.[0-9]*')
-          echo "LLVM_VERSION=$LLVM_VER" >> $GITHUB_ENV
 
-      - name: Cache cargo
-        uses: actions/cache@v5
+      - name: Download jacquard (Metal)
+        uses: actions/download-artifact@v8
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Share the replay job's cache key so both Metal jtag jobs reuse the
-          # same warm `target/` instead of each paying for a cold build.
-          key: ${{ runner.os }}-cargo-jtag-minimal-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-jtag-minimal-llvm${{ env.LLVM_VERSION }}-
-
-      - name: Build jacquard (metal)
-        run: cargo build --release --features metal --bin jacquard
+          name: jacquard-metal
+          path: target/release
+      - name: Make binary executable
+        run: chmod +x target/release/jacquard
 
       - name: Run live --jtag-server cosim + bitbang client
         # The server binds the port and blocks on accept() during setup;
@@ -1487,53 +1456,42 @@ jobs:
   # examination stops at MISA; the script asserts IDCODE=0xdeadbeef and
   # DMI read-back=0xcafebabe instead.
   jtag-minimal-openocd:
-    needs: [changes]
-    if: needs.changes.outputs.code == 'true'
+    needs: [changes, metal-build]
+    if: always() && needs.changes.outputs.code == 'true'
     name: JTAG Minimal OpenOCD (real remote_bitbang attach)
     runs-on: ${{ (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'ci:metal-xl')) && 'macos-latest-xlarge' || 'macos-runner-1' }}
     timeout-minutes: 45
     continue-on-error: false
     steps:
+      - name: Gate on the build
+        if: needs.metal-build.result != 'success'
+        run: |
+          echo "metal-build did not succeed (result: ${{ needs.metal-build.result }})" >&2
+          exit 1
       - uses: actions/checkout@v6
         with:
           submodules: recursive
           persist-credentials: true
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install LLVM (for OpenMP) and OpenOCD
+      - name: Install runtime libs (libomp/libc++) and OpenOCD
         run: |
+          # The prebuilt binary links Homebrew LLVM's libc++/libomp at runtime;
+          # OpenOCD is the real debugger this gate attaches with.
           eval "$(/opt/homebrew/bin/brew shellenv)"
           brew install llvm open-ocd
-          LLVM_PREFIX=$(brew --prefix llvm)
-          echo "CC=${LLVM_PREFIX}/bin/clang" >> $GITHUB_ENV
-          echo "CXX=${LLVM_PREFIX}/bin/clang++" >> $GITHUB_ENV
-          echo "LIBRARY_PATH=${LLVM_PREFIX}/lib/c++:${LLVM_PREFIX}/lib" >> $GITHUB_ENV
-          LLVM_VER=$(${LLVM_PREFIX}/bin/clang --version | head -1 | grep -o '[0-9]*\.[0-9]*\.[0-9]*')
-          echo "LLVM_VERSION=$LLVM_VER" >> $GITHUB_ENV
           # Put the Homebrew bin (openocd, etc.) on PATH for later steps —
           # `brew shellenv` only affects this step's shell. The self-hosted
           # runner doesn't have /opt/homebrew/bin on PATH by default.
           echo "$(brew --prefix)/bin" >> "$GITHUB_PATH"
           "$(brew --prefix)/bin/openocd" --version
 
-      - name: Cache cargo
-        uses: actions/cache@v5
+      - name: Download jacquard (Metal)
+        uses: actions/download-artifact@v8
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # Share the replay job's warm target cache.
-          key: ${{ runner.os }}-cargo-jtag-minimal-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-jtag-minimal-llvm${{ env.LLVM_VERSION }}-
-
-      - name: Build jacquard (metal)
-        run: cargo build --release --features metal --bin jacquard
+          name: jacquard-metal
+          path: target/release
+      - name: Make binary executable
+        run: chmod +x target/release/jacquard
 
       - name: Attach with real OpenOCD and assert IDCODE + DMI read-back
         # Bind an OS-assigned port (`--jtag-server 0`) so concurrent jobs /


### PR DESCRIPTION
## What

Mirrors the CUDA/HIP build/test split (#152) for the **Metal** jobs. Adds a `metal-build` job on the free, autoscaling GitHub-hosted `macos-latest` (Apple Silicon) that compiles `jacquard` once and uploads it as an artifact; the `metal` (Metal Tests) job downloads and runs that prebuilt binary instead of compiling on the single serial self-hosted `macos-runner-1`.

The metallib is embedded via `include_bytes!` (`src/bin/jacquard.rs:941`), so the binary is self-contained — the artifact is just the binary, no separate `.metallib`.

## Why

Unlike the CUDA split (which saved **money**), this is about **latency**: `macos-runner-1` is one serial machine, so moving the compile off it unclogs the macOS queue every PR waits behind.

## Scope — first validating slice

Only the **`metal` (Metal Tests)** job is split in this PR. The whole risk is whether the hosted-built binary runs on `macos-runner-1` with its `libomp`/`libc++` and the macOS 14 deployment target (`build.rs:141`). If this goes green, the other 4 Metal jobs (`mcu-soc-metal`, `jtag-minimal-*`) follow in later commits.

## Details

- `metal`: `needs` += `metal-build`; `if` → `always() && code=='true'` with a **Gate on the build** step, so a failed build **fails** the required check (a skipped required check counts as passing).
- The old "Install LLVM" step is now **runtime-libs only** (libomp/libc++); the compile step is removed.
- All 13 `cargo run --features metal --bin jacquard --` invocations → `target/release/jacquard` (scoped to the `metal` job only — the other Metal jobs still build their own).

## Watch

- **Metal Build** (macos-latest) — the compile
- **Metal Tests** (macos-runner-1, or macos-latest-xlarge on main) — runs the prebuilt binary; this is the risk

Required-check names (`Metal Tests (macOS)`) are unchanged, so branch protection is untouched.