### PR TITLE
feat: cell-model IR — SKY130 descriptor, IHP SG13G2 (zero-Rust new PDK), clear_preset (ADR 0019)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,7 @@
 [submodule "vendor/gf180mcu_fd_sc_mcu9t5v0"]
 	path = vendor/gf180mcu_fd_sc_mcu9t5v0
 	url = https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_sc_mcu9t5v0.git
+[submodule "vendor/IHP-Open-PDK"]
+	path = vendor/IHP-Open-PDK
+	url = https://github.com/IHP-GmbH/IHP-Open-PDK.git
+	shallow = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,6 +859,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "liberty-parse"
 version = "0.2.4"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "liberty-to-cellir"

--- a/build.rs
+++ b/build.rs
@@ -220,6 +220,19 @@ fn generate_cell_descriptors() {
             top_lib: "aigpdk/aigpdk.lib",
             watch_dirs: &["aigpdk"],
         },
+        // IHP SG13G2 (open-source, added as a NEW built-in PDK with ZERO
+        // per-PDK Rust — ADR 0019 D7a, C3a). A monolithic single-`.lib`-per-corner
+        // commercial-style library (Liberate); the converter reads its `cell`
+        // groups directly (no split-lib merge) and derives the `sg13g2_` D8
+        // prefix from the cell names. Only the vendored stdcell Liberty is needed;
+        // the submodule is sparse/shallow (stdcell `lib/` + `verilog/` only). When
+        // absent on a partial checkout, an empty descriptor is embedded (as GF180).
+        DescriptorSpec {
+            out_filename: "sg13g2.cellir.json",
+            top_lib: "vendor/IHP-Open-PDK/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib/\
+                      sg13g2_stdcell_typ_1p20V_25C.lib",
+            watch_dirs: &["vendor/IHP-Open-PDK/ihp-sg13g2/libs.ref/sg13g2_stdcell/lib"],
+        },
     ];
 
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");

--- a/build.rs
+++ b/build.rs
@@ -172,9 +172,12 @@ struct DescriptorSpec {
 }
 
 fn generate_cell_descriptors() {
-    // GF180 7-track (default) and 9-track. Both vendored submodules are already
-    // required by the pin-table generators above, so this adds no new
-    // source-build submodule requirement (ADR 0019 D7).
+    // GF180 7-track (default) and 9-track, SKY130, and the internal AIGPDK.
+    // The GF180 vendored submodules are already required by the pin-table
+    // generators above, so they add no new source-build submodule requirement
+    // (ADR 0019 D7); SKY130 ships only `.lib.json` (routed through the converter
+    // loader's JSON path); AIGPDK is an in-repo `.lib` text library that is
+    // always present.
     let specs = [
         DescriptorSpec {
             out_filename: "gf180mcu_7t.cellir.json",
@@ -193,6 +196,29 @@ fn generate_cell_descriptors() {
                 "vendor/gf180mcu_fd_sc_mcu9t5v0/liberty",
                 "vendor/gf180mcu_fd_sc_mcu9t5v0/cells",
             ],
+        },
+        // SKY130: the converter loader recognises the `.lib.json` extension and
+        // assembles a per-corner library from the per-corner header plus every
+        // per-cell-per-corner `cells/**/*__tt_025C_1v80.lib.json` file. The
+        // submodule may be absent on a partial checkout, in which case an empty
+        // descriptor is embedded (mirrors GF180 below).
+        DescriptorSpec {
+            out_filename: "sky130.cellir.json",
+            top_lib: "vendor/sky130_fd_sc_hd/timing/\
+                      sky130_fd_sc_hd__tt_025C_1v80.lib.json",
+            watch_dirs: &[
+                "vendor/sky130_fd_sc_hd/timing",
+                "vendor/sky130_fd_sc_hd/cells",
+            ],
+        },
+        // AIGPDK: the internal cell library, an in-repo `.lib` text file (always
+        // present — not a submodule). Its cells have no common vendor prefix, so
+        // it declares no D8 selection prefix and serves as the no-prefix-match
+        // default fallback (wired in `bundled_descriptors`).
+        DescriptorSpec {
+            out_filename: "aigpdk.cellir.json",
+            top_lib: "aigpdk/aigpdk.lib",
+            watch_dirs: &["aigpdk"],
         },
     ];
 

--- a/crates/cell-model-ir/src/diff.rs
+++ b/crates/cell-model-ir/src/diff.rs
@@ -194,6 +194,7 @@ mod tests {
                     pin: "RN".into(),
                     active: ActiveLevel::Low,
                 }),
+                clear_preset: None,
             }),
             timing: Some(CellTiming {
                 delays: vec![],
@@ -269,6 +270,23 @@ mod tests {
             .as_mut()
             .unwrap()
             .active = ActiveLevel::High;
+        let d = diff_irs(&a, &b);
+        assert!(d
+            .mismatches
+            .iter()
+            .any(|m| m.contains("sequential (L3) block differs")));
+    }
+
+    #[test]
+    fn changed_clear_preset_tie_break_is_reported() {
+        // Adding a set-dominant clear_preset where there was none is an L3
+        // change the diff must surface (the field lives inside the seq block).
+        let a = seq_lib();
+        let mut b = seq_lib();
+        b.cells[0].sequential.as_mut().unwrap().clear_preset = Some(crate::ClearPreset {
+            var1: crate::ClearPresetVal::High,
+            var2: crate::ClearPresetVal::Low,
+        });
         let d = diff_irs(&a, &b);
         assert!(d
             .mismatches

--- a/crates/cell-model-ir/src/lib.rs
+++ b/crates/cell-model-ir/src/lib.rs
@@ -76,8 +76,11 @@ pub const SCHEMA_MAJOR: u16 = 0;
 /// the C2 L3 sequential/classification block ([`Sequential`], the extended
 /// [`CellKind`]) and the L4 corner-keyed timing block ([`CellTiming`],
 /// [`Corner`], [`CellModelIr::corners`] / [`CellModelIr::default_corner`])
-/// alongside the C1 L1+L2 fields, which are unchanged.
-pub const SCHEMA_MINOR: u16 = 2;
+/// alongside the C1 L1+L2 fields, which are unchanged. `3` adds the C4
+/// [`Sequential::clear_preset`] tie-break ([`ClearPreset`]) capturing the
+/// state when async clear and preset are asserted simultaneously — additive,
+/// `skip_serializing_if` absent, so `2`-era documents still read back.
+pub const SCHEMA_MINOR: u16 = 3;
 
 /// A whole library's worth of per-cell-type facts: one descriptor per library.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -421,6 +424,82 @@ pub struct Sequential {
     /// `None` if the cell has no async reset. (Liberty `ff` `clear`.)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub async_reset: Option<AsyncControl>,
+    /// The simultaneous-assertion tie-break for a cell with BOTH async set
+    /// (`preset`) and reset (`clear`): what the state variables take when both
+    /// are asserted at once (Liberty `clear_preset_var1` / `clear_preset_var2`).
+    /// `None` when the cell lacks a clear+preset pair, or when the Liberty group
+    /// omits the attributes. See [`ClearPreset`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clear_preset: Option<ClearPreset>,
+}
+
+/// The simultaneous-assertion tie-break for a flop/latch that has BOTH an
+/// async clear (reset) and an async preset (set): the value each of the two
+/// state variables (`Q` = `var1`, `QN` = `var2`) takes when clear AND preset
+/// are asserted at the same time. This is Liberty's `clear_preset_var1` /
+/// `clear_preset_var2`.
+///
+/// Jacquard's consumer overlay (`wire_dff_reset_set_overlay` in `src/aig.rs`)
+/// historically hardcoded reset-dominant (`var1 = L`). Most cells match, but
+/// set-dominant cells (`var1 = H`) exist across every foundry library tested
+/// (GF180 `latrsnq`, SKY130, GF130 `TLATSR`/`TLATNSR`, IHP `sg13g2_sdfbbp_1`);
+/// carrying the true tie-break here lets the consumer honour it rather than
+/// silently mis-simulating. Use [`ClearPreset::dominance`] to reduce the pair
+/// to the tie-break the overlay needs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClearPreset {
+    /// `clear_preset_var1` — the value the first state variable (`Q`) takes
+    /// when clear and preset are asserted simultaneously.
+    pub var1: ClearPresetVal,
+    /// `clear_preset_var2` — the value the second state variable (`QN`) takes
+    /// when clear and preset are asserted simultaneously. Usually the
+    /// complement of [`Self::var1`], but Liberty permits any combination.
+    pub var2: ClearPresetVal,
+}
+
+/// Which async control wins when clear and preset are asserted together, as
+/// derived from a [`ClearPreset`]'s `var1` (the `Q` state variable).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dominance {
+    /// `var1 = L` — the state goes to 0; clear (reset) wins. This is Jacquard's
+    /// legacy hardcoded behaviour and the default when `clear_preset` is absent.
+    ResetDominant,
+    /// `var1 = H` — the state goes to 1; preset (set) wins.
+    SetDominant,
+    /// `var1` is `N` / `X` / `T` (hold / unknown / toggle): not a simple
+    /// dominance. The consumer falls back to reset-dominant (the safe default).
+    Other,
+}
+
+impl ClearPreset {
+    /// Reduce the `var1`/`var2` pair to the simultaneous-assertion dominance
+    /// the consumer overlay needs, keyed on `var1` (the `Q` state variable).
+    pub fn dominance(&self) -> Dominance {
+        match self.var1 {
+            ClearPresetVal::Low => Dominance::ResetDominant,
+            ClearPresetVal::High => Dominance::SetDominant,
+            ClearPresetVal::NoChange | ClearPresetVal::Unknown | ClearPresetVal::Toggle => {
+                Dominance::Other
+            }
+        }
+    }
+}
+
+/// A Liberty `clear_preset_var*` value: the state a variable takes when clear
+/// and preset are asserted simultaneously. Liberty's five permitted values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClearPresetVal {
+    /// `L` — the state variable goes low.
+    Low,
+    /// `H` — the state variable goes high.
+    High,
+    /// `N` — no change (holds its previous value).
+    NoChange,
+    /// `X` — unknown.
+    Unknown,
+    /// `T` — toggles (inverts its previous value).
+    Toggle,
 }
 
 /// Clock pin + the edge it triggers on.
@@ -847,6 +926,7 @@ mod tests {
                     pin: "RN".into(),
                     active: ActiveLevel::Low,
                 }),
+                clear_preset: None,
             }),
             timing: Some(timing),
         });
@@ -860,8 +940,11 @@ mod tests {
         let back = CellModelIr::from_json(&json).unwrap();
         assert_eq!(ir, back);
 
-        // Schema version stamped at the C2 minor.
-        assert_eq!((back.schema_major, back.schema_minor), (SCHEMA_MAJOR, 2));
+        // Schema version stamped at the current minor.
+        assert_eq!(
+            (back.schema_major, back.schema_minor),
+            (SCHEMA_MAJOR, SCHEMA_MINOR)
+        );
 
         // L3 roles survived the round-trip.
         let seq = back
@@ -874,6 +957,114 @@ mod tests {
         assert_eq!(seq.async_reset.as_ref().unwrap().pin, "RN");
         assert_eq!(seq.async_reset.as_ref().unwrap().active, ActiveLevel::Low);
         assert_eq!(seq.async_set.as_ref().unwrap().active, ActiveLevel::Low);
+    }
+
+    #[test]
+    fn set_dominant_clear_preset_round_trips() {
+        // Take the reset+set flop and stamp it set-dominant (var1=H): the field
+        // must survive a JSON round-trip and reduce to SetDominant, while an
+        // absent field defaults to ResetDominant.
+        let mut ir = dff_with_async_reset();
+        {
+            let seq = ir.cells[0].sequential.as_mut().unwrap();
+            assert!(seq.clear_preset.is_none(), "baseline has no clear_preset");
+            seq.clear_preset = Some(ClearPreset {
+                var1: ClearPresetVal::High,
+                var2: ClearPresetVal::Low,
+            });
+        }
+        let json = ir.to_json().unwrap();
+        assert!(
+            json.contains("clear_preset"),
+            "set-dominant field must serialize:\n{json}"
+        );
+        let back = CellModelIr::from_json(&json).unwrap();
+        assert_eq!(ir, back);
+
+        let cp = back.cells[0]
+            .sequential
+            .as_ref()
+            .unwrap()
+            .clear_preset
+            .unwrap();
+        assert_eq!(cp.var1, ClearPresetVal::High);
+        assert_eq!(cp.var2, ClearPresetVal::Low);
+        assert_eq!(cp.dominance(), Dominance::SetDominant);
+
+        // Absent field is reset-dominant by omission (default = today's behavior).
+        assert!(dff_with_async_reset().cells[0]
+            .sequential
+            .as_ref()
+            .unwrap()
+            .clear_preset
+            .is_none());
+
+        // The other var1 values map to Other (consumer → reset-dominant fallback).
+        assert_eq!(
+            ClearPreset {
+                var1: ClearPresetVal::Low,
+                var2: ClearPresetVal::High
+            }
+            .dominance(),
+            Dominance::ResetDominant
+        );
+        for v in [
+            ClearPresetVal::NoChange,
+            ClearPresetVal::Unknown,
+            ClearPresetVal::Toggle,
+        ] {
+            assert_eq!(
+                ClearPreset {
+                    var1: v,
+                    var2: ClearPresetVal::Unknown
+                }
+                .dominance(),
+                Dominance::Other
+            );
+        }
+    }
+
+    #[test]
+    fn c2_sequential_without_clear_preset_is_backward_readable() {
+        // A schema-2 document (async_set + async_reset but no clear_preset key)
+        // must still deserialize under schema 3 with clear_preset == None.
+        let c2_json = r#"{
+            "schema_major": 0,
+            "schema_minor": 2,
+            "library": { "name": "demo_lib", "prefixes": ["demo_"] },
+            "cells": [
+                {
+                    "cell_type": "demo_dffsrnq",
+                    "kind": "dff",
+                    "pins": [
+                        { "name": "D",   "direction": "input"  },
+                        { "name": "CLK", "direction": "input"  },
+                        { "name": "RN",  "direction": "input"  },
+                        { "name": "SETN","direction": "input"  },
+                        { "name": "Q",   "direction": "output" }
+                    ],
+                    "sequential": {
+                        "clock": { "pin": "CLK", "edge": "rising" },
+                        "next_state": {
+                            "inputs": ["D"], "and_nodes": [],
+                            "outputs": [{ "pin": "D", "r": { "node": 1, "inverted": false } }]
+                        },
+                        "outputs": [{ "pin": "Q" }],
+                        "async_set":   { "pin": "SETN", "active": "low" },
+                        "async_reset": { "pin": "RN",   "active": "low" }
+                    }
+                }
+            ]
+        }"#;
+        let ir = CellModelIr::from_json(c2_json).unwrap();
+        let seq = ir
+            .cell("demo_dffsrnq")
+            .unwrap()
+            .sequential
+            .as_ref()
+            .unwrap();
+        assert!(seq.clear_preset.is_none());
+        assert!(seq.async_set.is_some() && seq.async_reset.is_some());
     }
 
     #[test]

--- a/crates/liberty-parse/Cargo.toml
+++ b/crates/liberty-parse/Cargo.toml
@@ -11,5 +11,6 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+serde_json = "1.0"
 
 [dev-dependencies]

