### PR TITLE
docs: fix stale ChipFlow links + fold resolved issue-triage handoff

### DIFF
--- a/docs/adr/0010-declarative-cell-metadata.md
+++ b/docs/adr/0010-declarative-cell-metadata.md
@@ -26,7 +26,7 @@ Edwards' OCD 3.3V port of the GF180MCU SRAM IP, used in a downstream
 wafer.space tapeout. The cell is third-party IP (not in Jacquard's
 `vendor/`), doesn't match `is_gf180mcu_cell`'s prefix walk
 (`fd_*` / `ws_*` only), has no pin table, and isn't filler-stubbable.
-Issue [#67](https://github.com/ChipFlow/Jacquard/issues/67) captures
+Issue [#67](https://github.com/gpu-eda/Jacquard/issues/67) captures
 the discussion.
 
 The same pattern will repeat for every wafer.space tapeout that
@@ -156,7 +156,7 @@ tests stay green without churn.
 
 ## Links
 
-- Issue [#67](https://github.com/ChipFlow/Jacquard/issues/67) —
+- Issue [#67](https://github.com/gpu-eda/Jacquard/issues/67) —
   design discussion.
 - PR #64 (`9281e57`) — most recent per-PDK-code-as-data workaround
   this ADR resolves.

--- a/docs/adr/0011-ram-port-mapping-schema.md
+++ b/docs/adr/0011-ram-port-mapping-schema.md
@@ -20,12 +20,12 @@ boots from ROM, never reads SRAM contents" cases but **fails the
 moment a real CPU writes to SRAM and expects to read its data back**.
 
 The acute trigger is the JTAG-DM firmware-load path enabled by
-[PR #78](https://github.com/ChipFlow/Jacquard/pull/78): OpenOCD
+[PR #78](https://github.com/gpu-eda/Jacquard/pull/78): OpenOCD
 walks a debug-module sequence that culminates in abstract-memory
 writes into the design's SRAM, then jumps the CPU to that memory.
 Because the SRAM is opaque (no backing storage, writes go nowhere),
 the CPU boots to garbage. Issue
-[#80](https://github.com/ChipFlow/Jacquard/issues/80) captures the
+[#80](https://github.com/gpu-eda/Jacquard/issues/80) captures the
 symptom and notes that wiring `SramInitConfig` is the smaller sibling
 problem — pre-loading SRAM contents at tick 0 — but the bigger gap
 is that `kind = "ram"` doesn't model writes at all.
@@ -157,7 +157,7 @@ flagged cells as opaque RAMs, which is a graceful degradation.
 
 `TestbenchConfig::sram_init` (an existing schema field declared in
 `src/testbench.rs` but unwired today — issue
-[#80](https://github.com/ChipFlow/Jacquard/issues/80)) becomes
+[#80](https://github.com/gpu-eda/Jacquard/issues/80)) becomes
 load-bearing once explicit-port RAMs have backing storage. The
 preload path:
 
@@ -205,9 +205,9 @@ require an ADR — purely additive JSON schema work.
 
 - ADR 0010 — Declarative cell metadata (the parent decision deferring
   this schema).
-- Issue [#80](https://github.com/ChipFlow/Jacquard/issues/80) —
+- Issue [#80](https://github.com/gpu-eda/Jacquard/issues/80) —
   driving consumer.
-- PR [#78](https://github.com/ChipFlow/Jacquard/pull/78) — the
+- PR [#78](https://github.com/gpu-eda/Jacquard/pull/78) — the
   JTAG-DM workflow that surfaced the schema need.
 - Upstream OCD SRAM behavioural model:
   [RTimothyEdwards/gf180mcu_ocd_ip_sram](https://github.com/RTimothyEdwards/gf180mcu_ocd_ip_sram).

--- a/docs/adr/0012-cdc-jitter-injection.md
+++ b/docs/adr/0012-cdc-jitter-injection.md
@@ -29,7 +29,7 @@ handshake protocol violations) only surface when edge alignment varies
 from the ideal.
 
 The motivating incident was
-[PR #89 / run 26413667030](https://github.com/ChipFlow/Jacquard/actions/runs/26413667030):
+[PR #89 / run 26413667030](https://github.com/gpu-eda/Jacquard/actions/runs/26413667030):
 a scheduler index bug caused sys_clk to fire at TCK's period, making
 CDC synchronizers between the JTAG and system clock domains marginal.
 The test passed intermittently because Metal GPU scheduling jitter

--- a/docs/handoffs/issue-triage-and-upstreaming-handoff.md
+++ b/docs/handoffs/issue-triage-and-upstreaming-handoff.md
@@ -1,101 +1,75 @@
-# Handoff — issue triage & upstream hygiene
+# Handoff — upstream hygiene (eda-infra-rs + stale PRs)
 
-**Created/updated:** 2026-06-26 · main @ `e56e831`, CI green.
+**Created/updated:** 2026-07-01 · branch `docs/macos-split-handoff`.
 
-## Goal & now
+## Goal & next-up
 
-The distribution-and-release arc is **done** (folded into ADR 0018's amendment,
-`docs/release-process.md`, and the install docs — see "What shipped"). The
-active task is now a **triage of the 22 open GitHub issues against current
-state** — several are stale/resolved by what shipped this session. After that,
-two standing upstream-hygiene follow-ups remain.
+The **issue triage is done** (2026-07-01) — see "Triage outcome" below. What
+remains from the original arc are the two **upstream-hygiene follow-ups**:
+eda-infra-rs upstreaming (Phase 7) and the stale upstream PRs. Pick either up
+cold from the "Open follow-ups" section.
 
-## Active task: issue triage (just started, interrupted before agents ran)
+## Triage outcome (resolved — 2026-07-01)
 
-Review all **22 open issues** against the current code; decide close / keep /
-update-with-comment for each. **Do NOT auto-close** — produce a triage table
-and let Rob decide. The intended approach (interrupted): fan out ~4 parallel
-`scout` agents, each `gh issue view`s a group of issues, verifies against
-`src/`/`csrc/`/`CHANGELOG.md`/`docs/adr/`, and reports RESOLVED / PARTIAL /
-OPEN with file:line evidence + a recommended action.
+Triaged all open issues against `f6d0e23`. **No close candidates remained** —
+the strong-RESOLVED set (#104, #105, #100, #7, #130) had already been closed on
+2026-06-26/30. Every still-open issue is genuinely open. Three got scoping
+comments recording their partial-progress state (the permanent home for the
+triage conclusions):
 
-**Strong RESOLVED candidates (verify, then propose closing):**
-- **#104** "sim: CUDA/HIP drop timing constraints — `--timing-report`/
-  `--timing-summary`/`--timed` are Metal-only" → **wired** (commit `24723b5`;
-  confirmed in the ADR 0008 amendment). Almost certainly closeable.
-- **#105** "cosim is Metal-only — make backend-portable (CUDA/HIP)" → CUDA/HIP
-  cosim backends now exist (`src/sim/cosim/cuda.rs`, `hip.rs`; ADR 0013/0017
-  amendments). Check whether the CPU-fallback half is also done before closing.
+- **#6** multi-corner SDF — timing-IR path has `--timing-corner` (single-select);
+  SDF path still single-corner (`--sdf-corner`, no `all`). Comment posted.
+- **#9** WNS/TNS/WHS/THS — WNS+WHS + violation counts ship; **TNS/THS** (total-slack
+  sums) not yet computed. Comment posted.
+- **#10** multi-clock — `MultiClockScheduler` shipped for cosim *execution*
+  (`src/sim/cosim/mod.rs:1309`); per-domain *timing analysis* + CDC-path flagging
+  not built. Pairs with #87. Comment posted.
 
-**Likely PARTIAL / needs nuance:**
-- **#6** multi-corner SDF (min+max) — multi-corner *timing IR* shipped via
-  `--timing-corner`, but `--sdf-corner` is still one-corner-at-a-time.
-- **#9** WNS/TNS/WHS/THS summary — `--timing-summary` ships; confirm the exact
-  metrics match.
-- **#10** multi-clock domain — `MultiClockScheduler` shipped for cosim; confirm
-  scope vs the issue's ask.
-- **#7** clock skew from SDF — per-DFF clock-arrival folding (Pillar B) shipped;
-  confirm this is what #7 wanted.
-- **#92** complete ADR 0012 CDC jitter (deferred scope) — still partial (ADR
-  0012 is `Accepted (partial)`).
-- **#103** multi-SRAM `sram_init` — still OPEN (ADR 0011 amendment confirms
-  single-SRAM only). ⚠ **Cross-ref bug:** ADR 0011's new amendment cites
-  "issue #80" for this — the actual open issue is **#103**; verify/fix that
-  citation.
+Everything else stays open with no change: #92 (CDC jitter, well-scoped
+checklist), #103/#119 (priority:high), #127 (non-determinism), #87/#106/#107
+(coverage/roadmap), #142/#143 (new bugs), and the forward-looking timing
+roadmap #8/#11–#16.
 
-**Likely still OPEN (forward-looking timing roadmap, 2026-02-16 batch):**
-- #11 OCV derating, #12 crosstalk/SI, #13 IR-drop, #14 PBA, #15 SSTA, #16 ECO.
-- #127 non-deterministic output state-slot (mt-kahypar) — relates to the
-  HashMap-ordering heisenbug (see user memory `feedback_hashmap_ordering`).
-- #100 netlist-graph drivers walk clk/set/reset; #106/#107 X-barrier
-  assertions; #119/#130 GF180MCU cosim SRAM-race / 7T-hardcode; #87 multi-clock
-  test coverage.
-
-`gh issue list --state open --limit 100` for the live list.
-
-## What shipped (context — this arc is resolved)
-
-- **v0.2.3 released** (docs release; first working prebuilt channels were
-  v0.2.2). Three live install channels: `cargo binstall --git` (needs
-  `brew install llvm`), Homebrew tap `gpu-eda/homebrew-tap` (auto-LLVM),
-  PyPI `netlist-graph 0.1.0`.
-- **Staging install-validation** (`validate-install.yml`) — the gate that
-  caught v0.2.1's broken channels; RC → validate → promote flow.
-- **Unified crate versions** (`scripts/bump_version.py` + verify-guard);
-  **Cargo.lock tracked**; prerelease draft-publish fix for immutable releases.
-- **Docs currency pass**: README getting-started polish, latch-limitation
-  clarified across the book, stale `ChipFlow`→`gpu-eda` links fixed.
-- **ADR amend-in-place convention** (`docs/adr/README.md`): refinement → dated
-  in-place Amendment (original preserved); reversal → supersede. Applied as a
-  **currency pass amending 14 ADRs** (`e56e831`) — incl. 0018 Proposed→Accepted,
-  0008 Approved→Accepted, 0013/0017 cosim-Metal-only corrections.
-
-## Findings / learnings (carry forward)
-
-- PyPI trusted-publisher repo name is case-sensitive (`gpu-eda/Jacquard`).
-- cargo-binstall `--git` can't pin a tag; pass `GITHUB_TOKEN` or it 403s.
-- Modern brew rejects loose formula files; use a local tap + fully-qualified
-  install.
-- Immutable-releases repo: publish prereleases via a draft.
-- Prebuilt binary needs Homebrew LLVM at runtime (libc++/libomp via mt-kahypar).
-- Rust crates are NOT a Cargo workspace (separate `crates/*/target/`).
-- CI gotchas: the self-hosted `tesla4-runner` (CUDA/HIP) and `macos-runner-1`
-  (Metal) are single shared runners — CI can queue/stall on them or on a
-  spending-limit; docs/dist-only PRs are safe `--admin` merges when the
-  GPU-relevant checks are green.
+Also folded this session: the org-rename currency pass had missed 10 live
+`ChipFlow/Jacquard` hyperlinks across 4 doc files — repointed to
+`gpu-eda/Jacquard` (commit `f6d0e23`). The handoff's flagged ADR-0011
+`#80`→`#103` "cross-ref bug" was a non-issue: the amendment already cites #103
+correctly; the `#80` references legitimately track the original single-SRAM
+feature (closed).
 
 ## Open follow-ups (priority order)
 
-1. **Finish the issue triage** (active task above) — propose close/keep/update
-   per issue; fix the ADR 0011 `#80`→`#103` cross-ref.
-2. **eda-infra-rs upstreaming** (plan `docs/plans/distribution.md` Phase 7):
-   pull upstream license fix `026070c` + re-pin the submodule first; then the
-   ANSI-ports / Metal / HIP / unary-NOT PR work. Path to a crates.io publish.
-3. **Stale upstream PRs** #94/#57/#53/#17 — not safely mergeable; triage/rebase
-   or close.
+### 1. eda-infra-rs upstreaming (plan `docs/plans/distribution.md` Phase 7)
+
+Pull upstream license fix `026070c` + re-pin the submodule first; then the
+ANSI-ports / Metal / HIP / unary-NOT PR work. Path to a crates.io publish.
+
+### 2. Stale upstream PRs #94 / #57 / #53 / #17
+
+Not safely mergeable as-is; triage/rebase or close each.
+
+## Critical context (carry forward)
+
+- PyPI trusted-publisher repo name is case-sensitive (`gpu-eda/Jacquard`).
+- cargo-binstall `--git` can't pin a tag; pass `GITHUB_TOKEN` or it 403s.
+- Modern brew rejects loose formula files; use a local tap + fully-qualified install.
+- Immutable-releases repo: publish prereleases via a draft.
+- Prebuilt binary needs Homebrew LLVM at runtime (libc++/libomp via mt-kahypar).
+- Rust crates are NOT a Cargo workspace (separate `crates/*/target/`).
+- CI: self-hosted `tesla4-runner` (CUDA/HIP) + `macos-runner-1` (Metal) are single
+  shared runners — can queue/stall; docs/dist-only PRs are safe `--admin` merges
+  when GPU-relevant checks are green.
 
 ## References
 
-- ADRs (`docs/adr/`, all current as of the `e56e831` currency pass),
-  `docs/release-process.md`, `docs/installation.md`, `docs/plans/distribution.md`.
+- `docs/plans/distribution.md` (Phase 7), `docs/release-process.md`,
+  `docs/installation.md`.
+- ADRs under `docs/adr/` (all current as of the `e56e831` currency pass).
 - PRs this arc: #133–#140. Releases v0.2.1 → v0.2.3.
+
+---
+
+**Resume in a new session with:**
+```
+/resume_handoff docs/handoffs/issue-triage-and-upstreaming-handoff.md
+```

--- a/docs/plans/declarative-cell-metadata.md
+++ b/docs/plans/declarative-cell-metadata.md
@@ -7,8 +7,8 @@ and the port-mapping schema have all landed.
   (Tier 1 + minimal Tier 2)
 - [0011 — RAM port-mapping schema](../adr/0011-ram-port-mapping-schema.md)
   (the port-mapping extension originally deferred by ADR 0010)
-**Issues:** [#67](https://github.com/ChipFlow/Jacquard/issues/67),
-[#80](https://github.com/ChipFlow/Jacquard/issues/80).
+**Issues:** [#67](https://github.com/gpu-eda/Jacquard/issues/67),
+[#80](https://github.com/gpu-eda/Jacquard/issues/80).
 **Driving designs:** the wafer.space `chip_top.pnl.v` blocked on
 `gf180mcu_ocd_ip_sram__sram1024x8m8wm1`, then the JTAG-DM workflow
 in PR #78 surfacing the need for real RAM backing storage.


### PR DESCRIPTION
Docs housekeeping, no code changes.

## 1. Fix stale `ChipFlow/Jacquard` links → `gpu-eda/Jacquard`

The org-rename currency pass missed 10 live hyperlinks across 4 docs (ADRs 0010–0012, the declarative-cell-metadata plan). Repointed to `gpu-eda/Jacquard`. The two remaining `ChipFlow` mentions (ADR 0018, `distribution.md`) are descriptive text documenting the URL fix and are intentionally left intact.

## 2. Fold the resolved issue-triage handoff

Triaged all open issues vs. current `main`: no close candidates remained (the strong-RESOLVED set was already closed). Posted partial-progress scoping comments on #6 (SDF still single-corner), #9 (TNS/THS sums not yet computed), #10 (multi-clock execution shipped, timing-analysis half not) — those GitHub comments are the permanent home for the triage conclusions. The handoff now carries only the two live upstream-hygiene follow-ups (eda-infra-rs Phase 7 upstreaming, stale PRs #94/#57/#53/#17).

## Note on the macOS split handoff

The `macos-build-test-split` handoff (the Metal build/test split, shipped in #154) never landed on `main` — it lived only on the `docs/macos-split-handoff` working branch, whose useful commits are cherry-picked here. Its load-bearing content is captured in the merged `ci.yml` + commit `fb91a8f3`, so there's nothing to migrate. That stale branch can be deleted after this merges.