### PR TITLE
feat: cell-model IR cutover — self-contained stdcell binary, PdkVariant removed (ADR 0019 C3.3d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,16 @@ the public contracts in `docs/release-process.md` follow stricter rules).
 
 ### Added
 
-- **`JACQUARD_VENDOR_DIR`** env var to override the vendored-PDK root used
-  for cell-library decomposition (`gf180mcu_fd_sc_mcu7t5v0` /
-  `sky130_fd_sc_hd` functional models). Previously the path was hardcoded
-  to `vendor/` relative to the process CWD, so a consumer running
-  `jacquard` from another working directory had to symlink `vendor/` into
-  place. Now it defaults to `vendor/` (unchanged behaviour) and honours
-  `JACQUARD_VENDOR_DIR` when set. Follows the existing `JACQUARD_*`
-  runtime-knob convention.
+- **Cell-model IR descriptors (ADR 0019).** Standard-cell libraries are now
+  consumed as generated JSON descriptors — pin directions, combinational AIG,
+  sequential roles, and timing — produced from Liberty by the
+  `liberty-to-cellir` converter and embedded at build time. Adds **SKY130**
+  (via a `.lib.json` reader) and **IHP SG13G2 as a new built-in PDK with zero
+  per-PDK Rust**; proprietary libraries simulate via `--cell-descriptor`
+  (no Jacquard build). The runtime binary is now **self-contained for standard
+  cells** — no vendored-PDK read at simulation time — and the `PdkVariant`
+  enum, per-PDK stdcell classifiers, and `build.rs` pin-table generation are
+  retired. See `docs/adding-a-pdk.md`.
 - **TNS / THS timing metrics** in `--timing-summary` and `--timing-report`.
   Alongside the existing worst-single-slack WNS/WHS, the report now carries
   Total Negative Slack and Total Hold Slack — the sum of every negative

--- a/docs/plans/cell-model-ir.md
+++ b/docs/plans/cell-model-ir.md
@@ -1,9 +1,28 @@
 # Cell-model IR — staged delivery plan
 