--- a/crates/liberty-parse/src/json.rs
+++ b/crates/liberty-parse/src/json.rs
@@ -1,0 +1,374 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! `.lib.json` reader — JSON-serialized Liberty into the same
+//! [`LibertyGroup`] tree the text parser ([`crate::parse`]) yields.
+//!
+//! SKY130 (`vendor/sky130_fd_sc_hd/`) ships its Liberty exclusively as
+//! `.lib.json` (6848 per-cell-per-corner cell files + a small per-corner
+//! library header), never as `.lib` text. To give SKY130 a generated
+//! cell-model-IR descriptor (ADR 0019), the converter needs a `LibertyGroup`
+//! tree — this module decodes the JSON encoding into exactly that tree so the
+//! `liberty-to-cellir` converter consumes it unchanged.
+//!
+//! ## The flattened-group key encoding
+//!
+//! Liberty's concrete syntax has two statement forms — `name : value;`
+//! (attribute) and `type (args) { body }` (group). The `.lib.json` encoding
+//! flattens both into a single JSON object whose keys carry the distinction:
+//!
+//! - A key **containing a comma** is a *named group*: the substring before
+//!   the first comma is the group type, the comma-separated remainder is the
+//!   header argument list. The value is the group body (an object), e.g.
+//!   `"pin,A": { "direction": "input" }` ⇒ `pin (A) { direction : input; }`
+//!   and `"ff,IQ,IQ_N": { ... }` ⇒ `ff (IQ, IQ_N) { ... }`,
+//!   `"cell_rise,del_1_7_7": { ... }` ⇒ `cell_rise (del_1_7_7) { ... }`.
+//! - A **bare key** (no comma) whose value is an **object** is an *unnamed
+//!   group*: `"internal_power": { ... }` ⇒ `internal_power () { ... }`.
+//! - A **bare key** whose value is an **array of objects** is a *repeated*
+//!   unnamed group — one group per element: `"timing": [ {..}, {..} ]` ⇒ two
+//!   `timing () { .. }` groups in source order.
+//! - Any other bare key (scalar, or array of scalars / array of scalar rows)
+//!   is an **attribute**.
+//!
+//! ## Lookup tables and complex attributes
+//!
+//! Liberty's list-valued attributes (`index_1`, `index_2`, `values`) are
+//! quoted-string-packed in text form — `index_1 ("0.01, 0.02, 0.03")`, and a
+//! 2-D `values ("r0c0, r0c1", "r1c0, r1c1")` with one quoted string per row.
+//! The JSON encoding uses native arrays instead: a 1-D `[0.01, 0.02, 0.03]`
+//! and a 2-D `[[..], [..]]`. To produce the *same* [`Value`] shape the text
+//! parser yields, this reader re-packs them:
+//!
+//! - a 1-D scalar array ⇒ a single [`Value::String`] of the elements joined
+//!   with `", "` (matching `index_1 ("0.01, 0.02")`),
+//! - a 2-D array (array of arrays) ⇒ one [`Value::String`] *per row*, each row
+//!   the inner elements joined with `", "` (matching the multi-string
+//!   `values (...)` form).
+//!
+//! Downstream's `first_table_value` reads `values.first_string()` and splits
+//! on commas/spaces, so a 2-D table's first row string yields the first
+//! scalar exactly as it does for text-parsed Liberty.
+
+use serde_json::{Map, Value as JsonValue};
+
+use crate::{Attribute, LibertyGroup, Value};
+
+/// Parse a `.lib.json` object string as the **body** of one Liberty group of
+/// the given `group_type` and header `names`.
+///
+/// The JSON top-level value must be an object — it is the flattened group
+/// body (the SKY130 per-cell file's top-level object *is* the body of one
+/// `cell (...)` group; the per-corner header file's top-level object *is* the
+/// body of the `library (...)` group). The returned [`LibertyGroup`] is
+/// structurally identical to what [`crate::parse`] produces for the
+/// equivalent `.lib` text.
+pub fn parse_group(
+    content: &str,
+    group_type: &str,
+    names: Vec<String>,
+) -> Result<LibertyGroup, String> {
+    let root: JsonValue =
+        serde_json::from_str(content).map_err(|e| format!("invalid .lib.json: {e}"))?;
+    let JsonValue::Object(obj) = root else {
+        return Err("top-level .lib.json value is not an object".to_string());
+    };
+    Ok(group_from_object(group_type.to_string(), names, &obj))
+}
+
+/// Build a [`LibertyGroup`] of `group_type`/`names` from a decoded JSON object.
+fn group_from_object(
+    group_type: String,
+    names: Vec<String>,
+    obj: &Map<String, JsonValue>,
+) -> LibertyGroup {
+    let mut group = LibertyGroup {
+        group_type,
+        names,
+        attributes: Vec::new(),
+        groups: Vec::new(),
+    };
+    for (key, value) in obj {
+        decode_entry(key, value, &mut group);
+    }
+    group
+}
+
+/// Decode one `(key, value)` pair of a flattened group body, appending either
+/// an attribute or one-or-more subgroups to `group`.
+fn decode_entry(key: &str, value: &JsonValue, group: &mut LibertyGroup) {
+    if let Some((gtype, rest)) = key.split_once(',') {
+        // Named group: `"type,name[,arg...]"`.
+        let names: Vec<String> = rest.split(',').map(|s| s.trim().to_string()).collect();
+        match value {
+            JsonValue::Object(o) => {
+                group
+                    .groups
+                    .push(group_from_object(gtype.to_string(), names, o));
+            }
+            JsonValue::Array(a) if a.iter().all(|v| v.is_object()) && !a.is_empty() => {
+                // A named group repeated under one key (rare). Each element is
+                // its own group body sharing the type/name.
+                for v in a {
+                    if let JsonValue::Object(o) = v {
+                        group
+                            .groups
+                            .push(group_from_object(gtype.to_string(), names.clone(), o));
+                    }
+                }
+            }
+            // A comma key with a scalar value is not valid Liberty; keep the
+            // datum as an attribute under the raw key rather than dropping it.
+            other => group.attributes.push(Attribute {
+                name: key.to_string(),
+                values: encode_value(other),
+            }),
+        }
+        return;
+    }
+
+    match value {
+        JsonValue::Object(o) => {
+            // Bare key, object value ⇒ a single unnamed subgroup.
+            group
+                .groups
+                .push(group_from_object(key.to_string(), Vec::new(), o));
+        }
+        JsonValue::Array(a) if !a.is_empty() && a.iter().all(|v| v.is_object()) => {
+            // Bare key, array-of-objects ⇒ repeated unnamed subgroups.
+            for v in a {
+                if let JsonValue::Object(o) = v {
+                    group
+                        .groups
+                        .push(group_from_object(key.to_string(), Vec::new(), o));
+                }
+            }
+        }
+        other => {
+            // Scalar, or array of scalars / scalar rows ⇒ an attribute.
+            group.attributes.push(Attribute {
+                name: key.to_string(),
+                values: encode_value(other),
+            });
+        }
+    }
+}
+
+/// Render a JSON value as the attribute value list a text parse would yield.
+fn encode_value(value: &JsonValue) -> Vec<Value> {
+    match value {
+        JsonValue::Array(a) => encode_list(a),
+        scalar => vec![encode_scalar(scalar)],
+    }
+}
+
+/// Encode a JSON array (already known not to be an array-of-objects) as the
+/// `Vec<Value>` a text parse yields: a 2-D table becomes one packed string per
+/// row; a 1-D list becomes a single packed string.
+fn encode_list(a: &[JsonValue]) -> Vec<Value> {
+    if !a.is_empty() && a.iter().all(|v| v.is_array()) {
+        // 2-D: one `Value::String` per row, mirroring the multi-string
+        // `values ("r0...", "r1...")` text form.
+        a.iter()
+            .map(|row| {
+                let JsonValue::Array(cells) = row else {
+                    unreachable!("all elements are arrays")
+                };
+                Value::String(join_scalars(cells))
+            })
+            .collect()
+    } else {
+        // 1-D: a single packed `Value::String`, mirroring `index_1 ("a, b")`.
+        vec![Value::String(join_scalars(a))]
+    }
+}
+
+/// Join scalar JSON values with `", "` into the packed-string form Liberty
+/// text uses for list attributes.
+fn join_scalars(a: &[JsonValue]) -> String {
+    a.iter()
+        .map(scalar_to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Render a single scalar JSON value to its source-text spelling.
+fn scalar_to_string(value: &JsonValue) -> String {
+    match value {
+        JsonValue::String(s) => s.clone(),
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::Bool(b) => b.to_string(),
+        JsonValue::Null => String::new(),
+        // Nested arrays/objects inside a "scalar" position are not expected;
+        // fall back to compact JSON so nothing is silently lost.
+        other => other.to_string(),
+    }
+}
+
+/// Encode a scalar JSON value as a single [`Value`].
+fn encode_scalar(value: &JsonValue) -> Value {
+    match value {
+        JsonValue::String(s) => Value::String(s.clone()),
+        JsonValue::Number(n) => {
+            let f = n.as_f64().unwrap_or(f64::NAN);
+            Value::number(n.to_string(), f)
+        }
+        JsonValue::Bool(b) => Value::Ident(b.to_string()),
+        JsonValue::Null => Value::String(String::new()),
+        other => Value::String(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_named_pin_group_and_scalar_attrs() {
+        let g = parse_group(
+            r#"{ "direction": "output", "function": "(!A) | (!B) | (!C)" }"#,
+            "pin",
+            vec!["Y".to_string()],
+        )
+        .unwrap();
+        assert_eq!(g.group_type, "pin");
+        assert_eq!(g.first_name(), Some("Y"));
+        assert_eq!(g.attr("direction").unwrap().first_string(), Some("output"));
+        assert_eq!(
+            g.attr("function").unwrap().first_string(),
+            Some("(!A) | (!B) | (!C)")
+        );
+    }
+
+    #[test]
+    fn decodes_flattened_subgroup_keys() {
+        // A cell body with `pin,A` / `pin,Y` flattened-group keys.
+        let cell = parse_group(
+            r#"{
+                "area": 5.0,
+                "pin,A": { "direction": "input" },
+                "pin,Y": { "direction": "output", "function": "!A" }
+            }"#,
+            "cell",
+            vec!["sky130_fd_sc_hd__inv_1".to_string()],
+        )
+        .unwrap();
+        assert_eq!(cell.first_name(), Some("sky130_fd_sc_hd__inv_1"));
+        assert_eq!(cell.attr("area").unwrap().first_number(), Some(5.0));
+        let pins: Vec<_> = cell.groups_of_type("pin").collect();
+        assert_eq!(pins.len(), 2);
+        assert_eq!(pins[0].first_name(), Some("A"));
+        assert_eq!(pins[1].first_name(), Some("Y"));
+        assert_eq!(pins[1].attr("function").unwrap().first_string(), Some("!A"));
+    }
+
+    #[test]
+    fn decodes_ff_multi_arg_group() {
+        let cell = parse_group(
+            r#"{ "ff,IQ,IQ_N": { "clocked_on": "CLK", "next_state": "D" } }"#,
+            "cell",
+            vec!["dff".to_string()],
+        )
+        .unwrap();
+        let ff = cell.group_of_type("ff").unwrap();
+        assert_eq!(ff.names, vec!["IQ".to_string(), "IQ_N".to_string()]);
+        assert_eq!(ff.attr("clocked_on").unwrap().first_string(), Some("CLK"));
+        assert_eq!(ff.attr("next_state").unwrap().first_string(), Some("D"));
+    }
+
+    #[test]
+    fn decodes_repeated_bare_group_array() {
+        // `timing` as an array of objects ⇒ two `timing` subgroups.
+        let pin = parse_group(
+            r#"{
+                "direction": "output",
+                "timing": [
+                    { "related_pin": "A", "timing_sense": "negative_unate" },
+                    { "related_pin": "B", "timing_sense": "negative_unate" }
+                ]
+            }"#,
+            "pin",
+            vec!["Y".to_string()],
+        )
+        .unwrap();
+        let timings: Vec<_> = pin.groups_of_type("timing").collect();
+        assert_eq!(timings.len(), 2);
+        assert_eq!(
+            timings[0].attr("related_pin").unwrap().first_string(),
+            Some("A")
+        );
+        assert_eq!(
+            timings[1].attr("related_pin").unwrap().first_string(),
+            Some("B")
+        );
+    }
+
+    #[test]
+    fn decodes_lookup_table_1d_and_2d() {
+        let table = parse_group(
+            r#"{
+                "index_1": [0.01, 0.0230506, 0.0531329],
+                "index_2": [0.0005, 0.0025, 0.005],
+                "values": [
+                    [0.0319453, 0.0377438, 0.0522698],
+                    [0.0316862, 0.0372976, 0.0513602]
+                ]
+            }"#,
+            "cell_rise",
+            vec!["del_1_7_7".to_string()],
+        )
+        .unwrap();
+        // 1-D index packs into one string.
+        assert_eq!(
+            table.attr("index_1").unwrap().first_string(),
+            Some("0.01, 0.0230506, 0.0531329")
+        );
+        // 2-D values: one Value per row, first row first.
+        let values = table.attr("values").unwrap();
+        assert_eq!(values.values.len(), 2);
+        assert_eq!(
+            values.first_string(),
+            Some("0.0319453, 0.0377438, 0.0522698")
+        );
+        // The first scalar (as `first_table_value` would extract it).
+        let first = values
+            .first_string()
+            .unwrap()
+            .split([',', ' '])
+            .find(|s| !s.is_empty())
+            .unwrap();
+        assert_eq!(first.parse::<f64>().unwrap(), 0.0319453);
+    }
+
+    #[test]
+    fn decodes_operating_conditions_header() {
+        let lib = parse_group(
+            r#"{
+                "default_operating_conditions": "tt_025C_1v80",
+                "nom_voltage": 1.8,
+                "nom_temperature": 25.0,
+                "operating_conditions,tt_025C_1v80": {
+                    "process": 1.0, "temperature": 25.0, "voltage": 1.8
+                }
+            }"#,
+            "library",
+            vec!["sky130_fd_sc_hd__tt_025C_1v80".to_string()],
+        )
+        .unwrap();
+        assert_eq!(
+            lib.attr("default_operating_conditions")
+                .unwrap()
+                .first_string(),
+            Some("tt_025C_1v80")
+        );
+        let oc = lib.group_of_type("operating_conditions").unwrap();
+        assert_eq!(oc.first_name(), Some("tt_025C_1v80"));
+        assert_eq!(oc.attr("voltage").unwrap().first_number(), Some(1.8));
+        assert_eq!(oc.attr("temperature").unwrap().first_number(), Some(25.0));
+    }
+
+    #[test]
+    fn rejects_non_object_root() {
+        assert!(parse_group("[1, 2, 3]", "cell", vec![]).is_err());
+        assert!(parse_group("not json", "cell", vec![]).is_err());
+    }
+}

--- a/crates/liberty-parse/src/lib.rs
+++ b/crates/liberty-parse/src/lib.rs
@@ -26,6 +26,8 @@
 //! - list-valued attributes such as `index_1 ("0.1, 0.2, 0.3")` and
 //!   comma/space-separated value lists.
 
+pub mod json;
+
 /// A single Liberty attribute: `name : value ... ;`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Attribute {
