### PR TITLE
feat(timing): TNS/THS total-negative-slack metrics (#9, salvaged from #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ the public contracts in `docs/release-process.md` follow stricter rules).
   place. Now it defaults to `vendor/` (unchanged behaviour) and honours
   `JACQUARD_VENDOR_DIR` when set. Follows the existing `JACQUARD_*`
   runtime-knob convention.
+- **TNS / THS timing metrics** in `--timing-summary` and `--timing-report`.
+  Alongside the existing worst-single-slack WNS/WHS, the report now carries
+  Total Negative Slack and Total Hold Slack — the sum of every negative
+  setup / hold slack across the run (`stats.total_setup_slack_ps` /
+  `stats.total_hold_slack_ps`). Additive JSON-schema change, bumped to
+  `1.2.0` (older reports still parse via `#[serde(default)]`). Salvaged from
+  the timing logic in #17. (#9)
 
 ## [0.2.4] - 2026-06-26
 

--- a/docs/timing-violations.md
+++ b/docs/timing-violations.md
@@ -146,11 +146,25 @@ Violations:
 Worst slack:
   Setup: -150ps  at top/cpu/regs[7][bit 22] [word=5]  (cycle 87)
   Hold:   -40ps  at top/cpu/state[bit 3] [word=12]  (cycle 91)
+  Total negative: setup (TNS)=-620ps  hold (THS)=-80ps
 
 Top 2 by violation count (of 2 total words with violations):
   top/cpu/regs[7][bit 22] [word=5] (5 violations): worst setup=-150ps hold=- arrival=950ps
   top/cpu/state[bit 3] [word=12] (2 violations): worst setup=- hold=-40ps arrival=10ps
 ```
+
+The **Worst slack** block reports the four standard signoff metrics:
+
+| Metric | Meaning |
+|--------|---------|
+| **WNS** (Worst Negative Slack) | The single most-negative setup slack across the whole run — the worst setup path. |
+| **WHS** (Worst Hold Slack) | The single most-negative hold slack. |
+| **TNS** (Total Negative Slack) | Sum of *all* negative setup slacks (`stats.total_setup_slack_ps` in the JSON). Captures the aggregate severity, not just the worst path. |
+| **THS** (Total Hold Slack) | Sum of all negative hold slacks (`stats.total_hold_slack_ps`). |
+
+TNS/THS reflect every observed violation regardless of the per-cycle
+list cap, and are never optimistic: if the GPU event buffer overflows,
+dropped events only make the true totals *more* negative.
 
 The format is for human inspection — explicitly **not** a stable
 parseable contract. Tools that need to script against the data should

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -51,8 +51,10 @@ impl TimingReportConfig<'_> {
             setup_violations: stats.setup_violations,
             hold_violations: stats.hold_violations,
             events_dropped: stats.events_dropped,
-            // `violations_truncated` is filled in by builder.finalize().
-            violations_truncated: 0,
+            // violations_truncated + the TNS/THS totals are filled in by
+            // builder.finalize(); default the rest so new report fields
+            // don't have to be threaded through here.
+            ..Default::default()
         };
         let report = builder.finalize(cycles_run, report_stats);
         if let Some(json_path) = self.json_path {
@@ -1685,7 +1687,9 @@ fn sim_hip(
                 setup_violations: sim_stats.setup_violations,
                 hold_violations: sim_stats.hold_violations,
                 events_dropped: sim_stats.events_dropped,
-                violations_truncated: 0,
+                // violations_truncated + TNS/THS totals are filled in by
+                // builder.finalize(); default the rest.
+                ..Default::default()
             };
             let report = builder.finalize(num_cycles as u32, stats);
             if let Some(json_path) = report_cfg.json_path {

--- a/src/timing_report.rs
+++ b/src/timing_report.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 /// 1.1.0 — additive: `stats.violations_truncated`; per-cycle violations
 ///         array now bounded by default (worst-slack + per-word + totals
 ///         still reflect every event).
-pub const SCHEMA_VERSION: &str = "1.1.0";
+pub const SCHEMA_VERSION: &str = "1.2.0";
 
 /// One setup or hold violation record. Mirrors the `EventType::*Violation`
 /// payload, with `word_id` resolved to a human-readable `site` string via
@@ -72,6 +72,14 @@ pub struct ReportStats {
     /// per-cycle list is bounded.
     #[serde(default)]
     pub violations_truncated: u32,
+    /// Total negative slack (TNS / THS): the sum of every negative setup /
+    /// hold slack observed across the run, in picoseconds. Complements the
+    /// worst-single-slack (WNS / WHS) values carried in `worst_slack`. Always
+    /// ≤ 0; reflects every observed event regardless of the per-cycle cap.
+    #[serde(default)]
+    pub total_setup_slack_ps: i64,
+    #[serde(default)]
+    pub total_hold_slack_ps: i64,
 }
 
 /// Per-word aggregate: violation counts and worst slack across the run.
@@ -203,6 +211,12 @@ impl TimingReport {
         writeln!(out, "Worst slack:").unwrap();
         write_worst(&mut out, "Setup", self.worst_slack.setup.first());
         write_worst(&mut out, "Hold", self.worst_slack.hold.first());
+        writeln!(
+            out,
+            "  Total negative: setup (TNS)={}ps  hold (THS)={}ps",
+            self.stats.total_setup_slack_ps, self.stats.total_hold_slack_ps
+        )
+        .unwrap();
 
         if !self.per_word.is_empty() {
             writeln!(out).unwrap();
@@ -274,6 +288,10 @@ pub struct ReportBuilder {
     /// `None` = unbounded; `Some(n)` = keep the first `n` records.
     max_violations: Option<usize>,
     truncated: u32,
+    /// Running TNS / THS sums (negative slacks only), materialised into
+    /// `ReportStats` at `finalize`.
+    total_setup_slack_ps: i64,
+    total_hold_slack_ps: i64,
 }
 
 impl ReportBuilder {
@@ -294,15 +312,29 @@ impl ReportBuilder {
             hold_worst: WorstSlackTracker::with_capacity(worst_slack_n),
             max_violations,
             truncated: 0,
+            total_setup_slack_ps: 0,
+            total_hold_slack_ps: 0,
         }
     }
 
     pub fn observe(&mut self, v: ViolationRecord) {
-        // Worst-slack and per-word always see every violation; only the
-        // per-cycle list is bounded.
+        // Worst-slack, per-word, and the TNS/THS sums always see every
+        // violation; only the per-cycle list is bounded. Guard on
+        // `slack_ps < 0` so TNS/THS stay true "total *negative* slack"
+        // even if a zero/positive-slack record is ever observed.
         match v.kind {
-            ViolationKind::Setup => self.setup_worst.push(v.clone()),
-            ViolationKind::Hold => self.hold_worst.push(v.clone()),
+            ViolationKind::Setup => {
+                if v.slack_ps < 0 {
+                    self.total_setup_slack_ps += v.slack_ps as i64;
+                }
+                self.setup_worst.push(v.clone())
+            }
+            ViolationKind::Hold => {
+                if v.slack_ps < 0 {
+                    self.total_hold_slack_ps += v.slack_ps as i64;
+                }
+                self.hold_worst.push(v.clone())
+            }
         }
         update_per_word(&mut self.per_word, &v);
         match self.max_violations {
@@ -320,6 +352,8 @@ impl ReportBuilder {
     pub fn finalize(mut self, cycles_run: u32, mut stats: ReportStats) -> TimingReport {
         self.metadata.cycles_run = cycles_run;
         stats.violations_truncated = self.truncated;
+        stats.total_setup_slack_ps = self.total_setup_slack_ps;
+        stats.total_hold_slack_ps = self.total_hold_slack_ps;
         let per_word = sort_per_word(self.per_word.into_values().collect());
         TimingReport {
             schema_version: SCHEMA_VERSION.to_string(),
@@ -486,6 +520,39 @@ mod tests {
         assert_eq!(parsed.violations.len(), 2);
         assert_eq!(parsed.metadata.cycles_run, 50);
         assert_eq!(parsed.stats.setup_violations, 1);
+    }
+
+    #[test]
+    fn tns_ths_accumulate_across_observations() {
+        // Ported from PR #17: WNS/WHS are the single worst; TNS/THS are
+        // the sums. Setup: -100 + -450 + -200 = -750 (WNS = -450).
+        // Hold: -120 + -280 = -400 (WHS = -280).
+        let mut b = ReportBuilder::new(
+            RunMetadata {
+                jacquard_version: "0.1.0".into(),
+                clock_period_ps: 1000,
+                ..Default::default()
+            },
+            5,
+            None,
+        );
+        for slack in [-100, -450, -200] {
+            b.observe(make_violation(0, ViolationKind::Setup, 1, slack, 0));
+        }
+        for slack in [-120, -280] {
+            b.observe(make_violation(0, ViolationKind::Hold, 2, slack, 0));
+        }
+        let report = b.finalize(10, ReportStats::default());
+        assert_eq!(report.stats.total_setup_slack_ps, -750, "TNS");
+        assert_eq!(report.stats.total_hold_slack_ps, -400, "THS");
+        // WNS/WHS unaffected — still the single worst.
+        assert_eq!(report.worst_slack.setup[0].slack_ps, -450, "WNS");
+        assert_eq!(report.worst_slack.hold[0].slack_ps, -280, "WHS");
+        // Survives a JSON round-trip (serde default keeps back-compat).
+        let parsed: TimingReport =
+            serde_json::from_str(&serde_json::to_string(&report).unwrap()).unwrap();
+        assert_eq!(parsed.stats.total_setup_slack_ps, -750);
+        assert_eq!(parsed.stats.total_hold_slack_ps, -400);
     }
 
     #[test]


### PR DESCRIPTION
Closes the remaining gap in #9 (WNS/TNS/WHS/THS summary): the timing report had **WNS/WHS** (worst single setup/hold slack) but not the two *total* metrics, **TNS** (Total Negative Slack) and **THS** (Total Hold Slack).

## Change

- `ReportBuilder::observe` accumulates the sums as it sees each violation (guarded on `slack_ps < 0` so they stay true totals of *negative* slack).
- Surfaced via `ReportStats.total_setup_slack_ps` / `total_hold_slack_ps` (JSON) and a new `Total negative:` line in `--timing-summary`.
- **Additive JSON-schema change** → `SCHEMA_VERSION` 1.1.0 → 1.2.0 per ADR 0008 (older reports still parse via `#[serde(default)]`; covered by the pinned 1.0.0 fixture test).
- Docs: metrics glossary (WNS/TNS/WHS/THS) + updated sample in `docs/timing-violations.md`.

## Provenance — salvaged from #17

PR #17 implemented TNS/THS but on the pre-`loom→jacquard` `SimStats` on a since-rewritten timing path (530 commits back, 10/11 files conflicting). Rather than rebase that, this ports the logic into the current `ReportBuilder` architecture, with a unit test carrying #17's exact assertions (setup -100/-450/-200 → TNS -750, WNS -450; hold -120/-280 → THS -400, WHS -280). **#17 can be closed once this lands.**

All 18 `timing_report` unit tests pass.