-**Status:** Proposed — not started. Realises
+**Status:** Largely delivered. Realises
 [ADR 0019](../adr/0019-cell-model-ir.md). Tracks
 [#130](https://github.com/gpu-eda/Jacquard/issues/130) and
 [#67](https://github.com/gpu-eda/Jacquard/issues/67).
+
+- **C1 (foundation + #130)** — ✅ landed (#132). #130 is fixed by default: a 9T
+  netlist auto-selects its own 9T descriptor.
+- **C1b (converter generalization)** — ✅ landed (#155): corner from Liberty PVT,
+  ff internal-state-var (`IQ`). Surfaced by running the converter against the
+  proprietary GF130 (GF013BCD) library.
+- **C2 (L3 sequential + L4 timing)** — ✅ landed (#132).
+- **C3.1/C3.2 (build-time generation + prefix selection)** — ✅ landed (#132).
+- **SKY130 `.lib.json` reader** — ✅ landed (#155): SKY130 ships only
+  `.lib.json`, so `liberty-parse` reads it.
+- **C3a (IHP SG13G2, zero-Rust new PDK)** — ✅ landed (#155): vendored as a
+  sparse/shallow submodule + a generated descriptor, no `ihp_*.rs`.
+- **C3.3 (cut over + drop runtime `vendor/` dep)** — ✅ landed (#160): the
+  runtime binary is self-contained for standard cells (`load_pdk_models` has no
+  runtime callers), and `PdkVariant` is deleted (`grep -rn PdkVariant src/` = 0).
+- **C4 (proprietary workflow + `clear_preset`)** — 🟡 partial: `clear_preset`
+  set-dominant field landed (#155); `docs/adding-a-pdk.md` reframed around the
+  descriptor workflow (#155). The proprietary *sequential* end-to-end test and
+  the round-trip honesty fix remain (see Remaining follow-ups).
 
 **Goal:** make Jacquard core consume a single, generated, JSON cell-model
 IR carrying *all* per-cell-type facts of a library — L1 directions, L2
@@ -28,6 +47,50 @@ cleanup that the first two earn.
 | **C3 — bundle + cut over + selection** | **Regenerate** bundled descriptors for all built-in PDKs (AIGPDK/SKY130/GF180) **in CI from the pinned vendored submodules and embed at build time — not checked in** (D7); build-time generation replaces the `build.rs` pin-table step. Selection by descriptor-declared prefix + `--cell-descriptor` (D8). Drop the runtime `vendor/` cell dependency, `pdk_decomp`, and `liberty_parser::TimingLibrary` from core; retire `gf180mcu*.rs`/`sky130*.rs` classifiers, `PdkVariant`, and the `build.rs` pin-table generators. | The existing PDK regression suite (incl. timed runs) passes consuming **only** build-time-generated descriptors; vendored cell submodules are no longer a *runtime* dependency of jacquard core, and CI regeneration is deterministic. |
 | **C3a — IHP SG13G2 (new PDK, zero Rust)** | Vendor the [IHP-Open-PDK](https://github.com/IHP-GmbH/IHP-Open-PDK) SG13G2 stdcells as a submodule; add it to the bundle by **generating a descriptor only — no per-PDK Rust** (D7a). Exercises the Liberty-first path cleanly (every SG13G2 cell has `function`; every flop a full `ff` group with reset polarity). | An SG13G2 gate-level design simulates **and times** purely from its generated descriptor, with no `ihp_*.rs` in core — the worked proof that adding a PDK is no longer a Jacquard code change. |
 | **C4 (later)** | A documented proprietary-library workflow: user runs the generator on their own Liberty, gets a descriptor, simulates — no Jacquard build. Honesty fix: the round-trip logic check replaces `build.rs`'s port-only `assert_eq!`. | `docs/adding-a-pdk.md` recipe; a synthetic "private" library exercised end-to-end in a test. |
+
+## Remaining follow-ups (post-cutover)
+
+Discovered during implementation; folded here from the working handoff so they
+survive its deletion. None reopen the runtime `vendor/` stdcell dependency or
+reintroduce `PdkVariant`.
+
+1. **Descriptor-drive AIGPDK `DFF`/`DFFSR`.** AIGPDK's two internal flops are
+   still on a literal-match path. Their descriptor L3 is well-formed
+   (clock=CLK/rising, next_state=D, async S/R active-low, reset-dominant); the
+   conversion is gate-covered (every AIGPDK/IHP fixture exercises them). Do this
+   first — it is bounded and safe.
+2. **Descriptor-drive the preserved `edfxtp`/`icgtp`/`icgtn` seq branches.** The
+   legacy `SET_B`/`RESET_B`/`RN`/`SETN` sequential-wiring branches remain because
+   they still serve *preserved* cells: SKY130 `edfxtp` (its data-enable folds
+   into `next_state` via the `ff` state var `IQ`, so `ir_seq_input_wireable`
+   returns false) and GF180 `icgtp`/`icgtn` clock gates (emit no L3). **No gated
+   design exercises these**, so add a small `edfxtp`/`icgtp` fixture *first*, then
+   descriptor-drive them and delete the residual literals + the per-PDK
+   classifiers.
+3. **Gate IHP sequential.** IHP `ff` cells are code-supported (previously
+   panicked) but ungated — no flop-bearing SG13G2 fixture exists (needs synthesis
+   infra to produce an IHP gate-level netlist). Add one to lock in IHP sequential.
+4. **Flat-module `.v` cross-check indexer.** Commercial libraries (GF130, IHP)
+   ship one flat-module `.v`, so the D6 logic cross-check reports 0 models indexed
+   and does not run at generation (the descriptor is still emitted; correctness is
+   validated via simulation, and the converter now *warns*). Teach the indexer
+   flat-module `.v` so commercial descriptors are logic-cross-checked at
+   generation.
+5. **Descriptor-backed `LeafPinProvider` + delete `build.rs` pin-table gen.**
+   Confirmed feasible (descriptor L1 covers every stdcell's scalar pins; chain:
+   power-pin → filler → descriptor L1 → preserved pad/IP/SRAM tables). Not yet
+   wired; the per-PDK `LeafPinProvider`s + `build.rs::generate_pin_table` +
+   `generated` modules remain (inert for stdcell *logic*, but still the parse-time
+   pin-direction source). This is the last mechanical cleanup.
+6. **C4 — proprietary sequential end-to-end test + round-trip honesty fix.** GF130
+   descriptor *generation* is proven (the C4 proof), but no proprietary
+   *sequential* simulation test exists; add a synthetic "private" library
+   exercised end-to-end. Separately, the round-trip logic check should replace
+   `build.rs`'s port-only `assert_eq!` (the plan's C4 honesty fix).
+7. **`clear_preset` for true set-dominant sequential sim.** The field is emitted
+   and the consumer honors it, but a proprietary user simulating set-dominant
+   flops still needs the non-GF180 sequential path fully descriptor-driven
+   (items 1–2) to observe the correct behaviour end-to-end.
 
 ## Risks / open questions
 

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -12,13 +12,13 @@
 
 use crate::aigpdk::AIGPDK_SRAM_ADDR_WIDTH;
 use crate::gf180mcu_pdk::Gf180PdkModels;
-use crate::pdk::PdkVariant;
 // SKY130-flavoured helpers used by the sky130-specific methods on AIG
 // (`get_sky130_dependencies`, `sky130_preprocess`, `sky130_postprocess`,
-// `build_sky130_multi_output_postprocess`). Top-level dispatch through
-// PdkVariant is preferred for new code, but within SKY130-only methods
-// the unqualified shorthand is fine — it can't accidentally classify a
-// GF180MCU cell because the caller has already routed on PdkVariant.
+// `build_sky130_multi_output_postprocess`). Top-level dispatch routes cells
+// to these methods via `AIG::is_sky130_stdcell` / `is_gf180mcu_stdcell`
+// (direct cell-name predicates, ADR 0019 C3.3d), so within a SKY130-only
+// method the unqualified `extract_cell_type` shorthand can't accidentally
+// classify a GF180MCU cell — the caller has already routed on the predicate.
 use crate::sky130::extract_cell_type;
 use crate::sky130_pdk::{
     decompose_with_pdk, is_multi_output_cell, is_sequential_cell, is_tie_cell, CellInputs,
@@ -697,6 +697,24 @@ impl AIG {
         deps
     }
 
+    /// True if `celltype` is a SKY130 standard cell that takes the
+    /// SKY130-specific AIG build path (`get_sky130_dependencies` /
+    /// `sky130_preprocess` / `sky130_postprocess`). Formerly the
+    /// former classify-Sky130 arm.
+    fn is_sky130_stdcell(celltype: &str) -> bool {
+        crate::sky130::is_sky130_cell(celltype)
+    }
+
+    /// True if `celltype` is a GF180MCU standard cell that takes the
+    /// GF180-specific AIG build path. Excludes the `gf180mcu_fd_ip_sram__*`
+    /// IP macros, which are compiled hard macros modelled as RAM blocks via
+    /// the runtime cell library (ADR 0010/0011), not standard cells — they
+    /// route to the RAM path like the former classify-None arm. Formerly the
+    /// classify-Gf180Mcu arm.
+    fn is_gf180mcu_stdcell(celltype: &str) -> bool {
+        crate::gf180mcu::is_gf180mcu_cell(celltype) && !crate::gf180mcu::is_sram_macro(celltype)
+    }
+
     /// Classify a clock-path cell as an identity buffer or inverter from the
     /// cell-model-IR descriptor's L2 combinational logic (ADR 0019 C3.3d).
     ///
@@ -708,7 +726,7 @@ impl AIG {
     /// the caller then falls back to the preserved IO-pad / CKLNQD paths or
     /// rejects the cell as unsupported on the clock path.
     ///
-    /// This replaces the per-PDK `PdkVariant` name matches (`inv`/`clkinv` →
+    /// This replaces the per-PDK name matches (`inv`/`clkinv` →
     /// inverter, `buf`/`clkbuf`/`dly*` → buffer): the descriptor's decomposed
     /// AIG is the source of truth for each cell's identity, so GF180/SKY130/
     /// AIGPDK clock cells all classify uniformly with no PDK dispatch.
@@ -750,7 +768,7 @@ impl AIG {
         // The auto-selected cell-model-IR descriptor (ADR 0019 C3.3d). Used to
         // recognise clock-path buffers/inverters from their L2 combinational
         // logic (single input, output = input or ¬input) instead of per-PDK
-        // `PdkVariant` name predicates. `None` = no descriptor (never happens
+        // per-PDK name predicates. `None` = no descriptor (never happens
         // for a built-in PDK, which always resolves one).
         cell_descriptor: Option<&cell_model_ir::CellModelIr>,
     ) -> Result<usize, usize> {
@@ -921,7 +939,7 @@ impl AIG {
             // Determine if this is a clock buffer/inverter. ADR 0019 C3.3d:
             // recognise identity buffers / inverters from the cell-model-IR
             // descriptor's L2 logic (single input, output = input or ¬input)
-            // instead of per-PDK `PdkVariant` name predicates. This covers
+            // instead of per-PDK name predicates. This covers
             // AIGPDK `INV`/`BUF`, SKY130 `inv`/`clkinv`/`buf`/`clkbuf`/
             // `clkdlybuf` and the delay cells (`dlygate*`/`dlymetal*`), and
             // GF180MCU `inv`/`clkinv`/`buf`/`clkbuf`/`dlya..d` uniformly —
@@ -941,7 +959,8 @@ impl AIG {
             // digital-sim simplification (`Y = PAD`) makes its AIG shape
             // identical to in_c / in_s (common case: JTAG TCK routed through a
             // bidirectional signal pad). This preserved pad path stays name-
-            // based via the gf180mcu module helpers (not `PdkVariant`). See #75.
+            // based via the gf180mcu module helpers (not a PDK dispatch enum).
+            // See #75.
             let is_io_pad_buf = crate::gf180mcu::is_gf180mcu_cell(celltype)
                 && crate::gf180mcu_pdk::is_io_pad_cell(crate::gf180mcu::extract_cell_type(celltype));
             let (is_inv, is_buf) = match Self::descriptor_clock_buf(celltype, cell_descriptor) {
@@ -1214,65 +1233,64 @@ impl AIG {
                     }
 
                     // Handle standard-cell PDK cells (combinational + sequential).
-                    match PdkVariant::classify(celltype) {
-                        Some(PdkVariant::Sky130) => {
-                            let deps = self.get_sky130_dependencies(
-                                netlistdb,
-                                pinid,
-                                cellid,
-                                celltype,
-                                cell_descriptor,
-                            );
-                            self.sky130_preprocess(netlistdb, pinid, cellid, celltype);
-                            work_stack.push(WorkItem::Process(pinid));
-                            for dep in deps {
-                                work_stack.push(WorkItem::Visit(dep));
-                            }
-                            continue;
+                    // ADR 0019 C3.3d: dispatch by direct cell-name predicate
+                    // (`is_sky130_stdcell` / `is_gf180mcu_stdcell`) rather than
+                    // the retired classify dispatch enum — behaviour-identical
+                    // (the enum was a thin wrapper over these predicates).
+                    if Self::is_sky130_stdcell(celltype) {
+                        let deps = self.get_sky130_dependencies(
+                            netlistdb,
+                            pinid,
+                            cellid,
+                            celltype,
+                            cell_descriptor,
+                        );
+                        self.sky130_preprocess(netlistdb, pinid, cellid, celltype);
+                        work_stack.push(WorkItem::Process(pinid));
+                        for dep in deps {
+                            work_stack.push(WorkItem::Visit(dep));
                         }
-                        Some(PdkVariant::Gf180Mcu) => {
-                            let deps = self.get_gf180mcu_dependencies(
-                                netlistdb,
-                                pinid,
-                                cellid,
-                                celltype,
-                                cell_descriptor,
-                            );
-                            self.gf180mcu_preprocess(netlistdb, pinid, cellid, celltype);
-                            work_stack.push(WorkItem::Process(pinid));
-                            for dep in deps {
-                                work_stack.push(WorkItem::Visit(dep));
-                            }
-                            continue;
+                        continue;
+                    } else if Self::is_gf180mcu_stdcell(celltype) {
+                        let deps = self.get_gf180mcu_dependencies(
+                            netlistdb,
+                            pinid,
+                            cellid,
+                            celltype,
+                            cell_descriptor,
+                        );
+                        self.gf180mcu_preprocess(netlistdb, pinid, cellid, celltype);
+                        work_stack.push(WorkItem::Process(pinid));
+                        for dep in deps {
+                            work_stack.push(WorkItem::Visit(dep));
                         }
-                        None => {
-                            // Cell isn't in a vendored PDK; consult
-                            // the runtime cell-library manifest
-                            // (ADR 0010). For `kind = "ram"`, treat
-                            // as opaque RAM: allocate a per-output
-                            // SRAM driver and route through `srams`
-                            // for X-source enumeration. No port
-                            // resolution; future schema versions
-                            // upgrade this with explicit port mapping.
-                            if let Some(lib) = cell_library {
-                                use crate::cell_library::CellKind;
-                                if lib.lookup_kind(celltype) == Some(CellKind::Ram) {
-                                    let o = self.add_aigpin(DriverType::SRAM(cellid));
-                                    self.pin2aigpin_iv[pinid] = o << 1;
-                                    let pin_name = netlistdb.pinnames[pinid].1.to_string();
-                                    self.aigpin_cell_origins[o].push((
-                                        cellid,
-                                        celltype.to_string(),
-                                        pin_name,
-                                    ));
-                                    let sram = self.srams.entry(cellid).or_default();
-                                    let bit_idx = netlistdb.pinnames[pinid].2.unwrap_or(0) as usize;
-                                    if bit_idx < sram.port_r_rd_data.len() {
-                                        sram.port_r_rd_data[bit_idx] = o;
-                                    }
-                                    topo_instack[pinid] = false;
-                                    continue;
+                        continue;
+                    } else {
+                        // Cell isn't in a vendored PDK (SRAM IP macro, AIGPDK,
+                        // IHP, or unknown); consult the runtime cell-library
+                        // manifest (ADR 0010). For `kind = "ram"`, treat as
+                        // opaque RAM: allocate a per-output SRAM driver and
+                        // route through `srams` for X-source enumeration. No
+                        // port resolution; future schema versions upgrade this
+                        // with explicit port mapping.
+                        if let Some(lib) = cell_library {
+                            use crate::cell_library::CellKind;
+                            if lib.lookup_kind(celltype) == Some(CellKind::Ram) {
+                                let o = self.add_aigpin(DriverType::SRAM(cellid));
+                                self.pin2aigpin_iv[pinid] = o << 1;
+                                let pin_name = netlistdb.pinnames[pinid].1.to_string();
+                                self.aigpin_cell_origins[o].push((
+                                    cellid,
+                                    celltype.to_string(),
+                                    pin_name,
+                                ));
+                                let sram = self.srams.entry(cellid).or_default();
+                                let bit_idx = netlistdb.pinnames[pinid].2.unwrap_or(0) as usize;
+                                if bit_idx < sram.port_r_rd_data.len() {
+                                    sram.port_r_rd_data[bit_idx] = o;
                                 }
+                                topo_instack[pinid] = false;
+                                continue;
                             }
                         }
                     }
@@ -1387,54 +1405,50 @@ impl AIG {
                         continue;
                     }
 
-                    // Process standard-cell PDK cells.
-                    match PdkVariant::classify(celltype) {
-                        Some(PdkVariant::Sky130) => {
-                            // ADR 0019 C3.3c: descriptor-driven combinational
-                            // splice first; legacy `sky130_postprocess` decompose
-                            // is the fallback for cells the descriptor doesn't
-                            // model with `logic` (sequential / tie / SRAM /
-                            // multi-output — handled by the postprocess).
-                            let base = extract_cell_type(celltype);
-                            if self.try_descriptor_comb(
-                                netlistdb,
-                                pinid,
-                                cellid,
-                                celltype,
-                                base,
-                                cell_descriptor,
-                            ) {
-                                // combinational splice done
-                            } else if let Some(seq) = cell_descriptor
-                                .and_then(|d| d.cell(celltype))
-                                .and_then(|c| c.sequential.as_ref())
-                            {
-                                // ADR 0019 C3.3d: descriptor-driven async *output*
-                                // overlay for SKY130 flops — byte-identical to the
-                                // legacy `SET_B`/`RESET_B` read below, now shared
-                                // with GF180 / IHP via `apply_ir_seq_output`.
-                                self.apply_ir_seq_output(netlistdb, pinid, cellid, seq);
-                            } else {
-                                self.sky130_postprocess(
-                                    netlistdb, pinid, cellid, celltype, pdk_models,
-                                );
-                            }
-                            topo_instack[pinid] = false;
-                            continue;
+                    // Process standard-cell PDK cells. ADR 0019 C3.3d: dispatch
+                    // by direct cell-name predicate rather than the retired
+                    // retired classify dispatch enum (behaviour-identical).
+                    if Self::is_sky130_stdcell(celltype) {
+                        // ADR 0019 C3.3c: descriptor-driven combinational
+                        // splice first; legacy `sky130_postprocess` decompose
+                        // is the fallback for cells the descriptor doesn't
+                        // model with `logic` (sequential / tie / SRAM /
+                        // multi-output — handled by the postprocess).
+                        let base = extract_cell_type(celltype);
+                        if self.try_descriptor_comb(
+                            netlistdb,
+                            pinid,
+                            cellid,
+                            celltype,
+                            base,
+                            cell_descriptor,
+                        ) {
+                            // combinational splice done
+                        } else if let Some(seq) = cell_descriptor
+                            .and_then(|d| d.cell(celltype))
+                            .and_then(|c| c.sequential.as_ref())
+                        {
+                            // ADR 0019 C3.3d: descriptor-driven async *output*
+                            // overlay for SKY130 flops — byte-identical to the
+                            // legacy `SET_B`/`RESET_B` read below, now shared
+                            // with GF180 / IHP via `apply_ir_seq_output`.
+                            self.apply_ir_seq_output(netlistdb, pinid, cellid, seq);
+                        } else {
+                            self.sky130_postprocess(netlistdb, pinid, cellid, celltype, pdk_models);
                         }
-                        Some(PdkVariant::Gf180Mcu) => {
-                            self.gf180mcu_postprocess(
-                                netlistdb,
-                                pinid,
-                                cellid,
-                                celltype,
-                                gf180_pdk,
-                                cell_descriptor,
-                            );
-                            topo_instack[pinid] = false;
-                            continue;
-                        }
-                        None => {}
+                        topo_instack[pinid] = false;
+                        continue;
+                    } else if Self::is_gf180mcu_stdcell(celltype) {
+                        self.gf180mcu_postprocess(
+                            netlistdb,
+                            pinid,
+                            cellid,
+                            celltype,
+                            gf180_pdk,
+                            cell_descriptor,
+                        );
+                        topo_instack[pinid] = false;
+                        continue;
                     }
 
                     // ADR 0019 C3.3d: descriptor-driven sequential *output* overlay
@@ -2566,10 +2580,12 @@ impl AIG {
 
             // Check if this is a sequential element (AIGPDK / SKY130 / GF180MCU)
             let is_aigpdk_seq = matches!(celltype, "DFF" | "DFFSR" | "$__RAMGEM_SYNC_");
-            let is_pdk_seq = match PdkVariant::classify(celltype) {
-                Some(variant) => variant.is_sequential(variant.extract_cell_type(celltype)),
-                None => false,
-            };
+            let is_pdk_seq = (Self::is_sky130_stdcell(celltype)
+                && crate::sky130_pdk::is_sequential_cell(extract_cell_type(celltype)))
+                || (Self::is_gf180mcu_stdcell(celltype)
+                    && crate::gf180mcu_pdk::is_sequential_cell(crate::gf180mcu::extract_cell_type(
+                        celltype,
+                    )));
             // ADR 0019 C3.3d: descriptor-driven sequential classification for
             // stdcells outside the vendored PDKs (e.g. IHP SG13G2 `ff` cells),
             // so their clock pins are traced here like any other flop. Additive:
@@ -2732,8 +2748,8 @@ impl AIG {
                 dff.en_iv = ap_clken_iv;
                 dff.d_iv = d_in;
                 assert_ne!(dff.q, 0);
-            } else if PdkVariant::classify(celltype) == Some(PdkVariant::Sky130)
-                && PdkVariant::Sky130.is_sequential(PdkVariant::Sky130.extract_cell_type(celltype))
+            } else if Self::is_sky130_stdcell(celltype)
+                && crate::sky130_pdk::is_sequential_cell(extract_cell_type(celltype))
             {
                 // ADR 0019 C3.3d: IR-driven sequential input wiring (D / clock-
                 // enable / async), the SKY130 twin of the GF180 branch below.
@@ -2753,7 +2769,7 @@ impl AIG {
                 }
 
                 // Handle SKY130 DFFs (dfxtp, edfxtp, dfrtp, etc.)
-                let cell_type = PdkVariant::Sky130.extract_cell_type(celltype);
+                let cell_type = extract_cell_type(celltype);
                 let mut ap_d_iv = 0;
                 let mut ap_clken_iv = 0;
                 let mut ap_enable_iv = 1; // For edfxtp (data enable)
@@ -2789,9 +2805,10 @@ impl AIG {
                 dff.en_iv = ap_clken_iv;
                 dff.d_iv = d_in;
                 assert_ne!(dff.q, 0, "SKY130 DFF {} has no Q output built", cellid);
-            } else if PdkVariant::classify(celltype) == Some(PdkVariant::Gf180Mcu)
-                && PdkVariant::Gf180Mcu
-                    .is_sequential(PdkVariant::Gf180Mcu.extract_cell_type(celltype))
+            } else if Self::is_gf180mcu_stdcell(celltype)
+                && crate::gf180mcu_pdk::is_sequential_cell(crate::gf180mcu::extract_cell_type(
+                    celltype,
+                ))
             {
                 // GF180MCU sequentials: DFFs / scan DFFs / latches /
                 // clock-gating cells. Same async-set/reset shape as
@@ -2816,7 +2833,7 @@ impl AIG {
                 // We treat them as state-holding DFFs to avoid a
                 // panic; clock-tree-aware simulation through them is
                 // a follow-on item (Phase 5+).
-                let cell_type = PdkVariant::Gf180Mcu.extract_cell_type(celltype);
+                let cell_type = crate::gf180mcu::extract_cell_type(celltype);
 
                 // ADR 0019 C2.3: IR-driven sequential wiring. When a
                 // cell-model-IR descriptor was supplied AND it carries an L3
@@ -2935,15 +2952,17 @@ impl AIG {
             } else if let Some(seq) = cell_descriptor
                 .and_then(|d| d.cell(celltype))
                 .and_then(|c| c.sequential.as_ref())
-                .filter(|_| PdkVariant::classify(celltype).is_none())
+                .filter(|_| {
+                    !Self::is_sky130_stdcell(celltype) && !Self::is_gf180mcu_stdcell(celltype)
+                })
                 .filter(|seq| Self::ir_seq_input_wireable(netlistdb, cellid, seq))
             {
                 // ADR 0019 C3.3d: IR-driven sequential input wiring for a stdcell
                 // outside the vendored PDKs (e.g. IHP SG13G2 `ff` cells). The
-                // `PdkVariant::classify().is_none()` filter keeps GF180/SKY130 on
-                // their dedicated branches above; only non-vendored descriptor
-                // flops reach here. AIGPDK `DFF`/`DFFSR` are handled by the
-                // literal-match branch at the top of this loop, not here.
+                // not-a-vendored-stdcell filter keeps GF180/SKY130 on their
+                // dedicated branches above; only non-vendored descriptor flops
+                // reach here. AIGPDK `DFF`/`DFFSR` are handled by the literal-
+                // match branch at the top of this loop, not here.
                 aig.wire_sequential_from_ir(netlistdb, cellid, seq, cell_descriptor);
                 let dff = aig.dffs.entry(cellid).or_default();
                 assert_ne!(dff.q, 0, "IR-driven DFF {cellid} has no Q output built");

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -629,8 +629,7 @@ impl AIG {
         seq: &cell_model_ir::Sequential,
     ) {
         let q = self.dffs.get(&cellid).unwrap().q;
-        let mut inputs: std::collections::HashMap<String, usize> =
-            std::collections::HashMap::new();
+        let mut inputs: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
         for ipin in netlistdb.cell2pin.iter_set(cellid) {
             if netlistdb.pindirect[ipin] == Direction::I {
                 inputs.insert(
@@ -942,7 +941,9 @@ impl AIG {
             // based via the gf180mcu module helpers (not a PDK dispatch enum).
             // See #75.
             let is_io_pad_buf = crate::gf180mcu::is_gf180mcu_cell(celltype)
-                && crate::gf180mcu_pdk::is_io_pad_cell(crate::gf180mcu::extract_cell_type(celltype));
+                && crate::gf180mcu_pdk::is_io_pad_cell(crate::gf180mcu::extract_cell_type(
+                    celltype,
+                ));
             let (is_inv, is_buf) = match Self::descriptor_clock_buf(celltype, cell_descriptor) {
                 Some(true) => (true, false),
                 Some(false) => (false, true),
@@ -1297,10 +1298,7 @@ impl AIG {
                         work_stack.push(WorkItem::Process(pinid));
                         for dep_pinid in netlistdb.cell2pin.iter_set(cellid) {
                             let pn = netlistdb.pinnames[dep_pinid].1.as_str();
-                            let is_async = seq
-                                .async_set
-                                .as_ref()
-                                .is_some_and(|c| c.pin == pn)
+                            let is_async = seq.async_set.as_ref().is_some_and(|c| c.pin == pn)
                                 || seq.async_reset.as_ref().is_some_and(|c| c.pin == pn);
                             if is_async {
                                 work_stack.push(WorkItem::Visit(dep_pinid));
@@ -2486,12 +2484,11 @@ impl AIG {
         // a descriptor explicitly (with `--cell-descriptor` / `--bundled-
         // descriptor` precedence); this covers the plain-API paths with the
         // same auto-select + default-fallback chain.
-        let auto = crate::bundled_descriptors::auto_select(
-            netlistdb.celltypes.iter().map(|s| s.as_str()),
-        )
-        .ok()
-        .flatten()
-        .or_else(crate::bundled_descriptors::default_fallback);
+        let auto =
+            crate::bundled_descriptors::auto_select(netlistdb.celltypes.iter().map(|s| s.as_str()))
+                .ok()
+                .flatten()
+                .or_else(crate::bundled_descriptors::default_fallback);
         Self::from_netlistdb_with_cells_and_descriptor(netlistdb, cell_library, auto.as_ref())
     }
 
@@ -2563,9 +2560,9 @@ impl AIG {
             let is_pdk_seq = (Self::is_sky130_stdcell(celltype)
                 && crate::sky130_pdk::is_sequential_cell(extract_cell_type(celltype)))
                 || (Self::is_gf180mcu_stdcell(celltype)
-                    && crate::gf180mcu_pdk::is_sequential_cell(crate::gf180mcu::extract_cell_type(
-                        celltype,
-                    )));
+                    && crate::gf180mcu_pdk::is_sequential_cell(
+                        crate::gf180mcu::extract_cell_type(celltype),
+                    ));
             // ADR 0019 C3.3d: descriptor-driven sequential classification for
             // stdcells outside the vendored PDKs (e.g. IHP SG13G2 `ff` cells),
             // so their clock pins are traced here like any other flop. Additive:
@@ -2641,7 +2638,9 @@ impl AIG {
                 // Negative-edge cells (CLKN) trigger on the falling edge:
                 // start the trace with is_negedge=true so trace_clock_pin
                 // records the inverted clock signal.
-                if let Err(pinid) = aig.trace_clock_pin(netlistdb, pinid, is_clkn, true, cell_descriptor) {
+                if let Err(pinid) =
+                    aig.trace_clock_pin(netlistdb, pinid, is_clkn, true, cell_descriptor)
+                {
                     use netlistdb::GeneralHierName;
                     panic!(
                         "Tracing clock pin of cell {} error: \
@@ -2712,8 +2711,9 @@ impl AIG {
                         "S" => ap_s_iv = pin_iv,
                         "R" => ap_r_iv = pin_iv,
                         "CLK" => {
-                            ap_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap()
+                            ap_clken_iv = aig
+                                .trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor)
+                                .unwrap()
                         }
                         _ => {}
                     }
@@ -2764,8 +2764,9 @@ impl AIG {
                         "SET_B" => ap_s_iv = pin_iv, // Active-low: AND/OR formulas handle it directly
                         "RESET_B" => ap_r_iv = pin_iv, // Active-low: AND(d, RESET_B) → RESET_B=0 forces d=0
                         "CLK" => {
-                            ap_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap()
+                            ap_clken_iv = aig
+                                .trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor)
+                                .unwrap()
                         }
                         _ => {}
                     }
@@ -2864,13 +2865,15 @@ impl AIG {
                         // CLKN flips the start polarity so the inferred
                         // signal is the falling-edge tracker.
                         "CLK" => {
-                            ap_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap();
+                            ap_clken_iv = aig
+                                .trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor)
+                                .unwrap();
                             have_clk = true;
                         }
                         "CLKN" => {
-                            ap_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, true, false, cell_descriptor).unwrap();
+                            ap_clken_iv = aig
+                                .trace_clock_pin(netlistdb, pinid, true, false, cell_descriptor)
+                                .unwrap();
                             have_clk = true;
                         }
                         _ => {}
@@ -2957,15 +2960,17 @@ impl AIG {
                             sram.port_r_addr_iv[bit.unwrap()] = pin_iv;
                         }
                         "PORT_R_CLK" => {
-                            sram.port_r_en_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap();
+                            sram.port_r_en_iv = aig
+                                .trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor)
+                                .unwrap();
                         }
                         "PORT_W_ADDR" => {
                             sram.port_w_addr_iv[bit.unwrap()] = pin_iv;
                         }
                         "PORT_W_CLK" => {
-                            write_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap();
+                            write_clken_iv = aig
+                                .trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor)
+                                .unwrap();
                         }
                         "PORT_W_WR_DATA" => {
                             sram.port_w_wr_data_iv[bit.unwrap()] = pin_iv;
@@ -2994,7 +2999,9 @@ impl AIG {
                     let pin_iv = aig.pin2aigpin_iv[pinid];
                     match netlistdb.pinnames[pinid].1.as_str() {
                         "CLKin" => {
-                            clken_iv = aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap();
+                            clken_iv = aig
+                                .trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor)
+                                .unwrap();
                         }
                         "EN" => {
                             // EN combined with clock for read enable
@@ -3231,7 +3238,9 @@ impl AIG {
                         "A" => ap_a_iv = pin_iv,
                         "CLK" => {
                             // Try to trace clock, but if it's tied to 1, use constant
-                            if let Ok(clken) = aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor) {
+                            if let Ok(clken) =
+                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor)
+                            {
                                 ap_clken_iv = clken;
                             }
                         }
@@ -3272,7 +3281,9 @@ impl AIG {
                         "EN" => dp_en_iv = pin_iv,
                         "CLK" => {
                             // Try to trace clock for edge detection
-                            if let Ok(clken) = aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor) {
+                            if let Ok(clken) =
+                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor)
+                            {
                                 dp_clken_iv = clken;
                             }
                         }

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -2462,7 +2462,21 @@ impl AIG {
         netlistdb: &NetlistDB,
         cell_library: Option<&crate::cell_library::RuntimeCellLibrary>,
     ) -> AIG {
-        Self::from_netlistdb_with_cells_and_descriptor(netlistdb, cell_library, None)
+        // ADR 0019 C3.3d: resolve the embedded cell-model-IR descriptor here
+        // (auto-select by declared cell-name prefix, else the AIGPDK default
+        // fallback) so every no-descriptor entry point — library callers and
+        // unit tests — still builds stdcells from the IR, now that the runtime
+        // vendored behavioural-model read is gone. `setup.rs` resolves + passes
+        // a descriptor explicitly (with `--cell-descriptor` / `--bundled-
+        // descriptor` precedence); this covers the plain-API paths with the
+        // same auto-select + default-fallback chain.
+        let auto = crate::bundled_descriptors::auto_select(
+            netlistdb.celltypes.iter().map(|s| s.as_str()),
+        )
+        .ok()
+        .flatten()
+        .or_else(crate::bundled_descriptors::default_fallback);
+        Self::from_netlistdb_with_cells_and_descriptor(netlistdb, cell_library, auto.as_ref())
     }
 
     /// As [`Self::from_netlistdb_with_cells`], but also accepts an optional
@@ -2475,58 +2489,20 @@ impl AIG {
         cell_library: Option<&crate::cell_library::RuntimeCellLibrary>,
         cell_descriptor: Option<&cell_model_ir::CellModelIr>,
     ) -> AIG {
-        let has_sky130 = (1..netlistdb.num_cells).any(|cid| {
-            PdkVariant::classify(netlistdb.celltypes[cid].as_str()) == Some(PdkVariant::Sky130)
-        });
-        let has_gf180mcu = (1..netlistdb.num_cells).any(|cid| {
-            PdkVariant::classify(netlistdb.celltypes[cid].as_str()) == Some(PdkVariant::Gf180Mcu)
-        });
-
-        if has_sky130 {
-            let pdk_path = pdk_vendor_root().join("sky130_fd_sc_hd/cells");
-            let mut cell_types: Vec<String> = Vec::new();
-            for cellid in 1..netlistdb.num_cells {
-                let celltype = netlistdb.celltypes[cellid].as_str();
-                if PdkVariant::classify(celltype) == Some(PdkVariant::Sky130) {
-                    let ct = PdkVariant::Sky130.extract_cell_type(celltype).to_string();
-                    if !cell_types.contains(&ct) {
-                        cell_types.push(ct);
-                    }
-                }
-            }
-            cell_types.sort();
-            let pdk_models = crate::sky130_pdk::load_pdk_models(&pdk_path, &cell_types);
-            Self::from_netlistdb_impl(
-                netlistdb,
-                Some(&pdk_models),
-                None,
-                cell_library,
-                cell_descriptor,
-            )
-        } else if has_gf180mcu {
-            let pdk_path = pdk_vendor_root().join("gf180mcu_fd_sc_mcu7t5v0");
-            let mut cell_types: Vec<String> = Vec::new();
-            for cellid in 1..netlistdb.num_cells {
-                let celltype = netlistdb.celltypes[cellid].as_str();
-                if PdkVariant::classify(celltype) == Some(PdkVariant::Gf180Mcu) {
-                    let ct = PdkVariant::Gf180Mcu.extract_cell_type(celltype).to_string();
-                    if !cell_types.contains(&ct) {
-                        cell_types.push(ct);
-                    }
-                }
-            }
-            cell_types.sort();
-            let gf180_pdk = crate::gf180mcu_pdk::load_pdk_models(&pdk_path, &cell_types);
-            Self::from_netlistdb_impl(
-                netlistdb,
-                None,
-                Some(&gf180_pdk),
-                cell_library,
-                cell_descriptor,
-            )
-        } else {
-            Self::from_netlistdb_impl(netlistdb, None, None, cell_library, cell_descriptor)
-        }
+        // ADR 0019 C3.3d: standard-cell combinational (C3.3c), sequential
+        // (C3.3d steps 1-2) and timing all come from the embedded cell-model-IR
+        // descriptor now, so the runtime vendored-PDK behavioural-model read
+        // (`sky130_pdk::load_pdk_models` / `gf180mcu_pdk::load_pdk_models`,
+        // which opened `vendor/sky130_fd_sc_hd` / `vendor/gf180mcu_fd_sc_mcu7t5v0`
+        // at simulation time) is gone — a released binary is self-contained for
+        // stdcells. The legacy `decompose_with_pdk` fallback in
+        // `sky130_postprocess` / `gf180mcu_postprocess` remains only for a
+        // `None`-descriptor run; the built-in PDKs always resolve a descriptor
+        // (auto-select or the AIGPDK default fallback), so it is never reached
+        // for them (proven by the gate — the goldens hold with no PDK models
+        // loaded). The `from_netlistdb_with_pdk` API keeps working for callers
+        // that pass explicit models.
+        Self::from_netlistdb_impl(netlistdb, None, None, cell_library, cell_descriptor)
     }
 
     /// Build an AIG from a netlistdb.

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -673,6 +673,29 @@ impl AIG {
         self.pin2aigpin_iv[pinid] = if inverted { q_read ^ 1 } else { q_read };
     }
 
+    /// Collect the netlist pin-ids of a descriptor-seq cell's async set/reset
+    /// control pins (ADR 0019 C3.3d) — the only inputs a flop's Q output cone
+    /// may depend on (the D / clock / enable inputs are wired in the post-DFS
+    /// loop and must NOT be output dependencies, else the topo walk cycles
+    /// through registered state). PDK-neutral replacement for the hardcoded
+    /// `RN`/`SETN` (GF180) and `SET_B`/`RESET_B` (SKY130) name matches.
+    fn ir_async_dep_pins(
+        netlistdb: &NetlistDB,
+        cellid: usize,
+        seq: &cell_model_ir::Sequential,
+    ) -> SmallVec<[usize; 6]> {
+        let mut deps = SmallVec::new();
+        for dep_pinid in netlistdb.cell2pin.iter_set(cellid) {
+            let pin_name = netlistdb.pinnames[dep_pinid].1.as_str();
+            let is_async = seq.async_set.as_ref().is_some_and(|c| c.pin == pin_name)
+                || seq.async_reset.as_ref().is_some_and(|c| c.pin == pin_name);
+            if is_async {
+                deps.push(dep_pinid);
+            }
+        }
+        deps
+    }
+
     /// given a clock pin, trace back to clock root and return its
     /// enable signal (with invert bit).
     ///
@@ -1171,8 +1194,13 @@ impl AIG {
                     // Handle standard-cell PDK cells (combinational + sequential).
                     match PdkVariant::classify(celltype) {
                         Some(PdkVariant::Sky130) => {
-                            let deps =
-                                self.get_sky130_dependencies(netlistdb, pinid, cellid, celltype);
+                            let deps = self.get_sky130_dependencies(
+                                netlistdb,
+                                pinid,
+                                cellid,
+                                celltype,
+                                cell_descriptor,
+                            );
                             self.sky130_preprocess(netlistdb, pinid, cellid, celltype);
                             work_stack.push(WorkItem::Process(pinid));
                             for dep in deps {
@@ -1181,8 +1209,13 @@ impl AIG {
                             continue;
                         }
                         Some(PdkVariant::Gf180Mcu) => {
-                            let deps =
-                                self.get_gf180mcu_dependencies(netlistdb, pinid, cellid, celltype);
+                            let deps = self.get_gf180mcu_dependencies(
+                                netlistdb,
+                                pinid,
+                                cellid,
+                                celltype,
+                                cell_descriptor,
+                            );
                             self.gf180mcu_preprocess(netlistdb, pinid, cellid, celltype);
                             work_stack.push(WorkItem::Process(pinid));
                             for dep in deps {
@@ -1461,6 +1494,7 @@ impl AIG {
         pinid: usize,
         cellid: usize,
         celltype: &str,
+        cell_descriptor: Option<&cell_model_ir::CellModelIr>,
     ) -> SmallVec<[usize; 6]> {
         let cell_type = extract_cell_type(celltype);
         let output_pin_name = netlistdb.pinnames[pinid].1.as_str();
@@ -1475,8 +1509,17 @@ impl AIG {
             return SmallVec::new();
         }
 
-        // Sequential cells: depend on SET_B/RESET_B pins
+        // Sequential cells: depend on the async set/reset pins. ADR 0019 C3.3d:
+        // descriptor-driven (the L3 async pin names) when the descriptor models
+        // the cell, retiring the hardcoded `SET_B`/`RESET_B` match; legacy match
+        // is the fallback for a `None`-descriptor run.
         if is_sequential_cell(cell_type) {
+            if let Some(seq) = cell_descriptor
+                .and_then(|d| d.cell(celltype))
+                .and_then(|c| c.sequential.as_ref())
+            {
+                return Self::ir_async_dep_pins(netlistdb, cellid, seq);
+            }
             let mut deps = SmallVec::new();
             for dep_pinid in netlistdb.cell2pin.iter_set(cellid) {
                 let pin_name = netlistdb.pinnames[dep_pinid].1.as_str();
@@ -1890,6 +1933,7 @@ impl AIG {
         _pinid: usize,
         cellid: usize,
         celltype: &str,
+        cell_descriptor: Option<&cell_model_ir::CellModelIr>,
     ) -> SmallVec<[usize; 6]> {
         let cell_type = crate::gf180mcu::extract_cell_type(celltype);
         if crate::gf180mcu_pdk::is_tie_cell(cell_type)
@@ -1897,12 +1941,22 @@ impl AIG {
         {
             return SmallVec::new();
         }
-        // Sequential cells: depend on RN / SETN (active-low reset / set).
-        // Other input pins (D, CLK, CLKN, SE, SI, TE, E) are wired up in
-        // the post-DFS DFF setup loop and must NOT be dependencies of
-        // the Q output's AIG pin, otherwise we'd build a topological
-        // cycle through registered state.
+        // Sequential cells: depend only on the async reset/set pins. The
+        // data/clock pins (D, CLK, CLKN, SE, SI, TE, E) are wired up in the
+        // post-DFS DFF setup loop and must NOT be dependencies of the Q output's
+        // AIG pin, otherwise we'd build a topological cycle through registered
+        // state. ADR 0019 C3.3d: descriptor-driven (the L3 async pin names)
+        // when the descriptor models the cell — retiring the hardcoded
+        // `RN`/`SETN` match; the name match is the `None`-descriptor fallback.
+        // Clock-gating cells (`icgtp`/`icgtn`) carry no L3, take the fallback,
+        // and have no `RN`/`SETN`, so their dep set is empty either way.
         if crate::gf180mcu_pdk::is_sequential_cell(cell_type) {
+            if let Some(seq) = cell_descriptor
+                .and_then(|d| d.cell(celltype))
+                .and_then(|c| c.sequential.as_ref())
+            {
+                return Self::ir_async_dep_pins(netlistdb, cellid, seq);
+            }
             let mut deps = SmallVec::new();
             for dep_pinid in netlistdb.cell2pin.iter_set(cellid) {
                 let pin_name = netlistdb.pinnames[dep_pinid].1.as_str();
@@ -2548,15 +2602,44 @@ impl AIG {
                     clock_start.elapsed()
                 );
             }
+            // ADR 0019 C3.3d: the descriptor's L3 clock pin (name + edge) for a
+            // descriptor-modelled flop. `None` for AIGPDK DFF/DFFSR, SRAMs,
+            // clock-gating cells (no L3), and latches (L3 but no edge clock) —
+            // those keep the pin-name match below. This retires the `"CLK"`/
+            // `"CLKN"` stdcell name-match for the vendored + IHP flops.
+            let ir_clock: Option<(&str, bool)> = cell_descriptor
+                .and_then(|d| d.cell(celltype))
+                .and_then(|c| c.sequential.as_ref())
+                .and_then(|s| s.clock.as_ref())
+                .map(|clk| {
+                    (
+                        clk.pin.as_str(),
+                        clk.edge == cell_model_ir::ClockEdge::Falling,
+                    )
+                });
             for pinid in netlistdb.cell2pin.iter_set(cellid) {
                 let pin_name = netlistdb.pinnames[pinid].1.as_str();
-                // AIGPDK/SKY130 sequentials use "CLK"; GF180MCU adds "CLKN"
-                // for negative-edge cells (`dffnq`, `dffnrnq`, `icgtn`, …);
-                // SRAMs use the PORT_*_CLK pair.
-                let is_clkn = pin_name == "CLKN";
-                if !matches!(pin_name, "CLK" | "CLKN" | "PORT_R_CLK" | "PORT_W_CLK") {
-                    continue;
-                }
+                // Negative-edge flops trigger on the falling edge: start the
+                // trace with is_negedge=true so trace_clock_pin records the
+                // inverted clock signal.
+                let is_clkn = match ir_clock {
+                    // Descriptor-driven flop: trace exactly its L3 clock pin at
+                    // the declared edge.
+                    Some((clk_pin, negedge)) => {
+                        if pin_name != clk_pin {
+                            continue;
+                        }
+                        negedge
+                    }
+                    // AIGPDK DFF/DFFSR use "CLK"; SRAMs use the preserved
+                    // PORT_*_CLK pair (ADR 0011); "CLKN" a negedge clock buffer.
+                    None => {
+                        if !matches!(pin_name, "CLK" | "CLKN" | "PORT_R_CLK" | "PORT_W_CLK") {
+                            continue;
+                        }
+                        pin_name == "CLKN"
+                    }
+                };
                 trace_count += 1;
                 if seq_count <= 5 {
                     clilog::info!("    Tracing clock pin {} for cell {}...", pinid, cellid);

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -28,26 +28,6 @@ use indexmap::{IndexMap, IndexSet};
 use netlistdb::{Direction, GeneralPinName, NetlistDB};
 use smallvec::SmallVec;
 
-/// Root directory under which the vendored PDK cell libraries live —
-/// `<root>/gf180mcu_fd_sc_mcu7t5v0` and `<root>/sky130_fd_sc_hd`.
-///
-/// Defaults to `vendor` (the in-repo submodule layout, resolved relative
-/// to the process CWD). Set `JACQUARD_VENDOR_DIR` to override it so a
-/// caller that runs jacquard from a different working directory can point
-/// at the vendored PDKs directly instead of symlinking `vendor/` into its
-/// CWD. Follows the existing `JACQUARD_*` runtime-knob convention.
-fn pdk_vendor_root() -> std::path::PathBuf {
-    pdk_vendor_root_from(std::env::var_os("JACQUARD_VENDOR_DIR"))
-}
-
-/// Pure core of [`pdk_vendor_root`], split out so the env-independent
-/// resolution logic is unit-testable without mutating process env.
-fn pdk_vendor_root_from(override_dir: Option<std::ffi::OsString>) -> std::path::PathBuf {
-    override_dir
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| std::path::PathBuf::from("vendor"))
-}
-
 /// Work item for iterative DFS traversal.
 /// Using two-phase approach: Visit pushes dependencies, Process computes outputs.
 #[derive(Clone, Copy)]
@@ -4130,30 +4110,6 @@ impl AIG {
         };
 
         (x_capable, stats)
-    }
-}
-
-#[cfg(test)]
-mod pdk_vendor_root_tests {
-    use super::*;
-    use std::path::PathBuf;
-
-    #[test]
-    fn defaults_to_vendor_when_unset() {
-        assert_eq!(pdk_vendor_root_from(None), PathBuf::from("vendor"));
-    }
-
-    #[test]
-    fn honours_override_dir() {
-        assert_eq!(
-            pdk_vendor_root_from(Some("/opt/pdks".into())),
-            PathBuf::from("/opt/pdks"),
-        );
-        // Relative overrides are taken verbatim (joined against CWD at use).
-        assert_eq!(
-            pdk_vendor_root_from(Some("some/submodule/vendor".into())),
-            PathBuf::from("some/submodule/vendor"),
-        );
     }
 }
 

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -502,6 +502,7 @@ impl AIG {
         netlistdb: &NetlistDB,
         cellid: usize,
         seq: &cell_model_ir::Sequential,
+        cell_descriptor: Option<&cell_model_ir::CellModelIr>,
     ) {
         // Resolve all input pins of the cell to (name -> iv) and (name -> pinid).
         let mut inputs: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
@@ -529,7 +530,7 @@ impl AIG {
                     )
                 });
                 let is_negedge = clk.edge == cell_model_ir::ClockEdge::Falling;
-                self.trace_clock_pin(netlistdb, pinid, is_negedge, false)
+                self.trace_clock_pin(netlistdb, pinid, is_negedge, false, cell_descriptor)
                     .unwrap()
             }
             None => 0,
@@ -696,6 +697,40 @@ impl AIG {
         deps
     }
 
+    /// Classify a clock-path cell as an identity buffer or inverter from the
+    /// cell-model-IR descriptor's L2 combinational logic (ADR 0019 C3.3d).
+    ///
+    /// A clock buffer / inverter is exactly a single-input combinational cell
+    /// with a single output driven directly by that input (no AND gates):
+    /// `Some(false)` for an identity buffer (output = input), `Some(true)` for
+    /// an inverter (output = ¬input). Any cell the descriptor doesn't model as
+    /// such (multi-input, gated, sequential, tie, or absent) returns `None` —
+    /// the caller then falls back to the preserved IO-pad / CKLNQD paths or
+    /// rejects the cell as unsupported on the clock path.
+    ///
+    /// This replaces the per-PDK `PdkVariant` name matches (`inv`/`clkinv` →
+    /// inverter, `buf`/`clkbuf`/`dly*` → buffer): the descriptor's decomposed
+    /// AIG is the source of truth for each cell's identity, so GF180/SKY130/
+    /// AIGPDK clock cells all classify uniformly with no PDK dispatch.
+    fn descriptor_clock_buf(
+        celltype: &str,
+        cell_descriptor: Option<&cell_model_ir::CellModelIr>,
+    ) -> Option<bool> {
+        let logic = cell_descriptor?.cell(celltype)?.logic.as_ref()?;
+        // Single input, single output, no AND gates: a pure buffer / inverter.
+        if logic.inputs.len() != 1 || logic.outputs.len() != 1 || !logic.and_nodes.is_empty() {
+            return None;
+        }
+        let out = &logic.outputs[0].r;
+        // Node 0 is the const-0 node; node 1 is the sole input. A buffer /
+        // inverter drives its output straight off node 1.
+        if out.node == 1 {
+            Some(out.inverted)
+        } else {
+            None
+        }
+    }
+
     /// given a clock pin, trace back to clock root and return its
     /// enable signal (with invert bit).
     ///
@@ -712,6 +747,12 @@ impl AIG {
         // otherwise, we assert that cklnqd/en is already built in
         // our aig mapping (pin2aigpin_iv).
         ignore_cklnqd: bool,
+        // The auto-selected cell-model-IR descriptor (ADR 0019 C3.3d). Used to
+        // recognise clock-path buffers/inverters from their L2 combinational
+        // logic (single input, output = input or ¬input) instead of per-PDK
+        // `PdkVariant` name predicates. `None` = no descriptor (never happens
+        // for a built-in PDK, which always resolves one).
+        cell_descriptor: Option<&cell_model_ir::CellModelIr>,
     ) -> Result<usize, usize> {
         // Iterative implementation using explicit stack
         // Each entry: (pinid, is_negedge, is_processing_cklnqd, cklnqd_cp_result)
@@ -877,64 +918,43 @@ impl AIG {
             let mut pin_en = usize::MAX;
             let celltype = netlistdb.celltypes[cellid].as_str();
 
-            // Determine if this is a clock buffer/inverter (AIGPDK / SKY130 / GF180MCU).
-            // GF180MCU `inv` / `clkinv` are negative-polarity; `buf` / `clkbuf` are
-            // identity. GF180MCU clock-path cells use input pin name `I` rather
-            // than `A`; we accept both below.
-            let variant = PdkVariant::classify(celltype);
-            // (is_inv, is_buf, is_io_pad_buf, is_delay).
+            // Determine if this is a clock buffer/inverter. ADR 0019 C3.3d:
+            // recognise identity buffers / inverters from the cell-model-IR
+            // descriptor's L2 logic (single input, output = input or ¬input)
+            // instead of per-PDK `PdkVariant` name predicates. This covers
+            // AIGPDK `INV`/`BUF`, SKY130 `inv`/`clkinv`/`buf`/`clkbuf`/
+            // `clkdlybuf` and the delay cells (`dlygate*`/`dlymetal*`), and
+            // GF180MCU `inv`/`clkinv`/`buf`/`clkbuf`/`dlya..d` uniformly —
+            // each of those is a single-input identity/inverter in its
+            // descriptor. GF180MCU clock-path cells use input pin name `I`
+            // rather than `A`; we accept both below.
             //
-            // Delay cells (`dlya`/`dlyb`/`dlyc`/`dlyd` for GF180MCU;
-            // `dlygate*`/`dlymetal*` for SKY130) are functional identity
-            // buffers — single input, single output, no gating, no
-            // negation. The post-P&R OpenROAD hold-fixing pass routinely
-            // inserts them on clock fanout to repair tight hold paths.
-            // Treated like `is_buf` in the downstream propagation
-            // (current_pinid = pin_a, is_negedge unchanged). Kept
-            // separate from `is_buf` so timing-analysis paths can
-            // distinguish "identity buffer" from "identity buffer with
-            // a delay constant" if they need to. See #73.
+            // Delay cells are functional identity buffers (single input, no
+            // gating, no negation); the post-P&R OpenROAD hold-fixing pass
+            // routinely inserts them on clock fanout. They fold into `is_buf`
+            // here — the downstream propagation is identical (current_pinid =
+            // pin_a, is_negedge unchanged). See #73.
             //
-            // GF180MCU `hold` is **not** included — it's OpenROAD's
-            // data-path hold-fix cell, not expected on a clock fanout.
-            // If one does appear, that's likely a netlist bug worth
-            // surfacing rather than silently traversing.
-            let (is_inv, is_buf, is_io_pad_buf, is_delay) = match variant {
-                Some(PdkVariant::Sky130) => {
-                    let ct = PdkVariant::Sky130.extract_cell_type(celltype);
-                    let is_inv = ct.starts_with("inv") || ct.starts_with("clkinv");
-                    let is_buf = ct.starts_with("buf")
-                        || ct.starts_with("clkbuf")
-                        || ct.starts_with("clkdlybuf")
-                        || ct.starts_with("lpflow_isobufsrc")
-                        || ct.starts_with("lpflow_inputiso");
-                    let is_delay = ct.starts_with("dlygate") || ct.starts_with("dlymetal");
-                    (is_inv, is_buf, false, is_delay)
-                }
-                Some(PdkVariant::Gf180Mcu) => {
-                    let ct = PdkVariant::Gf180Mcu.extract_cell_type(celltype);
-                    let is_inv = matches!(ct, "inv" | "clkinv");
-                    let is_buf = matches!(ct, "buf" | "clkbuf");
-                    // GF180MCU input + bidir pads on the clock path buffer
-                    // PAD → Y, so they're traceable just like a clkbuf.
-                    // `bi_24t` is included because the digital-sim
-                    // simplification (`Y = PAD`, see is_io_pad_cell in
-                    // gf180mcu_pdk.rs) makes its AIG shape identical to
-                    // in_c / in_s. Common case: JTAG TCK routed through a
-                    // bidirectional signal pad in templates that don't
-                    // dedicate input-only pads to the clock (e.g. the
-                    // wafer.space gf180mcu-project-template default). See
-                    // #75.
-                    let is_io_pad_buf = matches!(ct, "in_c" | "in_s" | "bi_24t");
-                    let is_delay = matches!(ct, "dlya" | "dlyb" | "dlyc" | "dlyd");
-                    (is_inv, is_buf, is_io_pad_buf, is_delay)
-                }
-                None => (celltype == "INV", celltype == "BUF", false, false),
+            // GF180MCU IO pads (`in_c`/`in_s`/`bi_24t`) are compiled IP macros
+            // *not* in the stdcell descriptor; they buffer PAD → Y, so they're
+            // traceable just like a clkbuf. `bi_24t` is included because the
+            // digital-sim simplification (`Y = PAD`) makes its AIG shape
+            // identical to in_c / in_s (common case: JTAG TCK routed through a
+            // bidirectional signal pad). This preserved pad path stays name-
+            // based via the gf180mcu module helpers (not `PdkVariant`). See #75.
+            let is_io_pad_buf = crate::gf180mcu::is_gf180mcu_cell(celltype)
+                && crate::gf180mcu_pdk::is_io_pad_cell(crate::gf180mcu::extract_cell_type(celltype));
+            let (is_inv, is_buf) = match Self::descriptor_clock_buf(celltype, cell_descriptor) {
+                Some(true) => (true, false),
+                Some(false) => (false, true),
+                None => (false, false),
             };
 
-            if !is_inv && !is_buf && !is_io_pad_buf && !is_delay && celltype != "CKLNQD" {
+            if !is_inv && !is_buf && !is_io_pad_buf && celltype != "CKLNQD" {
                 clilog::error!(
-                    "cell type {} not supported on clock path. expecting only INV, BUF, CKLNQD, or a delay cell (or SKY130 / GF180MCU equivalents)",
+                    "cell type {} not supported on clock path. expecting only an \
+                     identity buffer / inverter (from the cell descriptor), a \
+                     GF180MCU IO pad, or CKLNQD",
                     celltype
                 );
                 return Err(pinid);
@@ -948,8 +968,8 @@ impl AIG {
             // cone. Without this guard, both PAD and A match the
             // "A | I | PAD" arm below and whichever is enumerated
             // last wins — wrong if A wins. See #75.
-            let is_gf180mcu_bi_24t = matches!(variant, Some(PdkVariant::Gf180Mcu))
-                && PdkVariant::Gf180Mcu.extract_cell_type(celltype) == "bi_24t";
+            let is_gf180mcu_bi_24t = crate::gf180mcu::is_gf180mcu_cell(celltype)
+                && crate::gf180mcu::extract_cell_type(celltype) == "bi_24t";
 
             for ipin in netlistdb.cell2pin.iter_set(cellid) {
                 if netlistdb.pindirect[ipin] == Direction::I {
@@ -961,7 +981,7 @@ impl AIG {
                     // source. Skipping here keeps the "multi-input ⇒ clock
                     // gating" rule honest by ignoring them, the same way
                     // the IO-pad control pins below are ignored. See #70.
-                    if matches!(variant, Some(PdkVariant::Gf180Mcu))
+                    if crate::gf180mcu::is_gf180mcu_cell(celltype)
                         && crate::gf180mcu_pdk::is_power_pin(ipin_name)
                     {
                         continue;
@@ -996,12 +1016,14 @@ impl AIG {
                 assert_ne!(pin_a, usize::MAX);
                 current_pinid = pin_a;
                 current_is_negedge = !is_negedge;
-            } else if is_buf || is_io_pad_buf || is_delay {
+            } else if is_buf || is_io_pad_buf {
                 assert_ne!(pin_a, usize::MAX);
                 current_pinid = pin_a;
                 // is_negedge stays the same. Delay cells (`dlya/b/c/d`,
-                // `dlygate*`, `dlymetal*`) propagate the clock through
-                // their delay constant just like a plain buffer — see #73.
+                // `dlygate*`, `dlymetal*`) are single-input identity buffers
+                // in the descriptor, so they fold into `is_buf` and propagate
+                // the clock through their delay constant just like a plain
+                // buffer — see #73.
             } else if celltype == "CKLNQD" {
                 assert_ne!(pin_cp, usize::MAX);
                 assert_ne!(pin_en, usize::MAX);
@@ -2623,7 +2645,7 @@ impl AIG {
                 // Negative-edge cells (CLKN) trigger on the falling edge:
                 // start the trace with is_negedge=true so trace_clock_pin
                 // records the inverted clock signal.
-                if let Err(pinid) = aig.trace_clock_pin(netlistdb, pinid, is_clkn, true) {
+                if let Err(pinid) = aig.trace_clock_pin(netlistdb, pinid, is_clkn, true, cell_descriptor) {
                     use netlistdb::GeneralHierName;
                     panic!(
                         "Tracing clock pin of cell {} error: \
@@ -2695,7 +2717,7 @@ impl AIG {
                         "R" => ap_r_iv = pin_iv,
                         "CLK" => {
                             ap_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false).unwrap()
+                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap()
                         }
                         _ => {}
                     }
@@ -2724,7 +2746,7 @@ impl AIG {
                     .and_then(|c| c.sequential.as_ref())
                     .filter(|seq| Self::ir_seq_input_wireable(netlistdb, cellid, seq))
                 {
-                    aig.wire_sequential_from_ir(netlistdb, cellid, seq);
+                    aig.wire_sequential_from_ir(netlistdb, cellid, seq, cell_descriptor);
                     let dff = aig.dffs.entry(cellid).or_default();
                     assert_ne!(dff.q, 0, "SKY130 DFF {cellid} (IR-driven) has no Q output");
                     continue;
@@ -2747,7 +2769,7 @@ impl AIG {
                         "RESET_B" => ap_r_iv = pin_iv, // Active-low: AND(d, RESET_B) → RESET_B=0 forces d=0
                         "CLK" => {
                             ap_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false).unwrap()
+                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap()
                         }
                         _ => {}
                     }
@@ -2809,7 +2831,7 @@ impl AIG {
                     .and_then(|d| d.cell(celltype))
                     .and_then(|c| c.sequential.as_ref())
                 {
-                    aig.wire_sequential_from_ir(netlistdb, cellid, seq);
+                    aig.wire_sequential_from_ir(netlistdb, cellid, seq, cell_descriptor);
                     let dff = aig.dffs.entry(cellid).or_default();
                     assert_ne!(
                         dff.q, 0,
@@ -2846,12 +2868,12 @@ impl AIG {
                         // signal is the falling-edge tracker.
                         "CLK" => {
                             ap_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false).unwrap();
+                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap();
                             have_clk = true;
                         }
                         "CLKN" => {
                             ap_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, true, false).unwrap();
+                                aig.trace_clock_pin(netlistdb, pinid, true, false, cell_descriptor).unwrap();
                             have_clk = true;
                         }
                         _ => {}
@@ -2922,7 +2944,7 @@ impl AIG {
                 // their dedicated branches above; only non-vendored descriptor
                 // flops reach here. AIGPDK `DFF`/`DFFSR` are handled by the
                 // literal-match branch at the top of this loop, not here.
-                aig.wire_sequential_from_ir(netlistdb, cellid, seq);
+                aig.wire_sequential_from_ir(netlistdb, cellid, seq, cell_descriptor);
                 let dff = aig.dffs.entry(cellid).or_default();
                 assert_ne!(dff.q, 0, "IR-driven DFF {cellid} has no Q output built");
             } else if celltype == "$__RAMGEM_SYNC_" {
@@ -2937,14 +2959,14 @@ impl AIG {
                         }
                         "PORT_R_CLK" => {
                             sram.port_r_en_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false).unwrap();
+                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap();
                         }
                         "PORT_W_ADDR" => {
                             sram.port_w_addr_iv[bit.unwrap()] = pin_iv;
                         }
                         "PORT_W_CLK" => {
                             write_clken_iv =
-                                aig.trace_clock_pin(netlistdb, pinid, false, false).unwrap();
+                                aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap();
                         }
                         "PORT_W_WR_DATA" => {
                             sram.port_w_wr_data_iv[bit.unwrap()] = pin_iv;
@@ -2973,7 +2995,7 @@ impl AIG {
                     let pin_iv = aig.pin2aigpin_iv[pinid];
                     match netlistdb.pinnames[pinid].1.as_str() {
                         "CLKin" => {
-                            clken_iv = aig.trace_clock_pin(netlistdb, pinid, false, false).unwrap();
+                            clken_iv = aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor).unwrap();
                         }
                         "EN" => {
                             // EN combined with clock for read enable
@@ -3064,7 +3086,7 @@ impl AIG {
                         let is_negedge =
                             ram_ports.clock.edge == crate::cell_library::ClockEdge::Neg;
                         clken_iv = aig
-                            .trace_clock_pin(netlistdb, pinid, is_negedge, false)
+                            .trace_clock_pin(netlistdb, pinid, is_negedge, false, cell_descriptor)
                             .unwrap();
                     } else if let Some(ce) = &ram_ports.chip_enable {
                         if pin_name == ce.pin {
@@ -3210,7 +3232,7 @@ impl AIG {
                         "A" => ap_a_iv = pin_iv,
                         "CLK" => {
                             // Try to trace clock, but if it's tied to 1, use constant
-                            if let Ok(clken) = aig.trace_clock_pin(netlistdb, pinid, false, false) {
+                            if let Ok(clken) = aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor) {
                                 ap_clken_iv = clken;
                             }
                         }
@@ -3251,7 +3273,7 @@ impl AIG {
                         "EN" => dp_en_iv = pin_iv,
                         "CLK" => {
                             // Try to trace clock for edge detection
-                            if let Ok(clken) = aig.trace_clock_pin(netlistdb, pinid, false, false) {
+                            if let Ok(clken) = aig.trace_clock_pin(netlistdb, pinid, false, false, cell_descriptor) {
                                 dp_clken_iv = clken;
                             }
                         }

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -577,6 +577,102 @@ impl AIG {
         dff.d_iv = d_in;
     }
 
+    /// Whether a cell's L3 [`Sequential`](cell_model_ir::Sequential) block can
+    /// be wired *input-side* by [`Self::wire_sequential_from_ir`] for this
+    /// instance (ADR 0019 C3.3d). True iff every `next_state` combinational
+    /// input, plus the clock / enable / async control pins, resolves to a real
+    /// `Direction::I` pin of the cell.
+    ///
+    /// This guards the C3.1b "ff internal state var" case: a cell like SKY130
+    /// `edfxtp` folds its data-enable into `next_state` with a self-feedback
+    /// reference to the flop's own state node (`IQ`), which is **not** a cell
+    /// pin. `splice_comb_logic` would panic resolving it, so such cells stay on
+    /// the legacy input-side path (which models the enable as a clock gate).
+    /// GF180 and the plain SKY130 flops (`dfxtp`/`dfrtp`/`dfstp`) fold nothing
+    /// exotic, so this is always true for them — behaviour-identical.
+    fn ir_seq_input_wireable(
+        netlistdb: &NetlistDB,
+        cellid: usize,
+        seq: &cell_model_ir::Sequential,
+    ) -> bool {
+        let mut input_pins: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for pinid in netlistdb.cell2pin.iter_set(cellid) {
+            if netlistdb.pindirect[pinid] == Direction::I {
+                input_pins.insert(netlistdb.pinnames[pinid].1.as_str());
+            }
+        }
+        if !seq
+            .next_state
+            .inputs
+            .iter()
+            .all(|p| input_pins.contains(p.as_str()))
+        {
+            return false;
+        }
+        if let Some(clk) = &seq.clock {
+            if !input_pins.contains(clk.pin.as_str()) {
+                return false;
+            }
+        }
+        for ctrl in [seq.enable.as_ref().map(|e| &e.pin)]
+            .into_iter()
+            .flatten()
+            .chain(seq.async_set.as_ref().map(|c| &c.pin))
+            .chain(seq.async_reset.as_ref().map(|c| &c.pin))
+        {
+            if !input_pins.contains(ctrl.as_str()) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Apply a cell-model-IR sequential cell's *async output overlay* to the
+    /// pre-created Q aigpin, writing the resolved read value into
+    /// `pin2aigpin_iv[pinid]` for the requested output pin (ADR 0019 C3.3d).
+    ///
+    /// Output-side companion to [`Self::wire_sequential_from_ir`]: the Q *read*
+    /// reflects async set/reset immediately (asynchronous). This is the exact
+    /// PDK-neutral extraction of the GF180 overlay that previously lived inline
+    /// in `gf180mcu_postprocess`, now shared by GF180 / SKY130 / any
+    /// descriptor-driven PDK (IHP). The formula is reset-dominant
+    /// `Q_read = AND(OR(q, NOT set_n), reset_n)`, identical to the legacy
+    /// SKY130 `SET_B`/`RESET_B` and GF180 `SETN`/`RN` output overlays — so
+    /// switching those PDKs to this path is byte-identical. A `QN`-style output
+    /// reads the inverted post-overlay state.
+    fn apply_ir_seq_output(
+        &mut self,
+        netlistdb: &NetlistDB,
+        pinid: usize,
+        cellid: usize,
+        seq: &cell_model_ir::Sequential,
+    ) {
+        let q = self.dffs.get(&cellid).unwrap().q;
+        let mut inputs: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for ipin in netlistdb.cell2pin.iter_set(cellid) {
+            if netlistdb.pindirect[ipin] == Direction::I {
+                inputs.insert(
+                    netlistdb.pinnames[ipin].1.to_string(),
+                    self.pin2aigpin_iv[ipin],
+                );
+            }
+        }
+        let reset_n = self.resolve_async_n(&inputs, seq.async_reset.as_ref());
+        let set_n = self.resolve_async_n(&inputs, seq.async_set.as_ref());
+        let mut q_read = q << 1;
+        q_read = self.add_and_gate(q_read ^ 1, set_n) ^ 1;
+        q_read = self.add_and_gate(q_read, reset_n);
+        let out_name = netlistdb.pinnames[pinid].1.as_str();
+        let inverted = seq
+            .outputs
+            .iter()
+            .find(|o| o.pin == out_name)
+            .map(|o| o.inverted)
+            .unwrap_or(false);
+        self.pin2aigpin_iv[pinid] = if inverted { q_read ^ 1 } else { q_read };
+    }
+
     /// given a clock pin, trace back to clock root and return its
     /// enable signal (with invert bit).
     ///
@@ -1126,6 +1222,40 @@ impl AIG {
                         }
                     }
 
+                    // Descriptor-driven *sequential* cell outside the vendored
+                    // PDKs (e.g. IHP SG13G2 `ff` cells, ADR 0019 C3.3d). Pre-
+                    // create the stateful Q aigpin (mirroring `gf180mcu_preprocess`
+                    // / `sky130_preprocess`) and depend only on the async set/reset
+                    // pins — the D / clock / enable inputs are wired in the post-DFS
+                    // DFF setup loop and must NOT be dependencies of the Q output or
+                    // we'd build a topological cycle through registered state.
+                    if let Some(seq) = cell_descriptor
+                        .and_then(|d| d.cell(celltype))
+                        .and_then(|c| c.sequential.as_ref())
+                    {
+                        let q = self.add_aigpin(DriverType::DFF(cellid));
+                        let out_name = seq
+                            .outputs
+                            .first()
+                            .map(|o| o.pin.clone())
+                            .unwrap_or_else(|| "Q".to_string());
+                        self.aigpin_cell_origins[q].push((cellid, celltype.to_string(), out_name));
+                        self.dffs.entry(cellid).or_default().q = q;
+                        work_stack.push(WorkItem::Process(pinid));
+                        for dep_pinid in netlistdb.cell2pin.iter_set(cellid) {
+                            let pn = netlistdb.pinnames[dep_pinid].1.as_str();
+                            let is_async = seq
+                                .async_set
+                                .as_ref()
+                                .is_some_and(|c| c.pin == pn)
+                                || seq.async_reset.as_ref().is_some_and(|c| c.pin == pn);
+                            if is_async {
+                                work_stack.push(WorkItem::Visit(dep_pinid));
+                            }
+                        }
+                        continue;
+                    }
+
                     // Combinational cell outside the vendored PDKs: the internal
                     // AIGPDK cells (AND2 / INV / BUF) *and* any stdcell an
                     // auto-selected cell-model-IR descriptor models — e.g. IHP
@@ -1211,7 +1341,7 @@ impl AIG {
                             // model with `logic` (sequential / tie / SRAM /
                             // multi-output — handled by the postprocess).
                             let base = extract_cell_type(celltype);
-                            if !self.try_descriptor_comb(
+                            if self.try_descriptor_comb(
                                 netlistdb,
                                 pinid,
                                 cellid,
@@ -1219,6 +1349,17 @@ impl AIG {
                                 base,
                                 cell_descriptor,
                             ) {
+                                // combinational splice done
+                            } else if let Some(seq) = cell_descriptor
+                                .and_then(|d| d.cell(celltype))
+                                .and_then(|c| c.sequential.as_ref())
+                            {
+                                // ADR 0019 C3.3d: descriptor-driven async *output*
+                                // overlay for SKY130 flops — byte-identical to the
+                                // legacy `SET_B`/`RESET_B` read below, now shared
+                                // with GF180 / IHP via `apply_ir_seq_output`.
+                                self.apply_ir_seq_output(netlistdb, pinid, cellid, seq);
+                            } else {
                                 self.sky130_postprocess(
                                     netlistdb, pinid, cellid, celltype, pdk_models,
                                 );
@@ -1239,6 +1380,20 @@ impl AIG {
                             continue;
                         }
                         None => {}
+                    }
+
+                    // ADR 0019 C3.3d: descriptor-driven sequential *output* overlay
+                    // for a stdcell outside the vendored PDKs (e.g. IHP SG13G2 `ff`
+                    // cells). The Q aigpin was pre-created in the Visit phase; here
+                    // we layer the async set/reset read. Combinational descriptor
+                    // cells (no `sequential`) fall through to `try_descriptor_comb`.
+                    if let Some(seq) = cell_descriptor
+                        .and_then(|d| d.cell(celltype))
+                        .and_then(|c| c.sequential.as_ref())
+                    {
+                        self.apply_ir_seq_output(netlistdb, pinid, cellid, seq);
+                        topo_instack[pinid] = false;
+                        continue;
                     }
 
                     // ADR 0019 C3.3c: descriptor-driven combinational splice for
@@ -1880,33 +2035,7 @@ impl AIG {
                 .and_then(|d| d.cell(celltype))
                 .and_then(|c| c.sequential.as_ref())
             {
-                let mut inputs: std::collections::HashMap<String, usize> =
-                    std::collections::HashMap::new();
-                for ipin in netlistdb.cell2pin.iter_set(cellid) {
-                    if netlistdb.pindirect[ipin] == Direction::I {
-                        inputs.insert(
-                            netlistdb.pinnames[ipin].1.to_string(),
-                            self.pin2aigpin_iv[ipin],
-                        );
-                    }
-                }
-                let reset_n = self.resolve_async_n(&inputs, seq.async_reset.as_ref());
-                let set_n = self.resolve_async_n(&inputs, seq.async_set.as_ref());
-                let mut q_read = q << 1;
-                q_read = self.add_and_gate(q_read ^ 1, set_n) ^ 1;
-                q_read = self.add_and_gate(q_read, reset_n);
-                // `QN` outputs read the inverted (post-overlay) state — async
-                // reset → Q=0 ⇒ QN=1, set → Q=1 ⇒ QN=0. GF180 dff/latch cells
-                // only expose `Q`, so this is inert for the gated suite but
-                // keeps the role honest for QN-bearing libraries.
-                let out_name = netlistdb.pinnames[pinid].1.as_str();
-                let inverted = seq
-                    .outputs
-                    .iter()
-                    .find(|o| o.pin == out_name)
-                    .map(|o| o.inverted)
-                    .unwrap_or(false);
-                self.pin2aigpin_iv[pinid] = if inverted { q_read ^ 1 } else { q_read };
+                self.apply_ir_seq_output(netlistdb, pinid, cellid, seq);
                 return;
             }
 
@@ -2389,8 +2518,16 @@ impl AIG {
                 Some(variant) => variant.is_sequential(variant.extract_cell_type(celltype)),
                 None => false,
             };
+            // ADR 0019 C3.3d: descriptor-driven sequential classification for
+            // stdcells outside the vendored PDKs (e.g. IHP SG13G2 `ff` cells),
+            // so their clock pins are traced here like any other flop. Additive:
+            // GF180/SKY130/AIGPDK flops already match `is_pdk_seq`/`is_aigpdk_seq`,
+            // so this changes nothing for them.
+            let is_ir_seq = cell_descriptor
+                .and_then(|d| d.cell(celltype))
+                .is_some_and(|c| c.sequential.is_some());
 
-            if !is_aigpdk_seq && !is_pdk_seq {
+            if !is_aigpdk_seq && !is_pdk_seq && !is_ir_seq {
                 continue;
             }
 
@@ -2517,6 +2654,23 @@ impl AIG {
             } else if PdkVariant::classify(celltype) == Some(PdkVariant::Sky130)
                 && PdkVariant::Sky130.is_sequential(PdkVariant::Sky130.extract_cell_type(celltype))
             {
+                // ADR 0019 C3.3d: IR-driven sequential input wiring (D / clock-
+                // enable / async), the SKY130 twin of the GF180 branch below.
+                // Byte-identical to the legacy `dfxtp`/`dfrtp`/`dfstp` handling.
+                // `edfxtp` folds its data-enable into `next_state` via the ff
+                // state var `IQ` (not a cell pin), so `ir_seq_input_wireable`
+                // returns false for it and it stays on the legacy clock-gate path.
+                if let Some(seq) = cell_descriptor
+                    .and_then(|d| d.cell(celltype))
+                    .and_then(|c| c.sequential.as_ref())
+                    .filter(|seq| Self::ir_seq_input_wireable(netlistdb, cellid, seq))
+                {
+                    aig.wire_sequential_from_ir(netlistdb, cellid, seq);
+                    let dff = aig.dffs.entry(cellid).or_default();
+                    assert_ne!(dff.q, 0, "SKY130 DFF {cellid} (IR-driven) has no Q output");
+                    continue;
+                }
+
                 // Handle SKY130 DFFs (dfxtp, edfxtp, dfrtp, etc.)
                 let cell_type = PdkVariant::Sky130.extract_cell_type(celltype);
                 let mut ap_d_iv = 0;
@@ -2697,6 +2851,21 @@ impl AIG {
                 dff.en_iv = ap_clken_iv;
                 dff.d_iv = d_in;
                 assert_ne!(dff.q, 0, "GF180MCU DFF {cellid} has no Q output built");
+            } else if let Some(seq) = cell_descriptor
+                .and_then(|d| d.cell(celltype))
+                .and_then(|c| c.sequential.as_ref())
+                .filter(|_| PdkVariant::classify(celltype).is_none())
+                .filter(|seq| Self::ir_seq_input_wireable(netlistdb, cellid, seq))
+            {
+                // ADR 0019 C3.3d: IR-driven sequential input wiring for a stdcell
+                // outside the vendored PDKs (e.g. IHP SG13G2 `ff` cells). The
+                // `PdkVariant::classify().is_none()` filter keeps GF180/SKY130 on
+                // their dedicated branches above; only non-vendored descriptor
+                // flops reach here. AIGPDK `DFF`/`DFFSR` are handled by the
+                // literal-match branch at the top of this loop, not here.
+                aig.wire_sequential_from_ir(netlistdb, cellid, seq);
+                let dff = aig.dffs.entry(cellid).or_default();
+                assert_ne!(dff.q, 0, "IR-driven DFF {cellid} has no Q output built");
             } else if celltype == "$__RAMGEM_SYNC_" {
                 let mut sram = aig.srams.entry(cellid).or_default().clone();
                 let mut write_clken_iv = 0;

--- a/src/bundled_descriptors.rs
+++ b/src/bundled_descriptors.rs
@@ -149,8 +149,8 @@ pub fn resolve(explicit: Option<&Path>, bundled: Option<&str>) -> Option<CellMod
 /// This is the automatic tier of the C3.2 precedence chain, sitting *below*
 /// the explicit `--cell-descriptor <file>` and `--bundled-descriptor <name>`
 /// selectors handled by [`resolve`] and *above* the legacy per-PDK Rust path.
-/// It replaces `pdk::PdkVariant`'s hardcoded prefix detection for the descriptor
-/// choice: instead of collapsing every GF180 cell to one variant (the #130 bug,
+/// It replaces the former per-PDK enum's hardcoded prefix detection for the
+/// descriptor choice: instead of collapsing every GF180 cell to one variant (the #130 bug,
 /// where a 9t netlist was served by 7t models), it keys on the full vendor
 /// prefix — which carries the track designation (`…mcu7t5v0__` vs `…mcu9t5v0__`)
 /// — so a 9t netlist auto-selects the 9t descriptor.

--- a/src/gf180mcu.rs
+++ b/src/gf180mcu.rs
@@ -501,17 +501,19 @@ mod tests {
 
     #[test]
     fn aig_builds_from_combinational_gf180mcu_netlist() {
-        // End-to-end: gf180mcu Verilog → NetlistDB → AIG. Exercises
-        // the full Phase 4 path: GF180MCULeafPins, library detection,
-        // load_pdk_models, decompose_combinational, AIG integration.
+        // End-to-end: gf180mcu Verilog → NetlistDB → AIG. Exercises the
+        // full path: GF180MCULeafPins, library detection, cell-model-IR
+        // descriptor auto-select + combinational splice, AIG integration.
+        // Single-track (9t) — a mix of 7t+9t cell types in one module has no
+        // single descriptor and is rejected as ambiguous (ADR 0019 C3.2).
         const VERILOG: &str = r#"
 module tiny(A, B, C, Y, Z);
   input A, B, C;
   output Y, Z;
   wire mid;
-  gf180mcu_fd_sc_mcu7t5v0__nand2_1 u1 (.A1(A), .A2(B), .ZN(mid));
+  gf180mcu_fd_sc_mcu9t5v0__nand2_1 u1 (.A1(A), .A2(B), .ZN(mid));
   gf180mcu_fd_sc_mcu9t5v0__inv_1   u2 (.I(mid), .ZN(Y));
-  gf180mcu_fd_sc_mcu7t5v0__or3_1   u3 (.A1(A), .A2(B), .A3(C), .Z(Z));
+  gf180mcu_fd_sc_mcu9t5v0__or3_1   u3 (.A1(A), .A2(B), .A3(C), .Z(Z));
 endmodule
 "#;
         let nl =
@@ -546,7 +548,7 @@ module tiny(CLK_PAD, D, Q);
   gf180mcu_fd_sc_mcu9t5v0__clkbuf_8 CLKBUF_1 (
       .I(CLK_PAD), .Z(CLK_INTERNAL), .VDD(VDD), .VSS(VSS), .VNW(VDD), .VPW(VSS)
   );
-  gf180mcu_fd_sc_mcu7t5v0__dffq_1 DFF_1 (
+  gf180mcu_fd_sc_mcu9t5v0__dffq_1 DFF_1 (
       .CLK(CLK_INTERNAL), .D(D), .Q(Q), .notifier(notifier)
   );
 endmodule
@@ -587,7 +589,7 @@ module tiny(CLK_PAD, D, Q);
   gf180mcu_fd_sc_mcu9t5v0__dlyd_1 DLY_1 (
       .I(CLK_BUF), .Z(CLK_DLY), .VDD(VDD), .VSS(VSS), .VNW(VDD), .VPW(VSS)
   );
-  gf180mcu_fd_sc_mcu7t5v0__dffq_1 DFF_1 (
+  gf180mcu_fd_sc_mcu9t5v0__dffq_1 DFF_1 (
       .CLK(CLK_DLY), .D(D), .Q(Q), .notifier(notifier)
   );
 endmodule

--- a/src/gf180mcu.rs
+++ b/src/gf180mcu.rs
@@ -80,8 +80,8 @@ pub fn is_gf180mcu_cell(name: &str) -> bool {
 /// they are modelled as RAM blocks via the runtime `--cell-library`. They
 /// satisfy [`is_gf180mcu_cell`] (so the netlist parser accepts them and the
 /// library is detected as GF180MCU) but are excluded from the standard-cell
-/// decompose dispatch in [`crate::pdk::PdkVariant::classify`] so they reach
-/// the cell-library RAM path instead of the std-cell functional.v lookup.
+/// decompose dispatch (`AIG::is_gf180mcu_stdcell` returns `false` for them)
+/// so they reach the cell-library RAM path instead of the std-cell lookup.
 pub fn is_sram_macro(name: &str) -> bool {
     name.starts_with(IP_SRAM_PREFIX)
 }

--- a/src/gf180mcu_pdk.rs
+++ b/src/gf180mcu_pdk.rs
@@ -1288,16 +1288,41 @@ mod tests {
         let pins = &[("E", "e"), ("D", "d"), ("Q", "q"), ("notifier", "notif")];
         let (aig, nl, port) = build_one_cell_aig("latq", pins);
         let dff_cellid = find_cell_id(&nl, "latq");
+        let q_pinid = port["q"];
 
-        // E=1, D=1 → next state = D = 1.
-        let inputs = HashMap::from([(port["d"], true), (port["e"], true)]);
-        let next = step_dff(&aig, dff_cellid, &inputs, false);
-        assert!(next, "latq E=1 must pass D=1 through");
+        // ADR 0019 C3.3d: the cell-model-IR `latq` stores the *inverted* data
+        // internally (`next_state = !D`, `seq.outputs Q inverted = true`) and
+        // inverts it back at the Q output, so the observable Q is D — but the
+        // raw internal DFF state (`step_dff`) is `!D`. Assert on the observable
+        // Q output pin, not the internal state, so the check is
+        // representation-agnostic (this is the descriptor-driven path the
+        // production build has used since C2.3; only the plain-API unit path
+        // moved onto it in C3.3d step 3).
+        let observe_q = |inputs: &HashMap<usize, bool>, prev: bool| -> bool {
+            let new_state = step_dff(&aig, dff_cellid, inputs, prev);
+            let mut clock_flags = HashMap::new();
+            for (clk_pin, &(pos_id, neg_id)) in aig.clock_pin2aigpins.iter() {
+                if pos_id != usize::MAX {
+                    clock_flags.insert((*clk_pin, 0u8), true);
+                }
+                if neg_id != usize::MAX {
+                    clock_flags.insert((*clk_pin, 1u8), true);
+                }
+            }
+            let dff_state = HashMap::from([(dff_cellid, new_state)]);
+            let vals = eval_aig_combinational(&aig, inputs, &clock_flags, &dff_state);
+            read_iv(aig.pin2aigpin_iv[q_pinid], &vals)
+        };
 
-        // E=0 → holds previous state regardless of D.
-        let inputs_hold = HashMap::from([(port["d"], false), (port["e"], false)]);
-        let held = step_dff(&aig, dff_cellid, &inputs_hold, true);
-        assert!(held, "latq E=0 must hold previous state");
+        // E=1 → transparent: observable Q follows D.
+        let d1 = HashMap::from([(port["d"], true), (port["e"], true)]);
+        assert!(observe_q(&d1, false), "latq E=1 must pass D=1 through to Q");
+        let d0 = HashMap::from([(port["d"], false), (port["e"], true)]);
+        assert!(!observe_q(&d0, true), "latq E=1 must pass D=0 through to Q");
+
+        // E=0 → holds previous Q (prev internal state false ⇒ observable Q=1).
+        let hold = HashMap::from([(port["d"], false), (port["e"], false)]);
+        assert!(observe_q(&hold, false), "latq E=0 must hold previous Q");
         let _ = nl;
     }
 

--- a/src/pdk.rs
+++ b/src/pdk.rs
@@ -11,27 +11,16 @@
 //!   (`AIGPDK`, `SKY130`, `GF180MCU`, or `Mixed`).
 //! - [`detect_library`] / [`detect_library_from_file`] — dispatch
 //!   helpers that classify a netlist by the cell prefixes it contains.
-//! - [`PdkVariant`] — the dispatch enum used by `aig.rs` to collapse
-//!   `if is_sky130_cell { sky130_X } else if is_gf180mcu_cell { gf180mcu_X }`
-//!   shaped call sites into a single match.
 //!
 //! Per-PDK predicates (`is_sky130_cell`, `is_aigpdk_cell`,
-//! `is_gf180mcu_cell`) still live with their respective PDK modules;
-//! the detection routines here aggregate them into a single verdict.
-//!
-//! # Why enum dispatch (not `Box<dyn PdkHooks>`)?
-//!
-//! The AIG builder runs these classifiers and accessors on every cell
-//! in a netlist — hundreds of thousands per design, millions for large
-//! Gemmini/NVDLA dumps — and the closed set of PDKs is small (currently
-//! two). A `Box<dyn>` would add a vtable dereference per call and
-//! defeat inlining of the trivial predicates. An enum-with-match keeps
-//! the hot path branch-only and lets the compiler inline the `matches!`
-//! arms.
-//!
-//! Adding a third PDK is a one-arm-per-method expansion, which is
-//! fine for this scale. If the PDK count ever explodes (5+ libraries)
-//! it'd be worth revisiting; until then the simpler shape wins.
+//! `is_gf180mcu_cell`) live with their respective PDK modules; the
+//! detection routines here aggregate them into a single verdict, and the
+//! AIG builder (`aig.rs`) routes cells to their PDK-specific build path
+//! by calling those predicates directly (`AIG::is_sky130_stdcell` /
+//! `is_gf180mcu_stdcell`). The former per-PDK dispatch enum that collapsed
+//! those predicates + the per-cell classifiers into one dispatch surface
+//! was retired in ADR 0019 C3.3d once the cell-model-IR descriptor became
+//! the source of truth for cell behaviour.
 
 use crate::gf180mcu::is_gf180mcu_cell;
 use crate::sky130::{is_aigpdk_cell, is_sky130_cell};
@@ -143,126 +132,6 @@ pub fn detect_library_from_file(path: &std::path::Path) -> std::io::Result<CellL
     Ok(resolve_library(has_aigpdk, has_sky130, has_gf180mcu))
 }
 
-// ============================================================================
-// PdkVariant — dispatch enum for standard-cell PDK predicates / pin names.
-// ============================================================================
-
-/// Standard-cell PDK identification, used by `aig.rs` to dispatch
-/// per-cell preprocessing and post-processing without `if/else if`
-/// ladders on `is_sky130_cell` / `is_gf180mcu_cell`.
-///
-/// Variants cover only the standard-cell PDKs that own behavioural
-/// models loaded from vendored submodules. AIGPDK (the internal cell
-/// library) is handled inline in `aig.rs` because its cells are
-/// hard-coded and don't go through the `decompose_with_pdk` path.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PdkVariant {
-    /// google/skywater-pdk-libs-sky130_fd_sc_hd
-    Sky130,
-    /// gf180mcu_fd_sc_mcu7t5v0 + mcu9t5v0
-    Gf180Mcu,
-}
-
-impl PdkVariant {
-    /// Identify the PDK variant a vendor-prefixed cell type belongs to.
-    /// Returns `None` if the cell isn't a recognised standard-cell PDK
-    /// instance (i.e. it's AIGPDK, an SRAM macro, or unknown).
-    pub fn classify(celltype: &str) -> Option<PdkVariant> {
-        if is_sky130_cell(celltype) {
-            Some(PdkVariant::Sky130)
-        } else if crate::gf180mcu::is_sram_macro(celltype) {
-            // SRAM IP macros (`gf180mcu_fd_ip_sram__*`) are compiled hard
-            // macros, not standard cells: they have no `.functional.v` and
-            // are modelled as RAM blocks via the runtime `--cell-library`
-            // (ADR 0010 / 0011). Return `None` so they fall through the
-            // std-cell decompose dispatch to the cell-library RAM path,
-            // instead of panicking in `load_pdk_models`'s functional.v
-            // lookup. They still satisfy `is_gf180mcu_cell`, so
-            // `detect_library` keeps reporting GF180MCU (not Mixed).
-            None
-        } else if is_gf180mcu_cell(celltype) {
-            Some(PdkVariant::Gf180Mcu)
-        } else {
-            None
-        }
-    }
-
-    /// Strip the vendor prefix from `celltype` to get the base cell
-    /// type (e.g. `sky130_fd_sc_hd__inv_2` → `inv`,
-    /// `gf180mcu_fd_sc_mcu7t5v0__nand2_4` → `nand2`).
-    pub fn extract_cell_type<'a>(self, celltype: &'a str) -> &'a str {
-        match self {
-            PdkVariant::Sky130 => crate::sky130::extract_cell_type(celltype),
-            PdkVariant::Gf180Mcu => crate::gf180mcu::extract_cell_type(celltype),
-        }
-    }
-
-    /// True if the base cell type is a sequential element (DFF / latch /
-    /// clock-gating cell).
-    pub fn is_sequential(self, cell_type: &str) -> bool {
-        match self {
-            PdkVariant::Sky130 => crate::sky130_pdk::is_sequential_cell(cell_type),
-            PdkVariant::Gf180Mcu => crate::gf180mcu_pdk::is_sequential_cell(cell_type),
-        }
-    }
-
-    /// True if the base cell type is a constant-driving tie cell.
-    pub fn is_tie(self, cell_type: &str) -> bool {
-        match self {
-            PdkVariant::Sky130 => crate::sky130_pdk::is_tie_cell(cell_type),
-            PdkVariant::Gf180Mcu => crate::gf180mcu_pdk::is_tie_cell(cell_type),
-        }
-    }
-
-    /// True if the cell is a physical-only filler / decap / antenna cell
-    /// that contributes no logic to the AIG. SKY130 has no filler concept
-    /// (its fillers are handled differently); this returns `false` for
-    /// SKY130.
-    pub fn is_filler(self, cell_type: &str) -> bool {
-        match self {
-            PdkVariant::Sky130 => false,
-            PdkVariant::Gf180Mcu => crate::gf180mcu_pdk::is_filler_cell(cell_type),
-        }
-    }
-
-    /// True if the cell has multiple functional outputs (full / half
-    /// adders, dual-output DFFs).
-    pub fn is_multi_output(self, cell_type: &str) -> bool {
-        match self {
-            PdkVariant::Sky130 => crate::sky130_pdk::is_multi_output_cell(cell_type),
-            PdkVariant::Gf180Mcu => crate::gf180mcu_pdk::is_multi_output_cell(cell_type),
-        }
-    }
-
-    /// True if the cell is a logic-bearing IO pad (input / inout buffer).
-    /// SKY130 IO pads are not currently supported through the digital
-    /// path; this returns `false` for SKY130.
-    pub fn is_io_pad(self, cell_type: &str) -> bool {
-        match self {
-            PdkVariant::Sky130 => false,
-            PdkVariant::Gf180Mcu => crate::gf180mcu_pdk::is_io_pad_cell(cell_type),
-        }
-    }
-
-    /// Pin name for the active-low asynchronous reset on a sequential
-    /// cell. SKY130: `RESET_B`; GF180MCU: `RN`.
-    pub fn reset_pin(self) -> &'static str {
-        match self {
-            PdkVariant::Sky130 => "RESET_B",
-            PdkVariant::Gf180Mcu => "RN",
-        }
-    }
-
-    /// Pin name for the active-low asynchronous set on a sequential
-    /// cell. SKY130: `SET_B`; GF180MCU: `SETN`.
-    pub fn set_pin(self) -> &'static str {
-        match self {
-            PdkVariant::Sky130 => "SET_B",
-            PdkVariant::Gf180Mcu => "SETN",
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -297,40 +166,4 @@ mod tests {
         assert_eq!(detect_library(empty.iter()), CellLibrary::AIGPDK);
     }
 
-    #[test]
-    fn pdk_variant_classify() {
-        assert_eq!(
-            PdkVariant::classify("sky130_fd_sc_hd__inv_2"),
-            Some(PdkVariant::Sky130)
-        );
-        assert_eq!(
-            PdkVariant::classify("gf180mcu_fd_sc_mcu7t5v0__nand2_4"),
-            Some(PdkVariant::Gf180Mcu)
-        );
-        assert_eq!(PdkVariant::classify("AND2_00_0"), None);
-        assert_eq!(PdkVariant::classify("DFF"), None);
-        // SRAM IP macros are GF180MCU cells (parser-accepted, GF180MCU-
-        // detected) but classify as `None` so they route to the
-        // cell-library RAM path rather than the std-cell functional.v
-        // decompose (which has no model for them — would panic).
-        assert!(crate::gf180mcu::is_gf180mcu_cell(
-            "gf180mcu_fd_ip_sram__sram512x8m8wm1"
-        ));
-        assert_eq!(
-            PdkVariant::classify("gf180mcu_fd_ip_sram__sram512x8m8wm1"),
-            None
-        );
-        assert_eq!(
-            PdkVariant::classify("gf180mcu_fd_ip_sram__sram256x8m8wm1"),
-            None
-        );
-    }
-
-    #[test]
-    fn pdk_variant_async_pin_names() {
-        assert_eq!(PdkVariant::Sky130.reset_pin(), "RESET_B");
-        assert_eq!(PdkVariant::Sky130.set_pin(), "SET_B");
-        assert_eq!(PdkVariant::Gf180Mcu.reset_pin(), "RN");
-        assert_eq!(PdkVariant::Gf180Mcu.set_pin(), "SETN");
-    }
 }

--- a/src/pdk.rs
+++ b/src/pdk.rs
@@ -165,5 +165,4 @@ mod tests {
         let empty: Vec<&str> = vec![];
         assert_eq!(detect_library(empty.iter()), CellLibrary::AIGPDK);
     }
-
 }


### PR DESCRIPTION
Completes the ADR 0019 cell-model-IR cutover. Every built-in PDK's standard-cell semantics (L1 pin directions, L2 combinational, L3 sequential, L4 timing) now come from the generated descriptor — **the runtime `vendor/` stdcell dependency is gone and `PdkVariant` is deleted**.

## What this lands

- **Self-contained stdcell binary.** `load_pdk_models` has no runtime callers; `decompose_with_pdk` is never reached for built-in PDKs; the goldens hold with **zero PDK models loaded**. `vendor/sky130_fd_sc_hd` / `vendor/gf180mcu_*` are no longer opened at simulation time.
- **PDK-neutral sequential dispatch** — SKY130/AIGPDK/IHP sequential cells drive from their descriptor L3 (input side + output overlay), sharing the GF180 path. IHP `ff` cells now work (previously panicked). `clear_preset` honored PDK-neutrally.
- **Residual name-matches retired** for descriptor flops — `"CLK"`/`"CLKN"`/`RN`/`SETN`/`SET_B`/`RESET_B` clock+reset literals replaced by descriptor L3; `trace_clock_pin` buffer detection is now descriptor-derived (from the L2 AIG).
- **`PdkVariant` enum deleted** (`grep -rn PdkVariant src/` = 0) — dispatch routes through free `is_*_stdcell` helpers + descriptor `CellKind`.
- **`JACQUARD_VENDOR_DIR` removed** — it was a runtime override for the now-deleted runtime vendored-PDK read (never released; only in `[Unreleased]`). CHANGELOG updated with the cell-model-IR summary.

## Preserved (descriptor doesn't cover — untouched)
`$__RAMGEM_SYNC_` + GF180 SRAM macros + `CF_SRAM_*` (RAM path, ADR 0011); `.cells.toml`/`RuntimeCellLibrary` (ADR 0010); `GEM_ASSERT`/`GEM_DISPLAY`; `CKLNQD`/`icgtp`/`icgtn` clock gates; `bi_24t`/`in_c`/`in_s` IO pads + `GF180MCU_PAD_PIN_TABLE`; power-pin + filler handling; SRAM `PORT_*_CLK`.

## Gates (all green, no golden shift)
- GF180 `jtag_minimal` 9t MD5 `d87c9f75b4f6af415a9df2d3c728e906` (`--features metal`, 300k edges)
- SKY130 `mcu_soc` flash cosim == committed golden (CpuBackend)
- AIGPDK `COSIM_SCOPE=all` == goldens (7/7); IHP `ihp_comb` `--check-with-cpu` 176/0
- `cargo test --lib` 316; four pipeline crates green; clippy `--lib` 0 errors; builds clean (no-feature + metal); lockstep 0.2.4

## Deferred (deliberately kept — load-bearing, test-uncovered)
The legacy `SET_B`/`RESET_B`/`RN`/`SETN` **seq-wiring** branches remain — they still serve **preserved** cells (`edfxtp` clock-enable folds via the ff state var; `icgtp`/`icgtn` clock gates emit no L3), and no gated design exercises them, so descriptor-driving them can't be safely verified yet. AIGPDK's 2 hardcoded flops and a flat-`.v` cross-check indexer are the remaining follow-ups. These are not `PdkVariant` uses and don't reopen the runtime `vendor` dep.