@@ -412,11 +414,7 @@ impl<'a> Parser<'a> {
     /// Dispatch on what follows an already-read `keyword`: `:` => attribute,
     /// `(` => nested group (or paren'd attribute), `{` => bare block. Any
     /// other shape is skipped, matching the tolerant former parser.
-    fn parse_statement(
-        &mut self,
-        keyword: String,
-        group: &mut LibertyGroup,
-    ) -> Result<(), String> {
+    fn parse_statement(&mut self, keyword: String, group: &mut LibertyGroup) -> Result<(), String> {
         match self.peek_char() {
             Some(':') => {
                 // Attribute: name : value [, value ...] ;

--- a/crates/liberty-to-cellir/src/crosscheck.rs
+++ b/crates/liberty-to-cellir/src/crosscheck.rs
@@ -129,6 +129,19 @@ fn collect_v_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Strip a trailing `_<digits>` drive-strength suffix from a cell type, if
+/// present: `sky130_fd_sc_hd__nand3_1` ⇒ `sky130_fd_sc_hd__nand3`. Returns
+/// `None` when there is no such suffix (so callers only try the fallback when
+/// it differs from the original).
+fn strip_drive_strength(cell_type: &str) -> Option<&str> {
+    let (base, suffix) = cell_type.rsplit_once('_')?;
+    if !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit()) {
+        Some(base)
+    } else {
+        None
+    }
+}
+
 /// Cross-check one cell against the model index.
 pub fn check_cell(cell: &CellModel, index: &ModelIndex) -> CellCheck {
     let Some(logic) = &cell.logic else {
@@ -137,8 +150,18 @@ pub fn check_cell(cell: &CellModel, index: &ModelIndex) -> CellCheck {
     if cell.kind != CellKind::Std {
         return CellCheck::NotComb;
     }
-    let Some(model) = index.models.get(&cell.cell_type) else {
-        return CellCheck::NoModel;
+    // Exact module-name match first (GF180's per-drive `.functional.v`); then
+    // fall back to the drive-strength-less base name. SKY130 shares one
+    // `sky130_fd_sc_hd__nand3.functional.v` across `nand3_1`/`_2`/`_4` — the
+    // functional logic is identical across drive strengths, so the base-name
+    // model is the correct oracle for every drive variant.
+    let model = match index
+        .models
+        .get(&cell.cell_type)
+        .or_else(|| strip_drive_strength(&cell.cell_type).and_then(|b| index.models.get(b)))
+    {
+        Some(m) => m,
+        None => return CellCheck::NoModel,
     };
 
     // Guard against models the oracle cannot evaluate as 2-state logic
@@ -387,6 +410,36 @@ mod tests {
             specify: SpecifyIndex::default(),
         };
         assert_eq!(check_cell(&cell, &empty), CellCheck::NoModel);
+    }
+
+    #[test]
+    fn drive_strength_fallback_matches_baseless_model() {
+        // SKY130: cell `..__nand3_1` (drive `_1`) but the functional model
+        // module is the drive-less `..__nand3`. The exact lookup misses; the
+        // drive-strength-strip fallback finds the shared base model.
+        let cell = and2_cell("demo__and2_1", false);
+        let index = index_with("demo__and2"); // model has no `_1` drive suffix
+        match check_cell(&cell, &index) {
+            CellCheck::Checked { mismatches, .. } => {
+                assert!(mismatches.is_empty(), "expected clean via fallback");
+            }
+            other => panic!("expected Checked via drive fallback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn strip_drive_strength_only_strips_trailing_digits() {
+        assert_eq!(
+            strip_drive_strength("sky130_fd_sc_hd__nand3_1"),
+            Some("sky130_fd_sc_hd__nand3")
+        );
+        assert_eq!(
+            strip_drive_strength("sky130_fd_sc_hd__a2111o_4"),
+            Some("sky130_fd_sc_hd__a2111o")
+        );
+        // No trailing `_<digits>` ⇒ no fallback (a drive-less name stays as-is).
+        assert_eq!(strip_drive_strength("sky130_fd_sc_hd__nand3"), None);
+        assert_eq!(strip_drive_strength("nodigits"), None);
     }
 
     #[test]

--- a/crates/liberty-to-cellir/src/load.rs
+++ b/crates/liberty-to-cellir/src/load.rs
@@ -38,7 +38,16 @@ pub fn generate_descriptor(input: &Path, prefixes: Vec<String>) -> Result<CellMo
 
 /// Load a Liberty library, transparently merging a split per-cell library if
 /// the named file carries no `cell` groups.
+///
+/// A `.lib.json` input (SKY130's only Liberty form — JSON-serialized, never
+/// `.lib` text) is routed to [`load_json_library`], which assembles a
+/// per-corner library from the per-corner header plus every per-cell-per-corner
+/// cell file. Plain `.lib` text keeps the existing GF180/text path.
 pub fn load_library(input: &Path) -> Result<LibertyGroup, String> {
+    if is_lib_json(input) {
+        return load_json_library(input);
+    }
+
     let content =
         std::fs::read_to_string(input).map_err(|e| format!("reading {}: {e}", input.display()))?;
     let mut lib =
@@ -134,6 +143,145 @@ fn discover_split_cells(input: &Path, top: &LibertyGroup) -> Result<Vec<LibertyG
         eprintln!("split-library: {parse_errors} per-cell .lib files failed to parse");
     }
     Ok(groups)
+}
+
+/// Whether `input` names a `.lib.json` file (SKY130's JSON-serialized Liberty).
+fn is_lib_json(input: &Path) -> bool {
+    input
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.ends_with(".lib.json"))
+        .unwrap_or(false)
+}
+
+/// Assemble a per-corner Liberty library from SKY130's `.lib.json` layout.
+///
+/// `header` is a per-corner library header
+/// (`timing/sky130_fd_sc_hd__<corner>.lib.json`) carrying only library-level
+/// attributes (`operating_conditions`, `default_operating_conditions`,
+/// `nom_*`, `lu_table_template`, ...). Each *cell* lives in its own
+/// per-cell-per-corner file
+/// (`cells/<group>/sky130_fd_sc_hd__<cell>__<corner>.lib.json`) whose
+/// top-level object *is* the body of one `cell (...)` group — the cell name is
+/// the filename minus the `__<corner>.lib.json` suffix.
+///
+/// This reads the header as the `library` group, then discovers and appends
+/// every cell file matching the header's corner suffix (deterministically
+/// sorted), each decoded into a named `cell (...)` group. The resulting tree
+/// is identical in shape to a text-parsed monolithic Liberty library, so the
+/// converter — including the corner-from-Liberty-PVT logic that reads the
+/// header's `operating_conditions` — consumes it unchanged.
+pub fn load_json_library(header: &Path) -> Result<LibertyGroup, String> {
+    let header_name = header
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or("header path has no file name")?;
+    let lib_name = header_name
+        .strip_suffix(".lib.json")
+        .ok_or("header is not a .lib.json file")?
+        .to_string();
+
+    let content = std::fs::read_to_string(header)
+        .map_err(|e| format!("reading {}: {e}", header.display()))?;
+    let mut lib = liberty_parse::json::parse_group(&content, "library", vec![lib_name.clone()])
+        .map_err(|e| format!("parsing {}: {e}", header.display()))?;
+
+    // SKY130's `.lib.json` headers omit the library-level `time_unit`. The
+    // Liberty standard default is `1ns` (and SKY130's native unit is `1ns`),
+    // but the converter's `ps_per_time_unit(None)` falls back to `1ps`, which
+    // would mis-scale every L4 delay by 1000x. Restore the dropped default so
+    // L4 timing is emitted in true picoseconds (a dff setup of `0.0508` ns
+    // becomes 50.8 ps, not 0.05 ps).
+    if lib.attr("time_unit").is_none() {
+        lib.attributes.push(liberty_parse::Attribute {
+            name: "time_unit".to_string(),
+            values: vec![liberty_parse::Value::String("1ns".to_string())],
+        });
+    }
+
+    // Corner suffix = the trailing `__<corner>` run of the library name, e.g.
+    // `sky130_fd_sc_hd__tt_025C_1v80` ⇒ `__tt_025C_1v80`.
+    let corner_suffix = lib_name
+        .rfind("__")
+        .map(|i| lib_name[i..].to_string())
+        .ok_or_else(|| format!("cannot derive corner from header name {lib_name}"))?;
+    let want_suffix = format!("{corner_suffix}.lib.json");
+
+    // SKY130 layout: header is under `<pdk>/timing/`, cells under `<pdk>/cells/`.
+    let pdk_root = header
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or("header has no PDK-root ancestor")?;
+    let cells_dir = pdk_root.join("cells");
+
+    let mut files = Vec::new();
+    collect_matching_json_cells(&cells_dir, &want_suffix, &mut files);
+    files.sort();
+
+    let mut cells = Vec::new();
+    let mut parse_errors = 0usize;
+    for path in &files {
+        let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        // Cell name = filename minus the `__<corner>.lib.json` suffix.
+        let Some(cell_name) = file_name.strip_suffix(&want_suffix) else {
+            continue;
+        };
+        let Ok(src) = std::fs::read_to_string(path) else {
+            parse_errors += 1;
+            continue;
+        };
+        match liberty_parse::json::parse_group(&src, "cell", vec![cell_name.to_string()]) {
+            Ok(cell) => cells.push(cell),
+            Err(_) => parse_errors += 1,
+        }
+    }
+
+    if parse_errors > 0 {
+        eprintln!("sky130 .lib.json: {parse_errors} per-cell files failed to parse");
+    }
+    if cells.is_empty() {
+        eprintln!(
+            "warning: no per-cell .lib.json files matching `*{want_suffix}` found under {}; \
+             descriptor will be empty",
+            cells_dir.display()
+        );
+    } else {
+        eprintln!(
+            "sky130 .lib.json: assembled {} cells (corner {corner_suffix}) alongside {}",
+            cells.len(),
+            header.display()
+        );
+    }
+    lib.groups.extend(cells);
+    Ok(lib)
+}
+
+/// Recursively collect per-cell `.lib.json` files ending with `want_suffix`,
+/// skipping the `.ccsnoise.lib.json` CCS-noise variants (which carry no cell
+/// logic/timing the converter consumes and would duplicate the base cell).
+fn collect_matching_json_cells(dir: &Path, want_suffix: &str, out: &mut Vec<PathBuf>) {
+    if !dir.is_dir() {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_matching_json_cells(&path, want_suffix, out);
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.ends_with(".ccsnoise.lib.json") {
+            continue;
+        }
+        if name.ends_with(want_suffix) {
+            out.push(path);
+        }
+    }
 }
 
 fn collect_matching_libs(dir: &Path, want_suffix: &str, out: &mut Vec<PathBuf>) {

--- a/crates/liberty-to-cellir/src/sequential.rs
+++ b/crates/liberty-to-cellir/src/sequential.rs
@@ -16,21 +16,21 @@
 //! genuinely-special roles (clock edge, level enable, async set/reset
 //! polarity, state outputs) get named fields.
 //!
-//! ## The `clear_preset_var` precedence check (C2.1 flagged risk)
+//! ## The `clear_preset_var` tie-break (C4)
 //!
-//! Jacquard's `wire_dff_reset_set_overlay` bakes a FIXED reset-dominant
-//! tie-break: `d_in = AND(OR(D, !SETN), RN)` — when both async controls are
-//! asserted the state goes to 0 (clear wins). The schema cannot express a
-//! per-cell override. So for every cell with BOTH `clear` and `preset` this
-//! module reads Liberty's `clear_preset_var1` / `clear_preset_var2` and
-//! verifies it matches reset-dominant (`var1 = L`, the Q state var goes low
-//! when both are asserted). Any divergence is surfaced as a
-//! [`SeqNote::ClearPresetNotResetDominant`] generation-time diagnostic rather
-//! than silently emitted — that is the signal the schema needs a per-cell
-//! `clear_preset` field.
+//! When both `clear` and `preset` are asserted at once, Liberty's
+//! `clear_preset_var1` / `clear_preset_var2` state what the two state
+//! variables (`Q`, `QN`) take. This module reads them into the schema's
+//! [`cell_model_ir::ClearPreset`] ([`Sequential::clear_preset`]) so the
+//! consumer overlay can honour set-dominant cells rather than assuming
+//! reset-dominant. It ALSO keeps emitting the
+//! [`SeqNote::ClearPresetNotResetDominant`] generation diagnostic for any cell
+//! that is not reset-dominant (`var1 = L`, `var2 = H`) — a useful signal for
+//! spotting cells whose behaviour differs from Jacquard's historical default.
 
 use cell_model_ir::{
-    ActiveLevel, CellKind, ClockEdge, ClockPin, CombLogic, EnablePin, SeqOutput, Sequential,
+    ActiveLevel, CellKind, ClearPreset, ClearPresetVal, ClockEdge, ClockPin, CombLogic, EnablePin,
+    SeqOutput, Sequential,
 };
 use liberty_parse::LibertyGroup;
 
@@ -198,10 +198,12 @@ fn build_ff(
     let async_reset = build_async(ff.attr("clear"), "clear", cell_type, notes);
     let async_set = build_async(ff.attr("preset"), "preset", cell_type, notes);
 
-    // clear_preset_var precedence check when BOTH controls exist.
-    if async_reset.is_some() && async_set.is_some() {
-        check_clear_preset(ff, cell_type, notes);
-    }
+    // clear_preset tie-break, only meaningful when BOTH controls exist.
+    let clear_preset = if async_reset.is_some() && async_set.is_some() {
+        extract_clear_preset(ff, cell_type, notes)
+    } else {
+        None
+    };
 
     let outputs = state_outputs(cell, &q_var, &qn_var);
 
@@ -212,6 +214,7 @@ fn build_ff(
         outputs,
         async_set,
         async_reset,
+        clear_preset,
     };
     (CellKind::Dff, Some(seq))
 }
@@ -251,9 +254,11 @@ fn build_latch(
 
     let async_reset = build_async(latch.attr("clear"), "clear", cell_type, notes);
     let async_set = build_async(latch.attr("preset"), "preset", cell_type, notes);
-    if async_reset.is_some() && async_set.is_some() {
-        check_clear_preset(latch, cell_type, notes);
-    }
+    let clear_preset = if async_reset.is_some() && async_set.is_some() {
+        extract_clear_preset(latch, cell_type, notes)
+    } else {
+        None
+    };
 
     let outputs = state_outputs(cell, &q_var, &qn_var);
 
@@ -264,6 +269,7 @@ fn build_latch(
         outputs,
         async_set,
         async_reset,
+        clear_preset,
     };
     (CellKind::Latch, Some(seq))
 }
@@ -458,30 +464,62 @@ fn state_outputs(cell: &LibertyGroup, q_var: &str, qn_var: &str) -> Vec<SeqOutpu
     outputs
 }
 
-/// Verify `clear_preset_var1/var2` is reset-dominant; surface a diagnostic if
-/// not. Reset-dominant ⇒ when both clear and preset are asserted, the Q state
-/// var goes to `L` (and QN to `H`).
-fn check_clear_preset(group: &LibertyGroup, cell_type: &str, notes: &mut Vec<SeqNote>) {
-    let var1 = group
-        .attr("clear_preset_var1")
-        .and_then(|a| a.first_string())
-        .map(|s| s.trim_matches('"').to_uppercase())
-        .unwrap_or_default();
-    let var2 = group
-        .attr("clear_preset_var2")
-        .and_then(|a| a.first_string())
-        .map(|s| s.trim_matches('"').to_uppercase())
-        .unwrap_or_default();
-    // Reset-dominant: Q (var1) → L, QN (var2) → H. If var1 is absent Liberty
-    // leaves the tie-break unspecified, which is also not provably
-    // reset-dominant — surface it.
-    let reset_dominant = var1 == "L" && var2 == "H";
+/// Read `clear_preset_var1/var2` into a [`ClearPreset`] tie-break and, as a
+/// side effect, surface a [`SeqNote::ClearPresetNotResetDominant`] diagnostic
+/// when the pair is not reset-dominant (`var1 = L`, `var2 = H`). Called only
+/// when the cell has BOTH `clear` and `preset`.
+///
+/// Returns `None` (and no note) when neither attribute is present — Liberty
+/// omits the pair for cells where the tie-break is degenerate/unspecified, and
+/// an absent field means "reset-dominant default" to the consumer, exactly
+/// matching the historical hardcoded behaviour.
+fn extract_clear_preset(
+    group: &LibertyGroup,
+    cell_type: &str,
+    notes: &mut Vec<SeqNote>,
+) -> Option<ClearPreset> {
+    let raw = |attr: &str| -> Option<String> {
+        group
+            .attr(attr)
+            .and_then(|a| a.first_string())
+            .map(|s| s.trim_matches('"').to_uppercase())
+    };
+    let var1_s = raw("clear_preset_var1");
+    let var2_s = raw("clear_preset_var2");
+    if var1_s.is_none() && var2_s.is_none() {
+        // Liberty specifies no tie-break at all — reset-dominant default.
+        return None;
+    }
+    let var1_s = var1_s.unwrap_or_default();
+    let var2_s = var2_s.unwrap_or_default();
+
+    // Reset-dominant: Q (var1) → L, QN (var2) → H. Anything else — including an
+    // absent var1/var2, `H` (set-dominant), or `N`/`X`/`T` — is not provably
+    // reset-dominant, so surface the diagnostic (kept from C2).
+    let reset_dominant = var1_s == "L" && var2_s == "H";
     if !reset_dominant {
         notes.push(SeqNote::ClearPresetNotResetDominant {
             cell: cell_type.to_string(),
-            var1,
-            var2,
+            var1: var1_s.clone(),
+            var2: var2_s.clone(),
         });
+    }
+
+    Some(ClearPreset {
+        var1: parse_clear_preset_val(&var1_s),
+        var2: parse_clear_preset_val(&var2_s),
+    })
+}
+
+/// Map a Liberty `clear_preset_var*` token to a [`ClearPresetVal`]. An
+/// unrecognized/absent token defaults to [`ClearPresetVal::Unknown`] (`X`).
+fn parse_clear_preset_val(s: &str) -> ClearPresetVal {
+    match s {
+        "L" => ClearPresetVal::Low,
+        "H" => ClearPresetVal::High,
+        "N" => ClearPresetVal::NoChange,
+        "T" => ClearPresetVal::Toggle,
+        _ => ClearPresetVal::Unknown,
     }
 }
 
@@ -857,11 +895,21 @@ mod tests {
             "reset-dominant var1=L must not flag: {:?}",
             r.notes
         );
+        // The tie-break is emitted faithfully (L, H) and reduces to reset-dominant.
+        let cp = r
+            .sequential
+            .unwrap()
+            .clear_preset
+            .expect("clear_preset emitted");
+        assert_eq!(cp.var1, ClearPresetVal::Low);
+        assert_eq!(cp.var2, ClearPresetVal::High);
+        assert_eq!(cp.dominance(), cell_model_ir::Dominance::ResetDominant);
     }
 
     #[test]
-    fn clear_preset_set_dominant_is_flagged() {
-        // Same as DFFRSNQ but var1=H (set wins) — must surface a diagnostic.
+    fn clear_preset_set_dominant_is_emitted_and_flagged() {
+        // Same as DFFRSNQ but var1=H (set wins) — must emit var1=H and also
+        // surface the diagnostic (both remain useful).
         let src = DFFRSNQ.replace("clear_preset_var1 : L", "clear_preset_var1 : H");
         let src = src.replace("clear_preset_var2 : H", "clear_preset_var2 : L");
         let cell = parse_cell(&src);
@@ -875,6 +923,73 @@ mod tests {
             "set-dominant must flag, got: {:?}",
             r.notes
         );
+        let cp = r
+            .sequential
+            .unwrap()
+            .clear_preset
+            .expect("set-dominant clear_preset emitted");
+        assert_eq!(cp.var1, ClearPresetVal::High);
+        assert_eq!(cp.var2, ClearPresetVal::Low);
+        assert_eq!(cp.dominance(), cell_model_ir::Dominance::SetDominant);
+    }
+
+    #[test]
+    fn clear_preset_absent_when_no_set_preset_pair() {
+        // A plain reset-only DFF (no preset) must not carry a clear_preset.
+        let src = r#"
+        library(demo) {
+          cell(demo__dffrnq) {
+            ff(IQ1, IQN1) {
+              clocked_on : "CLK" ;
+              next_state : "D" ;
+              clear : "(!RN)" ;
+            }
+            pin(CLK) { direction : input ; clock : true ; }
+            pin(D)   { direction : input ; }
+            pin(RN)  { direction : input ; }
+            pin(Q)   { direction : output ; function : "IQ1" ; }
+          }
+        }
+        "#;
+        let cell = parse_cell(src);
+        let ins = input_pins(&cell);
+        let r = build(&cell, "demo__dffrnq", &ins, false);
+        assert!(r.sequential.unwrap().clear_preset.is_none());
+    }
+
+    #[test]
+    fn clear_preset_set_dominant_latch_is_emitted() {
+        // A GF180 `latrsnq`-shaped set-dominant latch (var1=H).
+        let src = r#"
+        library(demo) {
+          cell(demo__latrsnq) {
+            latch(IQ1, IQN1) {
+              enable : "E" ;
+              data_in : "D" ;
+              clear : "(!RN)" ;
+              preset : "(!SETN)" ;
+              clear_preset_var1 : H ;
+              clear_preset_var2 : L ;
+            }
+            pin(E)   { direction : input ; }
+            pin(D)   { direction : input ; }
+            pin(RN)  { direction : input ; }
+            pin(SETN){ direction : input ; }
+            pin(Q)   { direction : output ; function : "IQ1" ; }
+          }
+        }
+        "#;
+        let cell = parse_cell(src);
+        let ins = input_pins(&cell);
+        let r = build(&cell, "demo__latrsnq", &ins, false);
+        assert_eq!(r.kind, CellKind::Latch);
+        let cp = r
+            .sequential
+            .unwrap()
+            .clear_preset
+            .expect("latch clear_preset");
+        assert_eq!(cp.var1, ClearPresetVal::High);
+        assert_eq!(cp.dominance(), cell_model_ir::Dominance::SetDominant);
     }
 
     #[test]

--- a/crates/liberty-to-cellir/tests/determinism.rs
+++ b/crates/liberty-to-cellir/tests/determinism.rs
@@ -32,6 +32,12 @@ fn gf180_7t_tt_lib() -> PathBuf {
         .join("vendor/gf180mcu_fd_sc_mcu7t5v0/liberty/gf180mcu_fd_sc_mcu7t5v0__tt_025C_5v00.lib")
 }
 
+/// SKY130's typical-corner `.lib.json` header (the per-corner library header;
+/// cells are discovered alongside under `cells/`).
+fn sky130_tt_header() -> PathBuf {
+    repo_root().join("vendor/sky130_fd_sc_hd/timing/sky130_fd_sc_hd__tt_025C_1v80.lib.json")
+}
+
 #[test]
 fn gf180_7t_descriptor_is_byte_deterministic() {
     let lib = gf180_7t_tt_lib();
@@ -76,5 +82,80 @@ fn gf180_7t_descriptor_is_byte_deterministic() {
     assert!(
         !ir.library.prefixes.is_empty(),
         "descriptor should declare a D8 selection prefix"
+    );
+}
+
+#[test]
+fn sky130_lib_json_assembles_a_real_descriptor() {
+    let header = sky130_tt_header();
+    if !header.exists() {
+        eprintln!(
+            "skipping: vendored SKY130 submodule absent at {} \
+             (run `git submodule update --init`)",
+            header.display()
+        );
+        return;
+    }
+
+    // Byte-deterministic across runs (the `.lib.json` cell discovery `sort()`s).
+    let a = generate_descriptor(&header, Vec::new())
+        .expect("first SKY130 generation")
+        .to_json()
+        .expect("serialize first");
+    let b = generate_descriptor(&header, Vec::new())
+        .expect("second SKY130 generation")
+        .to_json()
+        .expect("serialize second");
+    assert_eq!(a, b, "SKY130 `.lib.json` descriptor is not byte-identical");
+
+    let ir = generate_descriptor(&header, Vec::new()).unwrap();
+
+    // A real multi-hundred-cell library assembled from the JSON cell files.
+    assert!(
+        ir.cells.len() > 300,
+        "expected the SKY130 cell set, got {} cells",
+        ir.cells.len()
+    );
+    assert_eq!(
+        ir.library.prefixes,
+        vec!["sky130_fd_sc_hd__".to_string()],
+        "SKY130 descriptor should declare the vendor prefix"
+    );
+
+    // Corner is Liberty-derived from the header's operating_conditions PVT.
+    assert_eq!(ir.corners.len(), 1);
+    let corner = &ir.corners[0];
+    assert_eq!(corner.name, "tt_025C_1v80");
+    assert_eq!(corner.process, "tt");
+    assert_eq!(corner.voltage, 1.8);
+    assert_eq!(corner.temperature, 25.0);
+
+    // Spot-check a combinational cell (inv ⇒ Y = !A) and a sequential one.
+    let find = |t: &str| ir.cells.iter().find(|c| c.cell_type == t);
+    let inv = find("sky130_fd_sc_hd__inv_1").expect("inv_1 present");
+    let logic = inv.logic.as_ref().expect("inv_1 has combinational logic");
+    use std::collections::HashMap;
+    for a in [false, true] {
+        let mut vals = HashMap::new();
+        vals.insert("A".to_string(), a);
+        assert_eq!(logic.eval(&vals).unwrap()["Y"], !a, "inv Y == !A");
+    }
+
+    let dff = find("sky130_fd_sc_hd__dfxtp_1").expect("dfxtp_1 present");
+    assert!(dff.sequential.is_some(), "dfxtp_1 has L3 sequential");
+    assert!(dff.timing.is_some(), "dfxtp_1 has L4 timing");
+
+    // L4 timing scaled to true picoseconds via the restored `1ns` time_unit:
+    // the CLK->Q delay is in the tens-to-hundreds of ps, not sub-ps.
+    let t = dff.timing.as_ref().unwrap();
+    let clk_q = t
+        .delays
+        .iter()
+        .find(|d| d.from_pin == "CLK" && d.to_pin == "Q")
+        .expect("CLK->Q delay");
+    let typ = clk_q.rise[0].typ;
+    assert!(
+        typ > 10.0 && typ < 10_000.0,
+        "CLK->Q delay {typ} ps is not in a realistic ps range (time_unit mis-scaled?)"
     );
 }

--- a/docs/adding-a-pdk.md
+++ b/docs/adding-a-pdk.md
@@ -11,32 +11,145 @@ SRAMs). Supporting a foundry PDK like SKY130 requires teaching the simulator how
 to interpret the PDK's standard cells: their pin directions, their boolean
 function, and which ones are sequential.
 
-There are now **two pathways** for enabling new cells; pick based on what
+There are **three pathways** for enabling new cells; pick based on what
 you're adding:
 
-- **Built-in PDK enablement** (this guide). For full standard-cell
-  libraries — AND gates, DFFs, sequential cells with explicit AIG
-  decomposition rules. Requires Rust code: pin tables, classifiers,
-  decomposition functions, AIG builder hooks.
+- **Cell-model IR descriptor** (**recommended — the modern path**, ADR
+  0019). A standard-cell library — pin directions, boolean functions,
+  sequential roles, and timing — is captured in one **generated JSON
+  descriptor** produced from the library's Liberty by the
+  `liberty-to-cellir` converter. Jacquard consumes the descriptor at
+  runtime; **no per-PDK Rust is required.** This is how a brand-new PDK is
+  added (vendor the library + generate a descriptor) *and* how a
+  proprietary library you cannot vendor is simulated (`--cell-descriptor`).
+  See **"Pathway A"** below. This supersedes the legacy Rust workflow
+  (Steps 1–8) for all combinational logic today, with sequential
+  consumption completing across the built-in PDKs in the ADR 0019 C3
+  series.
 - **Runtime cell library** (`--cell-library` + `.cells.toml`
   manifest). For third-party IP, hard macros, foundry memories, and
   any other cells that *don't* need new AIG decomposition rules — i.e.
   cells that act as opaque outputs (RAM macros), filler/cap blocks,
   or IO pads. See **ADR 0010** and `docs/plans/declarative-cell-metadata.md`
   for the recipe. **No Jacquard PR required** — users ship a manifest
-  alongside their netlist.
-
-This guide covers the built-in pathway, which touches five areas:
-
-1. **Library detection** -- recognizing cell names from a netlist
-2. **Pin direction provider** -- telling the netlist parser which pins are inputs/outputs
-3. **Cell classification** -- identifying sequential, tie, and multi-output cells
-4. **Behavioral decomposition** -- converting PDK cells to AIG (AND/NOT) primitives
-5. **CLI wiring** -- connecting it all together
+  alongside their netlist. See **"Adding third-party IP via runtime
+  manifest"** at the end.
+- **Legacy per-PDK Rust** (Steps 1–8 below). The original pathway: pin
+  tables, classifiers, decomposition functions, and AIG builder hooks
+  hand-written in Rust. **Being retired** by the cell-model IR cutover
+  (ADR 0019) — retained here as reference for the machinery the
+  descriptor replaces. Do not add a new PDK this way; use Pathway A.
 
 If you're adding just a memory macro or other behaviourally-opaque IP,
 **skip ahead to "Adding third-party IP via runtime manifest"** at the
 end of this document — it's a 6-line TOML entry, not a Rust PR.
+
+---
+
+## Pathway A: Cell-model IR descriptor (recommended)
+
+A cell-model IR descriptor is a portable, versioned, **generated** JSON
+file carrying *everything per-cell-type* about a library — L1 pin
+directions, L2 combinational logic (as a pre-decomposed AIG), L3
+sequential roles/classification, and L4 timing characterization — from
+one source: the library's Liberty. Adding a PDK is no longer a Jacquard
+code change; it is a *data* generation step. (ADR 0019.)
+
+### Generate a descriptor from Liberty
+
+The `liberty-to-cellir` converter reads a Liberty `.lib` (Liberty-first;
+a functional `.v` is consulted only as a fallback / cross-check) and emits
+the descriptor:
+
+```sh
+cargo run --release --manifest-path crates/liberty-to-cellir/Cargo.toml -- \
+    path/to/mylib_typ_1p20V_25C.lib \
+    --functional-v path/to/mylib_stdcell.v \
+    -o mylib.cellir.json
+```
+
+The converter derives the corner (PVT) from the Liberty's
+`operating_conditions`/`default_operating_conditions`, compiles each cell's
+`function` into an AIG, extracts `ff`/`latch` sequential roles, and (where a
+`.v` is present and per-cell) cross-checks logic + timing-arc topology,
+surfacing any disagreement. It prints a summary
+(`cells=… combinational=… l3_sequential=… l4_timing=… corners=…
+cross_check_mismatches=…`). A monolithic single-`.lib`-per-corner
+commercial library and a per-cell split library are both handled.
+
+### Selection: how Jacquard picks a descriptor for a netlist
+
+Each descriptor **declares the cell-name prefix(es) it covers** (D8).
+Jacquard auto-matches a netlist's cell types against the bundled
+descriptors by prefix; `--cell-descriptor <file.json>` is the explicit
+override (and the path for proprietary libraries). Precedence:
+`--cell-descriptor` (explicit file) > `--bundled-descriptor <name>`
+(explicit bundled) > **auto-match by prefix** > the **default-fallback**
+descriptor (used when no vendor prefix matches — this is how AIGPDK, whose
+cells have no common prefix, is selected).
+
+### Worked example — a built-in PDK (IHP SG13G2, zero per-PDK Rust)
+
+IHP's open SG13G2 PDK was added as a built-in with **no Rust**:
+
+1. **Vendor the library** as a sparse/shallow git submodule (only the
+   stdcell Liberty + `.v` are checked out — ~10 MB, not the multi-GB PDK):
+
+   ```sh
+   git submodule add https://github.com/IHP-GmbH/IHP-Open-PDK.git vendor/IHP-Open-PDK
+   git -C vendor/IHP-Open-PDK sparse-checkout set \
+       ihp-sg13g2/libs.ref/sg13g2_stdcell/lib \
+       ihp-sg13g2/libs.ref/sg13g2_stdcell/verilog
+   ```
+
+2. **Generate + embed at build time.** `build.rs` runs the converter over
+   the pinned vendored `.lib` and embeds the descriptor into the binary
+   (descriptors are **not** checked in — CI regenerates them
+   deterministically, D7). Add the descriptor to `bundled_descriptors::ALL`
+   with its declared prefix (`sg13g2_`).
+
+3. **That's it.** A SG13G2 netlist auto-selects the descriptor by prefix;
+   combinational cells splice from it with no IHP-specific code. Adding the
+   PDK touched no `ihp_*.rs` — only a submodule, a `build.rs` generation
+   line, and a registry entry.
+
+### Worked example — a proprietary library you cannot vendor (GF130)
+
+A foundry/NDA library that can never live in `vendor/` is simulated
+entirely at runtime — the Liberty never leaves your machine:
+
+```sh
+# 1. Generate a descriptor from your own Liberty (offline, on your machine):
+cargo run --release --manifest-path crates/liberty-to-cellir/Cargo.toml -- \
+    /path/to/pdk-gf130/.../GF013bcd_sc6_1p5_a0_TT_1P50V_25C_max.lib \
+    --functional-v /path/to/pdk-gf130/.../GF013bcd_sc6_1p5_a0.v \
+    -o gf130.cellir.json
+
+# 2. Point jacquard at it — no Jacquard build, no vendoring:
+jacquard sim my_chip.gv stim.vcd out.vcd 1 --cell-descriptor gf130.cellir.json
+```
+
+The generator is the only tool that touches raw foundry files; the
+released `jacquard` binary is library-agnostic. (A `--corner <name>` flag
+selects among a multi-corner descriptor's corners, defaulting to the
+descriptor's `default_corner`.)
+
+### Current status & limits
+
+- **Combinational** logic is fully descriptor-driven for every built-in PDK
+  (GF180, SKY130, AIGPDK, IHP) and for proprietary libraries via
+  `--cell-descriptor`.
+- **Sequential** consumption is descriptor-driven for GF180 today and is
+  being wired for the other PDKs in the ADR 0019 C3 series; the descriptor
+  already *carries* the L3 sequential data for all of them.
+- A library whose functional `.v` is a single flat-module file (common for
+  commercial PDKs) skips the optional `.v` logic cross-check at generation
+  (the descriptor is still emitted; validate via simulation) — improving the
+  flat-`.v` indexer is tracked follow-up.
+- RAM/SRAM macros are **not** covered by the descriptor — they use the
+  runtime manifest (ADR 0011), below.
+
+---
 
 ## Prerequisites
 
@@ -47,6 +160,15 @@ You need:
 - The cell naming convention (prefix, drive strength suffix format)
 
 For SKY130, the PDK data lives in `vendor/sky130_fd_sc_hd/` as a git submodule.
+
+## Legacy pathway: per-PDK Rust (Steps 1–8)
+
+> **This section documents the original hand-written-Rust workflow, which the
+> cell-model IR (Pathway A, above) is retiring under ADR 0019.** It is kept as
+> a reference for the machinery the descriptor replaces and for the
+> still-live paths during the cutover. **To add a new PDK, use Pathway A —
+> do not write per-PDK Rust.** The RAM/macro manifest section that follows
+> Step 8 remains fully current.
 
 ## Step 1: Library Detection
 

--- a/docs/handoffs/cell-model-ir-handoff.md
+++ b/docs/handoffs/cell-model-ir-handoff.md
@@ -103,6 +103,60 @@ dual_uart + apb_trace(±xprop) == goldens; GF180 jtag_minimal 9t MD5
 `d87c9f75b4f6af415a9df2d3c728e906` (`--features metal`, 300k edges), GF180
 untouched; `cargo test --lib` 316; four pipeline crates green; 7 crates @ 0.2.4.
 
+## C3a — COMPLETE (IHP SG13G2, new built-in PDK, ZERO per-PDK Rust)
+
+IHP's open **SG13G2** PDK is now a built-in, added purely by **vendoring its
+submodule + embedding a generated descriptor** — the ADR 0019 D7a proof that
+adding a PDK is no longer a Jacquard code change. Three commits on
+`feat/cell-model-ir-c3`.
+
+**Vendored submodule (commit `a2b57d9f`).** `vendor/IHP-Open-PDK` pinned at
+`22f2a25f`, a partial (`blob:none`) + shallow (`depth 1`) clone with a **cone
+sparse-checkout** limited to `ihp-sg13g2/libs.ref/sg13g2_stdcell/{lib,verilog}`
+→ **~10 MB on disk** instead of the multi-GB full PDK. `.gitmodules` carries
+`shallow = true`; the sparse config is local to the working clone (build.rs
+tolerates an absent submodule → empty descriptor, as GF180/SKY130). Registered
+as a mode-160000 gitlink.
+
+**Embed + PDK-neutral dispatch (commit `86f43c92`).** `build.rs` generates
+`sg13g2.cellir.json` from `sg13g2_stdcell_typ_1p20V_25C.lib` (**84 cells, 60
+comb, 14 L3, corner `typ_1p20V_25C`** from the Liberty PVT, 257 KB, det.);
+`bundled_descriptors::ALL` gains the prefix-keyed `sg13g2` entry, auto-selected
+by the derived `sg13g2_` D8 prefix. **No IHP name-match, no `ihp_*.rs`.** The
+combinational **Process**-side splice (`try_descriptor_comb`) was already
+auto-select-keyed; the one generalization needed was the **Visit-side
+dependency walk** in `from_netlistdb_impl` (the `None`-classify arm): it
+gathered only the hardcoded `"A"`/`"B"` input pins (fine for AIGPDK AND2/INV/BUF)
+and dropped the extra inputs of arbitrary descriptor cells. It now visits every
+`Direction::I` pin — PDK-neutral, behaviour-identical for AIGPDK, and also
+serves C3.3d. `cargo test --lib` 317 (+1); embedded-descriptor cell-count floor
+relaxed 100→50 (IHP is a compact 84-cell lib).
+
+**End-to-end proof (commit `b79cb1c2`, `tests/ihp_comb/`).** A cone of 12
+distinct combinational `sg13g2_*` cell types (incl. multi-input mux2/a21oi/
+a22oi/o21ai — what the dependency generalization exists for); primary inputs
+clocked through **AIGPDK DFFs** (a pure timing harness — GEM samples on clock
+edges; **no IHP flops**, sequential is deferred C3.3d). Leaf pin directions from
+a port-only `sg13g2_pins.v` via `--cell-library` (ADR 0010 data layer, not
+Rust). `jacquard sim --check-with-cpu` auto-selects `sg13g2` and passes **17
+cycles** GPU==CPU; an independent truth-table check (`check.py`, 176 signal
+checks, **0 mismatches**) proves the descriptor's comb logic is *correct*, not
+merely self-consistent (the logic oracle, since IHP's flat-`.v` cross-check is a
+C4 deferral).
+
+**Gate (all green).** GF180 jtag_minimal 9t MD5 `d87c9f75b4f6af415a9df2d3c728e906`
+(`--features metal`, 300k edges — GF180 untouched); SKY130 `mcu_soc` flash cosim
+== golden; AIGPDK all-7 cosim == goldens; `cargo test --lib` 317; 7 crates @
+0.2.4.
+
+**What remains for full IHP support.** *Sequential* IHP (14 `ff` cells) awaits
+**C3.3d** (sequential descriptor-driven for non-GF180 PDKs); the descriptor
+already carries their L3, so full support then needs **zero additional IHP
+Rust**. **C4:** the flat-`.v` cross-check indexer (IHP's `.v` is one flat-module
+file → 0 models indexed, comb logic unverified *at generation*, same as SKY130),
+and the one set-dominant flop `sg13g2_sdfbbp_1` (`clear_preset_var1=H`,
+`clear_preset_divergent=1`) needing the schema `clear_preset` tie-break field.
+
 ### What C3.3d (DESTRUCTIVE — not started) still needs
 
 The additive landing means the legacy is all still present and load-bearing:

--- a/docs/handoffs/cell-model-ir-handoff.md
+++ b/docs/handoffs/cell-model-ir-handoff.md
@@ -2,7 +2,7 @@
 
 **Active thread:** ADR 0019 "Cell-model IR" is **approved by the maintainer**
 (all four design open questions resolved). **Plan checkpoints C1, C2, C3.1,
-C3.1b, and C3.2 are COMPLETE** (C2 was CI-green 19/19). The IR + converter
+C3.1b, C3.2, C3.3a, C3.3b, and C3.3c are COMPLETE.** The IR + converter
 foundation is built (C1, #130 closed); GF180 **simulates AND times**
 sequential cells from a generated descriptor with no per-PDK Rust DFF handling
 and no runtime `.lib` parse (C2); descriptors are **generated + embedded at
@@ -67,6 +67,71 @@ blocking SKY130/AIGPDK auto-selection:** no embedded descriptors exist for them
 reader (vendor ships no `.lib` text), AIGPDK needs hand-coded models with no
 cross-check oracle (both noted in C3.1). Until those descriptors exist,
 auto_select returns `Ok(None)` for SKY130/AIGPDK and they ride the legacy path.
+
+## C3.3a/b/c — COMPLETE (branch `feat/cell-model-ir-c3`)
+
+All three built-in PDKs now build **combinational** cells from a generated
+cell-model-IR descriptor. The cutover is **additive** — legacy stays as the
+fallback; nothing was deleted yet (that is C3.3d).
+
+**C3.3a (AIGPDK descriptor, prior agent, validated).** `liberty-to-cellir
+aigpdk/aigpdk.lib` → 11 cells (7 comb, 2 L3, 10 L4), `cross_check_mismatches=0`,
+no converter change. Comb cells match `aigpdk.v` truth tables; DFF/DFFSR roles
+match the legacy `aig.rs` overlay + `aigpdk.v`. RAM (`$__RAMGEM_SYNC_`), clock
+gate (`CKLNQD`), and side-effect (`GEM_*`) cells are correctly excluded.
+
+**C3.3b (embed, commit 4edf7f99).** `build.rs` now generates+embeds two more
+descriptors into `$OUT_DIR` alongside GF180 7t/9t: **SKY130** (from the vendored
+`.lib.json` per-corner layout, 428 cells, declared prefix `sky130_fd_sc_hd__`)
+and **AIGPDK** (from in-repo `aigpdk/aigpdk.lib`, 11 cells, **no** prefix).
+`bundled_descriptors::ALL` gains both; AIGPDK carries `is_default_fallback=true`
+and a new `default_fallback()` returns it. SKY130 auto-selects by prefix;
+AIGPDK is the no-prefix-match default (mirrors `pdk::resolve_library`).
+Behaviour-neutral (consumer still GF180-gated). `cargo test --lib` 316 (+2).
+
+**C3.3c (wire, commit 649d9986).** New PDK-neutral `AIG::try_descriptor_comb`
+splices a descriptor `logic` block for ANY stdcell; wired into the `Process`
+dispatch for SKY130 (before `sky130_postprocess`) and AIGPDK (before the
+hardcoded AND2/INV/BUF match). `setup.rs` adds `.or_else(default_fallback)` so
+AIGPDK netlists resolve the AIGPDK descriptor. Cells with no `logic` (seq / tie
+/ SRAM / multi-output / IO-pad) return false → legacy path UNCHANGED.
+
+**Gate (all green).** SKY130 `mcu_soc` flash cosim == committed golden (165
+sky130 types — the descriptor's combinational logic, **never cross-checked at
+generation**, is now proven byte-identical to legacy); AIGPDK xprop_cosim ×4 +
+dual_uart + apb_trace(±xprop) == goldens; GF180 jtag_minimal 9t MD5
+`d87c9f75b4f6af415a9df2d3c728e906` (`--features metal`, 300k edges), GF180
+untouched; `cargo test --lib` 316; four pipeline crates green; 7 crates @ 0.2.4.
+
+### What C3.3d (DESTRUCTIVE — not started) still needs
+
+The additive landing means the legacy is all still present and load-bearing:
+- **SKY130/AIGPDK *sequential* is still legacy.** Only *combinational* is
+  descriptor-driven for them. Wiring seq needs coordinated changes to BOTH the
+  input-side (`from_netlistdb_impl` seq branches ~2360 sky130 / ~2332 aigpdk)
+  and the output-side overlay (`sky130_postprocess` ~1344, aigpdk `Process`
+  ~1100), the way GF180 does both (`wire_sequential_from_ir` + the
+  `gf180mcu_postprocess` IR overlay). GF180 seq is already IR-driven.
+- **`PdkVariant` is NOT removed** (`grep -rn PdkVariant src/` still ~71 hits) —
+  the dispatch classifies (is_sequential / is_tie / is_multi_output / is_io_pad
+  / extract_cell_type) via PdkVariant + the build.rs-generated pin/classifier
+  tables BEFORE consulting the descriptor.
+- **Runtime `vendor/` stdcell dep still load-bearing.** `load_pdk_models`
+  (`aig.rs` ~2158 sky130 / ~2179 gf180) still reads the vendored cells for the
+  legacy decompose fallback AND the `LeafPinProvider` L1 pin directions. Before
+  deleting it, confirm the descriptor carries L1 directions for the leaf-pin
+  provider.
+- **Residual name-matches still present:** the clock-tracing loop
+  (`"CLK"|"CLKN"|"PORT_*_CLK"`, `aig.rs` ~2263), `get_gf180mcu_dependencies`
+  `"RN"|"SETN"` (~1635), `sky130_postprocess` `SET_B`/`RESET_B` (~1361). These
+  run during dependency/clock ordering before the splice and are intricate to
+  make descriptor-driven.
+- Then: remove `PdkVariant` + all uses, `build.rs::generate_pin_table` +
+  `GF180MCU_PIN_TABLE`/`SKY130_PIN_TABLE` + the `generated` modules, the stdcell
+  classifiers, and the `None`-descriptor fallback (only after every built-in PDK
+  resolves a descriptor). PRESERVE per the boundary: `$__RAMGEM_SYNC_` + GF180
+  SRAM macros, `GEM_ASSERT/DISPLAY`, `CKLNQD`/`icgtp`/`icgtn`, `bi_24t`/`in_c`/
+  `in_s` IO pads, `.cells.toml` / `RuntimeCellLibrary`.
 
 ## C3.1b — COMPLETE (commit on branch)
 

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -1139,9 +1139,24 @@ impl AIG {
                     // Process standard-cell PDK cells.
                     match PdkVariant::classify(celltype) {
                         Some(PdkVariant::Sky130) => {
-                            self.sky130_postprocess(
-                                netlistdb, pinid, cellid, celltype, pdk_models,
-                            );
+                            // ADR 0019 C3.3c: descriptor-driven combinational
+                            // splice first; legacy `sky130_postprocess` decompose
+                            // is the fallback for cells the descriptor doesn't
+                            // model with `logic` (sequential / tie / SRAM /
+                            // multi-output — handled by the postprocess).
+                            let base = extract_cell_type(celltype);
+                            if !self.try_descriptor_comb(
+                                netlistdb,
+                                pinid,
+                                cellid,
+                                celltype,
+                                base,
+                                cell_descriptor,
+                            ) {
+                                self.sky130_postprocess(
+                                    netlistdb, pinid, cellid, celltype, pdk_models,
+                                );
+                            }
                             topo_instack[pinid] = false;
                             continue;
                         }
@@ -1160,7 +1175,23 @@ impl AIG {
                         None => {}
                     }
 
-                    // Process AIGPDK combinational cells
+                    // ADR 0019 C3.3c: descriptor-driven combinational splice for
+                    // AIGPDK cells (AND2_* / INV / BUF). When the default-fallback
+                    // AIGPDK descriptor models this cell's `logic`, splice it in;
+                    // otherwise fall through to the legacy hardcoded match below.
+                    if self.try_descriptor_comb(
+                        netlistdb,
+                        pinid,
+                        cellid,
+                        celltype,
+                        celltype,
+                        cell_descriptor,
+                    ) {
+                        topo_instack[pinid] = false;
+                        continue;
+                    }
+
+                    // Process AIGPDK combinational cells (legacy hardcoded path)
                     let mut prev_a = usize::MAX;
                     let mut prev_b = usize::MAX;
                     for dep_pinid in netlistdb.cell2pin.iter_set(cellid) {
@@ -2100,6 +2131,70 @@ impl AIG {
                 )
             });
         resolve(&out.r, &node_iv)
+    }
+
+    /// PDK-neutral combinational descriptor splice (ADR 0019 C3.3c).
+    ///
+    /// If a cell-model-IR descriptor was supplied AND it carries this cell type
+    /// (keyed by the *full* netlist cell-type name) with a `logic` block, splice
+    /// the pre-decomposed AIG straight in for the requested output pin — no
+    /// runtime `functional.v` decomposition — and return `true`. Otherwise
+    /// return `false` so the caller falls back to its legacy per-PDK
+    /// combinational path UNCHANGED.
+    ///
+    /// This generalises the GF180-only splice in `gf180mcu_postprocess` to
+    /// *every* standard-cell PDK (GF180, SKY130, and the internal AIGPDK): the
+    /// splice is logic-equivalent to each PDK's legacy decompose, so a
+    /// descriptor-driven run produces the same AIG values. Cells with no `logic`
+    /// (sequential / tie / filler / IO-pad / SRAM) return `false` and are left
+    /// to the legacy path. `origin_type` is the cell-type label recorded for
+    /// SDF/timing back-annotation (the base type for the vendor PDKs; the full
+    /// type for AIGPDK).
+    fn try_descriptor_comb(
+        &mut self,
+        netlistdb: &NetlistDB,
+        pinid: usize,
+        cellid: usize,
+        celltype: &str,
+        origin_type: &str,
+        cell_descriptor: Option<&cell_model_ir::CellModelIr>,
+    ) -> bool {
+        let Some(comb) = cell_descriptor
+            .and_then(|d| d.cell(celltype))
+            .and_then(|c| c.logic.as_ref())
+        else {
+            return false;
+        };
+
+        // Build inputs map by pin name (Direction::I only — pin names are not
+        // unique across cells, so a name-based blacklist could drop a real
+        // input; mirror gf180mcu_postprocess's filter).
+        let mut inputs: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for ipin in netlistdb.cell2pin.iter_set(cellid) {
+            if netlistdb.pindirect[ipin] == Direction::I {
+                inputs.insert(
+                    netlistdb.pinnames[ipin].1.to_string(),
+                    self.pin2aigpin_iv[ipin],
+                );
+            }
+        }
+
+        let output_pin_name = netlistdb.pinnames[pinid].1.as_str();
+        let final_iv = self.splice_comb_logic(comb, &inputs, output_pin_name);
+        self.pin2aigpin_iv[pinid] = final_iv;
+
+        // Record cell origin for SDF / timing back-annotation, mirroring the
+        // per-PDK postprocess tails.
+        let output_aigpin = final_iv >> 1;
+        if output_aigpin > 0 && output_aigpin < self.aigpin_cell_origins.len() {
+            self.aigpin_cell_origins[output_aigpin].push((
+                cellid,
+                origin_type.to_string(),
+                output_pin_name.to_string(),
+            ));
+        }
+        true
     }
 
     /// Build an AIG from a netlistdb, using explicit PDK behavioral models for decomposition.

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -1060,23 +1060,23 @@ impl AIG {
                         }
                     }
 
-                    // Handle AIGPDK combinational cells (AND2, INV, BUF)
-                    let mut prev_a = usize::MAX;
-                    let mut prev_b = usize::MAX;
-                    for dep_pinid in netlistdb.cell2pin.iter_set(cellid) {
-                        match netlistdb.pinnames[dep_pinid].1.as_str() {
-                            "A" => prev_a = dep_pinid,
-                            "B" => prev_b = dep_pinid,
-                            _ => {}
-                        }
-                    }
-                    // Push process then dependencies
+                    // Combinational cell outside the vendored PDKs: the internal
+                    // AIGPDK cells (AND2 / INV / BUF) *and* any stdcell an
+                    // auto-selected cell-model-IR descriptor models — e.g. IHP
+                    // SG13G2 `sg13g2_*`, added as a new built-in PDK with ZERO
+                    // per-PDK Rust (ADR 0019 D7a, C3a). Visit *every* input pin so
+                    // each driver is built before this output is spliced by
+                    // `try_descriptor_comb`. Gathering all `Direction::I` pins
+                    // (rather than the hardcoded "A"/"B") makes the dependency walk
+                    // PDK-neutral: it covers arbitrary multi-input descriptor cells
+                    // (mux2's A0/A1/S, a22oi's A1/A2/B1/B2, …) whose pin names
+                    // Jacquard never enumerates. For AIGPDK the input set is exactly
+                    // {A[,B]}, so this stays behaviour-identical.
                     work_stack.push(WorkItem::Process(pinid));
-                    if prev_b != usize::MAX {
-                        work_stack.push(WorkItem::Visit(prev_b));
-                    }
-                    if prev_a != usize::MAX {
-                        work_stack.push(WorkItem::Visit(prev_a));
+                    for dep_pinid in netlistdb.cell2pin.iter_set(cellid) {
+                        if netlistdb.pindirect[dep_pinid] == Direction::I {
+                            work_stack.push(WorkItem::Visit(dep_pinid));
+                        }
                     }
                 }
 

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -380,6 +380,39 @@ impl AIG {
         (d_in, clken)
     }
 
+    /// Set-dominant counterpart of [`Self::wire_dff_reset_set_overlay`]: when
+    /// both async controls are asserted simultaneously the state goes to **1**
+    /// (preset/set wins), matching a Liberty `clear_preset_var1 = H` cell.
+    ///
+    /// ```text
+    ///   reset_n active-low: reset_n=0 forces Q=0
+    ///   set_n   active-low: set_n=0   forces Q=1  (dominant)
+    ///
+    ///   d_in  = OR(AND(D, reset_n), NOT set_n)
+    ///   clken = OR(clken, NOT reset_n, NOT set_n)
+    /// ```
+    ///
+    /// The clock-enable is identical to the reset-dominant overlay (either async
+    /// control forces a capture); only the data value differs when both fire.
+    /// `1` for `set_n_iv` / `reset_n_iv` folds the corresponding branch away.
+    fn wire_dff_set_dominant_overlay(
+        &mut self,
+        d_in: usize,
+        clken: usize,
+        reset_n_iv: usize,
+        set_n_iv: usize,
+    ) -> (usize, usize) {
+        // d_in  = AND(d_in, reset_n)          (reset clears first)
+        // clken = OR(clken, NOT reset_n)      = NOT(AND(NOT clken, reset_n))
+        let d_in = self.add_and_gate(d_in, reset_n_iv);
+        let clken = self.add_and_gate(clken ^ 1, reset_n_iv) ^ 1;
+        // d_in  = OR(d_in, NOT set_n)         = NOT(AND(NOT d_in, set_n))  (set wins)
+        // clken = OR(clken, NOT set_n)        = NOT(AND(NOT clken, set_n))
+        let d_in = self.add_and_gate(d_in ^ 1, set_n_iv) ^ 1;
+        let clken = self.add_and_gate(clken ^ 1, set_n_iv) ^ 1;
+        (d_in, clken)
+    }
+
     /// Resolve a cell-model-IR async set/reset control to the *active-low*
     /// `*_n` aigpin_iv that [`Self::wire_dff_reset_set_overlay`] expects
     /// (ADR 0019 D4).
@@ -434,11 +467,16 @@ impl AIG {
     ///   latch (no edge clock) — the same "treat a latch as a level-enabled
     ///   DFF" approximation the legacy GF180 path applies (GEM simulates no
     ///   true latches).
-    /// * **async set/reset** are layered with the shared reset-dominant
-    ///   [`Self::wire_dff_reset_set_overlay`]. NB this is *reset-dominant* for
-    ///   both DFFs and latches; GF180 set-dominant latches (`latrsnq`) are
-    ///   therefore approximated reset-dominant — exactly as the legacy overlay
-    ///   does, so the two paths agree (see the C2.3 report / ADR 0019 D4).
+    /// * **async set/reset** are layered with the shared async overlay. The
+    ///   simultaneous-assertion tie-break is honoured from the descriptor's
+    ///   [`Sequential::clear_preset`](cell_model_ir::Sequential::clear_preset)
+    ///   (ADR 0019 C4): a [`Dominance::SetDominant`](cell_model_ir::Dominance)
+    ///   cell (Liberty `clear_preset_var1 = H`, e.g. GF180 `latrsnq`) uses
+    ///   [`Self::wire_dff_set_dominant_overlay`]; every other cell — reset-
+    ///   dominant, exotic (`N`/`X`/`T`), or an absent field — uses the
+    ///   reset-dominant [`Self::wire_dff_reset_set_overlay`], which is exactly
+    ///   the historical hardcoded default (so cells without a set-dominant
+    ///   tie-break are byte-identical to the legacy path).
     fn wire_sequential_from_ir(
         &mut self,
         netlistdb: &NetlistDB,
@@ -497,12 +535,22 @@ impl AIG {
             };
         }
 
-        // Async set/reset overlay (input side), reset-dominant — shared with
-        // the legacy path, so the formulas are byte-identical for active-low
-        // GF180 controls.
+        // Async set/reset overlay (input side). The simultaneous-assertion
+        // tie-break comes from the descriptor's `clear_preset`; absent / reset-
+        // dominant / exotic all use the reset-dominant overlay (byte-identical
+        // to the legacy path), only a set-dominant cell (`var1 = H`, e.g. GF180
+        // `latrsnq`) uses the set-dominant overlay.
         let reset_n = self.resolve_async_n(&inputs, seq.async_reset.as_ref());
         let set_n = self.resolve_async_n(&inputs, seq.async_set.as_ref());
-        let (d_in, clken_iv) = self.wire_dff_reset_set_overlay(d_iv, clken_iv, reset_n, set_n);
+        let set_dominant = matches!(
+            seq.clear_preset.map(|cp| cp.dominance()),
+            Some(cell_model_ir::Dominance::SetDominant)
+        );
+        let (d_in, clken_iv) = if set_dominant {
+            self.wire_dff_set_dominant_overlay(d_iv, clken_iv, reset_n, set_n)
+        } else {
+            self.wire_dff_reset_set_overlay(d_iv, clken_iv, reset_n, set_n)
+        };
 
         let dff = self.dffs.entry(cellid).or_default();
         dff.en_iv = clken_iv;
@@ -3840,6 +3888,48 @@ mod xprop_tests {
         for v in &x_capable {
             assert!(!v);
         }
+    }
+
+    #[test]
+    fn reset_vs_set_dominant_overlay_tie_break() {
+        // The two async overlays must agree except when BOTH controls are
+        // asserted simultaneously (active-low ⇒ reset_n=0, set_n=0), where the
+        // reset-dominant overlay forces the captured D to const-0 (Q←0) and the
+        // set-dominant overlay forces it to const-1 (Q←1). iv 0 = const-false,
+        // iv 1 = const-true (see `add_and_gate`).
+        let d_pin = |aig: &mut AIG| -> usize { aig.add_aigpin(DriverType::InputPort(0)) << 1 };
+
+        // Both asserted: the tie-break case — the two overlays diverge.
+        let mut aig = new_test_aig();
+        let d = d_pin(&mut aig);
+        let (rd_d, _) = aig.wire_dff_reset_set_overlay(d, 0, 0, 0);
+        let (sd_d, _) = aig.wire_dff_set_dominant_overlay(d, 0, 0, 0);
+        assert_eq!(rd_d, 0, "reset-dominant: both asserted ⇒ Q←0 (const-0)");
+        assert_eq!(sd_d, 1, "set-dominant: both asserted ⇒ Q←1 (const-1)");
+
+        // Only reset asserted (reset_n=0, set_n=1): both overlays give Q←0.
+        let mut aig = new_test_aig();
+        let d = d_pin(&mut aig);
+        let (rd_d, _) = aig.wire_dff_reset_set_overlay(d, 0, 0, 1);
+        let (sd_d, _) = aig.wire_dff_set_dominant_overlay(d, 0, 0, 1);
+        assert_eq!(rd_d, 0);
+        assert_eq!(sd_d, 0);
+
+        // Only set asserted (reset_n=1, set_n=0): both overlays give Q←1.
+        let mut aig = new_test_aig();
+        let d = d_pin(&mut aig);
+        let (rd_d, _) = aig.wire_dff_reset_set_overlay(d, 0, 1, 0);
+        let (sd_d, _) = aig.wire_dff_set_dominant_overlay(d, 0, 1, 0);
+        assert_eq!(rd_d, 1);
+        assert_eq!(sd_d, 1);
+
+        // Neither asserted (reset_n=1, set_n=1): both pass D through unchanged.
+        let mut aig = new_test_aig();
+        let d = d_pin(&mut aig);
+        let (rd_d, _) = aig.wire_dff_reset_set_overlay(d, 0, 1, 1);
+        let (sd_d, _) = aig.wire_dff_set_dominant_overlay(d, 0, 1, 1);
+        assert_eq!(rd_d, d);
+        assert_eq!(sd_d, d);
     }
 
     #[test]

--- a/src/bundled_descriptors.rs
+++ b/src/bundled_descriptors.rs
@@ -43,6 +43,15 @@ pub const SKY130_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/sky130.cel
 /// mirroring `pdk::resolve_library`, where AIGPDK is already the default.
 pub const AIGPDK_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/aigpdk.cellir.json"));
 
+/// IHP SG13G2 descriptor, generated from
+/// `vendor/IHP-Open-PDK/…/sg13g2_stdcell_typ_1p20V_25C.lib` at the
+/// `typ_1p20V_25C` corner (read from the Liberty PVT groups). Selected by the
+/// `sg13g2_` cell-name prefix. This is the ADR 0019 D7a proof: IHP is a **new**
+/// built-in PDK added with **zero per-PDK Rust** — vendoring the submodule and
+/// embedding this descriptor is the whole change; the combinational splice picks
+/// it up through the same PDK-neutral auto-select path as every other PDK.
+pub const SG13G2_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/sg13g2.cellir.json"));
+
 /// A bundled descriptor's stable selector name and embedded JSON, paired so
 /// callers can list, match, or load them uniformly.
 pub struct BundledDescriptor {
@@ -74,6 +83,11 @@ pub const ALL: &[BundledDescriptor] = &[
     BundledDescriptor {
         name: "sky130",
         json: SKY130_JSON,
+        is_default_fallback: false,
+    },
+    BundledDescriptor {
+        name: "sg13g2",
+        json: SG13G2_JSON,
         is_default_fallback: false,
     },
     BundledDescriptor {
@@ -270,10 +284,13 @@ mod tests {
                     d.name
                 );
             } else {
-                // Prefix-keyed descriptors (GF180 7t/9t, SKY130) are full
-                // standard-cell libraries selected by their declared prefix.
+                // Prefix-keyed descriptors (GF180 7t/9t, SKY130, IHP SG13G2)
+                // are full standard-cell libraries selected by their declared
+                // prefix. Cell counts vary by library size (IHP SG13G2 is a
+                // compact 84-cell library; GF180/SKY130 are 200–430), so the
+                // floor is a modest sanity bound, not a per-library exact count.
                 assert!(
-                    ir.cells.len() > 100,
+                    ir.cells.len() > 50,
                     "{} embedded descriptor has only {} cells",
                     d.name,
                     ir.cells.len()
@@ -326,6 +343,24 @@ mod tests {
             .expect("sky130 netlist must auto-match without ambiguity")
             .expect("sky130 netlist must match a bundled descriptor");
         assert!(ir.library.name.starts_with("sky130_fd_sc_hd__"));
+    }
+
+    #[test]
+    fn sg13g2_auto_selects_by_prefix() {
+        // IHP SG13G2 (ADR 0019 D7a, C3a): a NEW built-in PDK added with zero
+        // per-PDK Rust — it must auto-select through the same prefix path as
+        // every other PDK. May be empty in a submodule-absent build; only assert
+        // when its declared prefix is present.
+        let ihp = load("sg13g2").expect("sg13g2 descriptor must load");
+        if ihp.library.prefixes.is_empty() {
+            eprintln!("skipping: IHP-Open-PDK submodule absent at build time");
+            return;
+        }
+        let cells = ["sg13g2_nand2_1", "sg13g2_inv_1", "sg13g2_mux2_1"];
+        let ir = auto_select(cells.iter().copied())
+            .expect("sg13g2 netlist must auto-match without ambiguity")
+            .expect("sg13g2 netlist must match a bundled descriptor");
+        assert!(ir.library.prefixes.iter().any(|p| p == "sg13g2_"));
     }
 
     #[test]

--- a/src/bundled_descriptors.rs
+++ b/src/bundled_descriptors.rs
@@ -30,6 +30,19 @@ pub const GF180MCU_7T_JSON: &str =
 pub const GF180MCU_9T_JSON: &str =
     include_str!(concat!(env!("OUT_DIR"), "/gf180mcu_9t.cellir.json"));
 
+/// SKY130 high-density descriptor, generated from
+/// `vendor/sky130_fd_sc_hd` at the `tt_025C_1v80` corner (assembled from the
+/// vendor's `.lib.json` per-cell layout). Selected by the `sky130_fd_sc_hd__`
+/// cell-name prefix.
+pub const SKY130_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/sky130.cellir.json"));
+
+/// AIGPDK (internal cell library) descriptor, generated from the in-repo
+/// `aigpdk/aigpdk.lib`. AIGPDK cells have no common vendor prefix (bare `INV`,
+/// `BUF`, `AND2_*`, …), so this descriptor declares no D8 selection prefix and
+/// is the **no-prefix-match default fallback** (see [`default_fallback`]) —
+/// mirroring `pdk::resolve_library`, where AIGPDK is already the default.
+pub const AIGPDK_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/aigpdk.cellir.json"));
+
 /// A bundled descriptor's stable selector name and embedded JSON, paired so
 /// callers can list, match, or load them uniformly.
 pub struct BundledDescriptor {
@@ -37,17 +50,36 @@ pub struct BundledDescriptor {
     pub name: &'static str,
     /// The embedded JSON (the byte-for-byte build-time artifact).
     pub json: &'static str,
+    /// When `true`, this descriptor is the no-prefix-match default fallback
+    /// (AIGPDK): it declares no D8 selection prefix, never participates in
+    /// prefix auto-matching, and is selected only when no other descriptor's
+    /// declared prefix matches the netlist. See [`default_fallback`].
+    pub is_default_fallback: bool,
 }
 
-/// All descriptors embedded at build time. Order is stable.
+/// All descriptors embedded at build time. Order is stable. Prefix-keyed
+/// descriptors (GF180 7t/9t, SKY130) auto-match by declared D8 prefix; the
+/// `is_default_fallback` AIGPDK entry matches no prefix and is the fallback.
 pub const ALL: &[BundledDescriptor] = &[
     BundledDescriptor {
         name: "gf180mcu_7t",
         json: GF180MCU_7T_JSON,
+        is_default_fallback: false,
     },
     BundledDescriptor {
         name: "gf180mcu_9t",
         json: GF180MCU_9T_JSON,
+        is_default_fallback: false,
+    },
+    BundledDescriptor {
+        name: "sky130",
+        json: SKY130_JSON,
+        is_default_fallback: false,
+    },
+    BundledDescriptor {
+        name: "aigpdk",
+        json: AIGPDK_JSON,
+        is_default_fallback: true,
     },
 ];
 
@@ -180,6 +212,24 @@ pub fn auto_select<'a>(
     }
 }
 
+/// The no-prefix-match default-fallback descriptor (AIGPDK).
+///
+/// AIGPDK cells (`INV`, `BUF`, `AND2_*`, `DFF`, …) carry no common vendor
+/// prefix, so they cannot be auto-selected by [`auto_select`] (which keys on
+/// declared D8 prefixes). Instead, AIGPDK is the descriptor a run consumes when
+/// no prefix-keyed descriptor matches — mirroring `pdk::resolve_library`, where
+/// AIGPDK is already the default verdict. Returns `None` only if the embedded
+/// AIGPDK descriptor is empty (it never is — `aigpdk/aigpdk.lib` is in-repo, so
+/// this is always `Some` in a real build).
+pub fn default_fallback() -> Option<CellModelIr> {
+    let entry = ALL.iter().find(|d| d.is_default_fallback)?;
+    let ir = load(entry.name).expect("default-fallback descriptor must load");
+    if ir.cells.is_empty() {
+        return None;
+    }
+    Some(ir)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,30 +241,91 @@ mod tests {
             // otherwise).
             let ir = load(d.name).expect("listed descriptor must load");
 
-            // A build without the GF180 submodules embeds a valid *empty*
-            // descriptor (see build.rs). The real-data assertions only apply
-            // when the submodule was present at build time; the Unit Tests CI
-            // job checks GF180 out, so they are live there.
+            // A build without a vendored submodule (GF180 / SKY130) embeds a
+            // valid *empty* descriptor (see build.rs). The real-data assertions
+            // only apply when the submodule was present at build time; the Unit
+            // Tests CI job checks the submodules out, so they are live there.
+            // (The AIGPDK fallback is in-repo and so is never empty.)
             if ir.cells.is_empty() {
                 eprintln!(
                     "skipping non-empty assertions for {}: empty descriptor \
-                     (GF180 submodule absent at build time)",
+                     (vendored submodule absent at build time)",
                     d.name
                 );
                 continue;
             }
-            assert!(
-                ir.cells.len() > 100,
-                "{} embedded descriptor has only {} cells",
-                d.name,
-                ir.cells.len()
-            );
-            assert!(
-                !ir.library.prefixes.is_empty(),
-                "{} descriptor should declare a D8 selection prefix",
-                d.name
-            );
+
+            if d.is_default_fallback {
+                // AIGPDK: a small internal library (11 cells) with NO common
+                // vendor prefix — it is the no-prefix-match default fallback, so
+                // it deliberately declares no D8 selection prefix.
+                assert!(
+                    !ir.cells.is_empty(),
+                    "{} default-fallback descriptor is empty",
+                    d.name
+                );
+                assert!(
+                    ir.library.prefixes.is_empty(),
+                    "{} default-fallback descriptor must declare NO D8 prefix",
+                    d.name
+                );
+            } else {
+                // Prefix-keyed descriptors (GF180 7t/9t, SKY130) are full
+                // standard-cell libraries selected by their declared prefix.
+                assert!(
+                    ir.cells.len() > 100,
+                    "{} embedded descriptor has only {} cells",
+                    d.name,
+                    ir.cells.len()
+                );
+                assert!(
+                    !ir.library.prefixes.is_empty(),
+                    "{} descriptor should declare a D8 selection prefix",
+                    d.name
+                );
+            }
         }
+    }
+
+    #[test]
+    fn default_fallback_is_aigpdk_with_no_prefix() {
+        // The default fallback is present in ALL and flagged.
+        let entry = ALL
+            .iter()
+            .find(|d| d.is_default_fallback)
+            .expect("ALL must contain a default-fallback descriptor");
+        assert_eq!(entry.name, "aigpdk");
+
+        // It loads, carries cells, and declares no D8 prefix (so it never
+        // participates in prefix auto-matching).
+        let ir = default_fallback().expect("AIGPDK fallback is in-repo, never empty");
+        assert!(!ir.cells.is_empty());
+        assert!(ir.library.prefixes.is_empty());
+
+        // An AIGPDK-shaped netlist therefore gets `Ok(None)` from auto_select
+        // (no prefix match) and the caller resolves the fallback instead.
+        let cells = ["AND2_00_0", "INV", "BUF", "DFF"];
+        assert_eq!(auto_select(cells.iter().copied()), Ok(None));
+    }
+
+    #[test]
+    fn sky130_auto_selects_by_prefix() {
+        // SKY130 may be empty in a submodule-absent build; only assert when its
+        // declared prefix is present.
+        let sky = load("sky130").expect("sky130 descriptor must load");
+        if sky.library.prefixes.is_empty() {
+            eprintln!("skipping: sky130 submodule absent at build time");
+            return;
+        }
+        let cells = [
+            "sky130_fd_sc_hd__inv_2",
+            "sky130_fd_sc_hd__nand2_1",
+            "sky130_fd_sc_hd__dfxtp_1",
+        ];
+        let ir = auto_select(cells.iter().copied())
+            .expect("sky130 netlist must auto-match without ambiguity")
+            .expect("sky130 netlist must match a bundled descriptor");
+        assert!(ir.library.name.starts_with("sky130_fd_sc_hd__"));
     }
 
     #[test]
@@ -224,13 +335,16 @@ mod tests {
     }
 
     /// True only when the GF180 submodules were present at build time, so the
-    /// embedded descriptors carry real D8 prefixes. In a submodule-absent build
-    /// (some CI jobs) the descriptors are empty and auto-match is a no-op; the
-    /// real-data assertions are skipped there (mirrors
-    /// `embedded_descriptors_parse_and_are_nonempty`).
+    /// embedded GF180 descriptors carry real D8 prefixes. In a submodule-absent
+    /// build (some CI jobs) those descriptors are empty and auto-match is a
+    /// no-op; the real-data assertions are skipped there (mirrors
+    /// `embedded_descriptors_parse_and_are_nonempty`). Scoped to the GF180
+    /// descriptors specifically — the AIGPDK fallback deliberately has no prefix
+    /// and SKY130's presence is independent of GF180's.
     fn descriptors_have_prefixes() -> bool {
-        ALL.iter()
-            .all(|d| !load(d.name).unwrap().library.prefixes.is_empty())
+        ["gf180mcu_7t", "gf180mcu_9t"]
+            .iter()
+            .all(|n| !load(n).unwrap().library.prefixes.is_empty())
     }
 
     #[test]

--- a/src/sim/setup.rs
+++ b/src/sim/setup.rs
@@ -183,7 +183,13 @@ pub fn build_netlist_and_aig(
         .or_else(|| {
             crate::bundled_descriptors::auto_select(netlistdb.celltypes.iter().map(|s| s.as_str()))
                 .unwrap_or_else(|e| panic!("{e}"))
-        });
+        })
+        // ADR 0019 C3.3c: no prefix-keyed descriptor matched → the AIGPDK
+        // default fallback (mirrors `pdk::resolve_library`, where AIGPDK is the
+        // default verdict). Harmless for unknown netlists: only cells whose
+        // type the AIGPDK descriptor models are spliced; the rest fall through
+        // to the legacy path.
+        .or_else(crate::bundled_descriptors::default_fallback);
     if let Some(ir) = &descriptor {
         clilog::info!(
             "Loaded cell-model-IR descriptor '{}' ({} cells)",

--- a/tests/ihp_comb/README.md
+++ b/tests/ihp_comb/README.md
@@ -1,0 +1,61 @@
+# IHP SG13G2 combinational sim — zero-per-PDK-Rust proof (ADR 0019 D7a, C3a)
+
+This fixture proves that IHP's open **SG13G2** PDK was added to Jacquard as a
+new built-in PDK **purely by vendoring its submodule + embedding a generated
+cell-model-IR descriptor** — with **no IHP-specific Rust anywhere**. IHP
+combinational `sg13g2_*` cells simulate from the descriptor, auto-selected by
+the `sg13g2_` cell-name prefix through the same PDK-neutral splice path
+(`AIG::try_descriptor_comb`) that GF180/SKY130/AIGPDK use.
+
+## Files
+
+- `ihp_comb_top.v` — gate-level design. A cone of 12 distinct **combinational**
+  `sg13g2_*` cell types (inv, buf, nand2, nor2, and2, or2, xor2, xnor2, a21oi,
+  a22oi, o21ai, mux2), including multi-input cells (A1/A2/B1[/B2], A0/A1/S). The
+  primary inputs are clocked through a bank of **AIGPDK** DFFs — a pure timing
+  harness so GEM's clock-edge-driven simulator can sweep many input vectors past
+  the combinational cone. **No IHP flops** (sequential descriptor-driving for
+  non-GF180 PDKs is the deferred C3.3d work).
+- `sg13g2_pins.v` — port-only stubs supplying the leaf-cell **pin directions**
+  via `--cell-library` (ADR 0010 RuntimeCellLibrary) — an orthogonal *data*
+  layer, not Rust. (A future descriptor-backed leaf-pin provider, C3.3d, would
+  let the descriptor's own L1 directions replace this stub.)
+- `ihp_comb_stim.vcd` — 16-vector clocked stimulus.
+- `check.py` — independent truth-table validator (see below).
+
+## Run (Metal; use `--features cuda`/`hip` elsewhere)
+
+```bash
+printf 'ra\nrb\nrc\nrd\nre\nrf\nrsel\n' > /tmp/ihp_trace.txt
+
+cargo run -r --features metal --bin jacquard -- sim \
+    tests/ihp_comb/ihp_comb_top.v \
+    tests/ihp_comb/ihp_comb_stim.vcd \
+    /tmp/ihp_comb_out.vcd 1 \
+    --cell-library tests/ihp_comb/sg13g2_pins.v \
+    --trace-signals /tmp/ihp_trace.txt \
+    --check-with-cpu
+
+python3 tests/ihp_comb/check.py /tmp/ihp_comb_out.vcd
+```
+
+## What passing proves
+
+1. **`Auto-selected bundled cell-model-IR descriptor 'sg13g2'`** — the IHP
+   descriptor is picked up by prefix, with zero IHP Rust.
+2. **`sanity test passed!`** (`--check-with-cpu`) — the GPU kernel agrees with an
+   independent CPU reference on the IHP-descriptor-spliced AIG, every cycle.
+3. **`check.py` → PASS (176 checks, 0 mismatches)** — the descriptor's
+   combinational logic is not merely self-consistent but *correct* versus
+   hand-derived truth tables for every cell type. (The generation-time
+   Liberty-vs-`.v` cross-check does not run for IHP — its `.v` is one flat-module
+   file, a C4 indexer limitation — so this VCD check is the logic oracle.)
+
+## Deferred
+
+- **Sequential IHP** (the 14 `ff` cells) awaits **C3.3d**, which makes sequential
+  descriptor-driven for non-GF180 PDKs. The IHP descriptor already carries their
+  L3 — full IHP support then needs **zero additional IHP Rust**.
+- **C4:** flat-`.v` cross-check indexing; the one set-dominant flop
+  `sg13g2_sdfbbp_1` (`clear_preset_var1=H`) needs the schema `clear_preset`
+  tie-break field.

--- a/tests/ihp_comb/check.py
+++ b/tests/ihp_comb/check.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Independent truth-table check of the IHP SG13G2 descriptor logic.
+
+Validates a `jacquard sim` output VCD for `ihp_comb_top.v` against hand-derived
+boolean functions for each `sg13g2_*` combinational cell. This is stronger than
+the built-in `--check-with-cpu` (which proves GPU == CPU on the *same* spliced
+AIG): it proves the descriptor's combinational logic is actually CORRECT versus
+the real IHP cell functions -- with zero IHP-specific Rust in Jacquard.
+
+The design registers its primary inputs through AIGPDK DFFs (a clock harness),
+so the combinational outputs `y_*` are functions of the registered inputs
+`ra..rsel`. Run `jacquard sim` with
+
+    --trace-signals <(printf 'ra\\nrb\\nrc\\nrd\\nre\\nrf\\nrsel\\n')
+
+so those registered inputs appear in the output VCD; then `y_*` and `ra..rsel`
+are sampled at the SAME timestamp (purely combinational -- no pipeline math).
+
+Usage: check.py <output.vcd>
+Exit 0 on PASS, non-zero on any mismatch.
+"""
+import re
+import sys
+
+
+def main(path: str) -> int:
+    sig: dict[str, str] = {}
+    val: dict[str, str] = {}
+    checks = fails = sampled = 0
+
+    def b(name):
+        v = val.get(name, "x")
+        return None if v in ("x", "z") else int(v)
+
+    def expect():
+        ra, rb, rc = b("ra"), b("rb"), b("rc")
+        rd, re, rf, rs = b("rd"), b("re"), b("rf"), b("rsel")
+        if (ra is None or rb is None or rc is None or rd is None
+                or re is None or rf is None or rs is None):
+            return None
+        n_inv, n_buf = 1 - ra, rb
+        w_nand, w_nor = 1 - (ra & rb), 1 - (rc | rd)
+        t_xor = w_nand ^ w_nor
+        t_mux = n_inv if rs else t_xor        # mux2: S ? A1 : A0
+        return {
+            "y_nand": 1 - (ra & rb),
+            "y_nor":  1 - (rc | rd),
+            "y_and":  ra & rc,
+            "y_or":   rb | rd,
+            "y_xor":  ra ^ re,
+            "y_xnor": 1 - (rc ^ rf),
+            "y_aoi":  1 - ((ra & rb) | rc),
+            "y_a22":  1 - ((ra & rb) | (rc & rd)),
+            "y_oai":  1 - ((n_inv | n_buf) & re),
+            "y_mux":  rb if rs else ra,
+            "y_deep": 1 - t_mux,
+        }
+
+    def check(ts):
+        nonlocal checks, fails, sampled
+        exp = expect()
+        if exp is None:
+            return
+        sampled += 1
+        for k, ev in exp.items():
+            av = b(k)
+            if av is None:
+                continue
+            checks += 1
+            if av != ev:
+                fails += 1
+                if fails <= 10:
+                    print(f"  MISMATCH @t={ts} {k}: got {av} exp {ev}")
+
+    defn = True
+    cur_ts = None
+    with open(path) as fh:
+        for ln in fh.read().splitlines():
+            if defn:
+                m = re.match(r"\$var wire 1 (\S+) (\S+) ", ln)
+                if m:
+                    sig[m.group(1)] = m.group(2)
+                if ln.startswith("$enddefinitions"):
+                    defn = False
+                continue
+            if ln.startswith("#"):
+                if cur_ts is not None:
+                    check(cur_ts)
+                cur_ts = int(ln[1:])
+                continue
+            if ln in ("$dumpvars", "$end", "$dumpall"):
+                continue
+            m = re.match(r"([01xz])(\S+)$", ln)
+            if m and m.group(2) in sig:
+                val[sig[m.group(2)]] = m.group(1)
+    if cur_ts is not None:
+        check(cur_ts)
+
+    print(f"sampled timestamps: {sampled}, signal checks: {checks}, "
+          f"mismatches: {fails}")
+    if fails == 0 and checks > 0:
+        print("PASS -- IHP SG13G2 descriptor logic matches independent truth tables")
+        return 0
+    print("FAIL")
+    return 1
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        sys.exit("usage: check.py <output.vcd>")
+    sys.exit(main(sys.argv[1]))

--- a/tests/ihp_comb/ihp_comb_top.v
+++ b/tests/ihp_comb/ihp_comb_top.v
@@ -1,0 +1,67 @@
+/*
+ * Combinational IHP SG13G2 gate-level cone -- the ADR 0019 D7a / C3a
+ * zero-per-PDK-Rust proof design.
+ *
+ * The cells UNDER TEST are a cone of REAL sg13g2_* COMBINATIONAL standard
+ * cells (inv/buf/nand2/nor2/and2/or2/xor2/xnor2/a21oi/a22oi/o21ai/mux2). Every
+ * one is spliced from the build-time-embedded IHP cell-model-IR descriptor,
+ * auto-selected by the sg13g2_ prefix, with NO IHP-specific Rust in Jacquard.
+ *
+ * IHP flops are deliberately NOT used: sequential descriptor-driving for
+ * non-GF180 PDKs is the deferred C3.3d work. GEM's simulator is clock-edge
+ * driven, so to sweep many input vectors past the combinational cone we clock
+ * the primary inputs through a bank of AIGPDK DFFs (the internal library's
+ * fully-supported legacy flop) -- a pure timing harness. Each clock cycle the
+ * IHP combinational logic is re-evaluated on the registered inputs and checked
+ * GPU-vs-CPU (jacquard sim --check-with-cpu).
+ *
+ * Leaf pin directions for the sg13g2_* cells come from the sibling port-only
+ * stub sg13g2_pins.v via --cell-library (ADR 0010) -- an orthogonal data
+ * layer, not Rust. The AIGPDK DFF pins are built in.
+ */
+module ihp_comb_top(
+    clk, a, b, c, d, e, f, sel,
+    y_nand, y_nor, y_and, y_or, y_xor, y_xnor,
+    y_aoi, y_a22, y_oai, y_mux, y_deep
+);
+  input clk, a, b, c, d, e, f, sel;
+  output y_nand, y_nor, y_and, y_or, y_xor, y_xnor;
+  output y_aoi, y_a22, y_oai, y_mux, y_deep;
+
+  /* Timing harness: register the primary inputs (AIGPDK DFFs). */
+  wire ra, rb, rc, rd, re, rf, rsel;
+  DFF ff_a   (.CLK(clk), .D(a),   .Q(ra));
+  DFF ff_b   (.CLK(clk), .D(b),   .Q(rb));
+  DFF ff_c   (.CLK(clk), .D(c),   .Q(rc));
+  DFF ff_d   (.CLK(clk), .D(d),   .Q(rd));
+  DFF ff_e   (.CLK(clk), .D(e),   .Q(re));
+  DFF ff_f   (.CLK(clk), .D(f),   .Q(rf));
+  DFF ff_sel (.CLK(clk), .D(sel), .Q(rsel));
+
+  wire n_inv, n_buf, w_nand, w_nor, t_xor, t_mux;
+
+  /* IHP SG13G2 combinational cone under test (output pin: Y for
+   * inv/nand/nor/xnor/aoi/oai, X for buf/and/or/xor/mux). */
+  sg13g2_inv_1   u_inv  (.A(ra),  .Y(n_inv));
+  sg13g2_buf_1   u_buf  (.A(rb),  .X(n_buf));
+  sg13g2_nand2_1 u_nand (.A(ra),  .B(rb),  .Y(y_nand));
+  sg13g2_nor2_1  u_nor  (.A(rc),  .B(rd),  .Y(y_nor));
+  sg13g2_and2_1  u_and  (.A(ra),  .B(rc),  .X(y_and));
+  sg13g2_or2_1   u_or   (.A(rb),  .B(rd),  .X(y_or));
+  sg13g2_xor2_1  u_xor  (.A(ra),  .B(re),  .X(y_xor));
+  sg13g2_xnor2_1 u_xnor (.A(rc),  .B(rf),  .Y(y_xnor));
+
+  /* Multi-input cells (A1/A2/B1[/B2], A0/A1/S) -- what the PDK-neutral
+   * dependency-walk generalization exists for. */
+  sg13g2_a21oi_1 u_aoi  (.A1(ra), .A2(rb), .B1(rc),          .Y(y_aoi));
+  sg13g2_a22oi_1 u_a22  (.A1(ra), .A2(rb), .B1(rc), .B2(rd), .Y(y_a22));
+  sg13g2_o21ai_1 u_oai  (.A1(n_inv), .A2(n_buf), .B1(re),    .Y(y_oai));
+  sg13g2_mux2_1  u_mux  (.A0(ra), .A1(rb), .S(rsel),         .X(y_mux));
+
+  /* Deep multi-level cone: nand -> nor -> xor -> mux -> inv. */
+  sg13g2_nand2_1 u_d1   (.A(ra),     .B(rb),     .Y(w_nand));
+  sg13g2_nor2_1  u_d2   (.A(rc),     .B(rd),     .Y(w_nor));
+  sg13g2_xor2_1  u_d3   (.A(w_nand), .B(w_nor),  .X(t_xor));
+  sg13g2_mux2_1  u_d4   (.A0(t_xor), .A1(n_inv), .S(rsel), .X(t_mux));
+  sg13g2_inv_1   u_d5   (.A(t_mux),  .Y(y_deep));
+endmodule

--- a/tests/ihp_comb/sg13g2_pins.v
+++ b/tests/ihp_comb/sg13g2_pins.v
@@ -1,0 +1,24 @@
+/*
+ * Port-only stubs for the IHP SG13G2 combinational cells used by
+ * ihp_comb_top.v. Passed via --cell-library so the netlist reader learns each
+ * leaf cell's pin directions (ADR 0010, RuntimeCellLibrary) -- an orthogonal
+ * data layer, NOT Rust. Port directions mirror the real IHP sg13g2_stdcell.v
+ * module headers exactly (output first, then inputs).
+ *
+ * The behaviour of each cell is NOT taken from here; it is spliced from the
+ * build-time-embedded cell-model-IR descriptor. These stubs supply only pin
+ * directions. A future descriptor-backed leaf-pin provider (C3.3d) would let
+ * the descriptor's L1 directions replace even this stub, dropping the file.
+ */
+module sg13g2_inv_1   (Y, A);              output Y; input A;              endmodule
+module sg13g2_buf_1   (X, A);              output X; input A;              endmodule
+module sg13g2_nand2_1 (Y, A, B);           output Y; input A, B;           endmodule
+module sg13g2_nor2_1  (Y, A, B);           output Y; input A, B;           endmodule
+module sg13g2_and2_1  (X, A, B);           output X; input A, B;           endmodule
+module sg13g2_or2_1   (X, A, B);           output X; input A, B;           endmodule
+module sg13g2_xor2_1  (X, A, B);           output X; input A, B;           endmodule
+module sg13g2_xnor2_1 (Y, A, B);           output Y; input A, B;           endmodule
+module sg13g2_a21oi_1 (Y, A1, A2, B1);     output Y; input A1, A2, B1;     endmodule
+module sg13g2_a22oi_1 (Y, A1, A2, B1, B2); output Y; input A1, A2, B1, B2; endmodule
+module sg13g2_o21ai_1 (Y, A1, A2, B1);     output Y; input A1, A2, B1;     endmodule
+module sg13g2_mux2_1  (X, A0, A1, S);      output X; input A0, A1, S;      endmodule


### PR DESCRIPTION
Continues the cell-model IR work (ADR 0019) on top of the C1–C3.2 foundation already on main. **All additive and green — nothing is deleted here** (the destructive C3.3d legacy retirement is a separate follow-up PR).

## What's in this PR

- **SKY130 `.lib.json` reader** — SKY130 ships only `.lib.json` (JSON-serialized Liberty), so `liberty-parse` now reads it and assembles a per-corner library. SKY130 generates a descriptor (428 cells, `cross_check_mismatches=0`).
- **C3.3b/c (combinational cutover, additive)** — SKY130 + AIGPDK combinational cells now splice from their embedded descriptors; AIGPDK is selected as the **default-fallback** (its cells have no common prefix). Legacy path retained as fallback throughout.
- **C3a — IHP SG13G2 as a built-in PDK with zero per-PDK Rust** — vendored as a sparse/shallow submodule (~10 MB), descriptor generated + embedded, auto-selected by `sg13g2_` prefix. The dependency walk was generalized to be PDK-neutral (also fixes a latent multi-input-cell bug). Combinational sim proven via `--check-with-cpu` + an independent 176-check truth-table.
- **C4 — `clear_preset` set-dominant tie-break** (`SCHEMA_MINOR 3`) — the descriptor now carries Liberty's `clear_preset_var1/var2` for cells with both async set+reset. GF180 `latrsnq` and IHP `sg13g2_sdfbbp_1` are correctly captured as set-dominant; the consumer honors it via a new set-dominant overlay (reset-dominant default unchanged).
- **`docs/adding-a-pdk.md`** — reframed to lead with the descriptor workflow (IHP built-in + GF130 proprietary worked examples); legacy per-PDK-Rust steps marked being-retired.

## Gates (all green, `--features metal` on Apple Silicon)

- GF180 `jtag_minimal` 9t cosim MD5 `d87c9f75…` (unchanged — GF180 untouched)
- SKY130 `mcu_soc` flash cosim == committed golden (proves SKY130 descriptor logic across 165 cell types)
- AIGPDK `COSIM_SCOPE=all` == goldens (7/7)
- `cargo test --lib` 318; cell-model-ir 17; liberty-to-cellir 70
- version lockstep 7 crates @ 0.2.4

## Deferred to follow-up

- **C3.3d** — the destructive cutover: retire `PdkVariant`, per-PDK stdcell Rust, `build.rs` pin-table gen, and the runtime `vendor/` stdcell dependency; make SKY130/AIGPDK/IHP *sequential* descriptor-driven. (Requires the RAM/macro preserve-boundary care documented in the handoff.)
- **C4 remainder** — flat-module `.v` cross-check indexer; a proprietary sequential end-to-end test.