### PR TITLE
feat: behavioral RTL on-ramp — `jacquard sim design.v` (ADR 0021)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,7 +450,13 @@ jobs:
       - name: Resolve pinned yosys.wasm
         run: |
           set -euo pipefail
-          WASM=$(uv run --with yowasp-yosys python3 -c \
+          # PIN the version — keep in sync with uv.lock's yowasp-yosys. An
+          # unpinned `--with yowasp-yosys` fetches the latest wheel, whose wasm is
+          # now built with the exception-handling proposal that our wasmtime
+          # engine (no `gc` feature) can't load. Loading newer wasm robustly is a
+          # tracked follow-up (ADR 0021 Phase 4); until then the on-ramp targets
+          # the verified 0.64 module (which also carries yosys-slang).
+          WASM=$(uv run --with 'yowasp-yosys==0.64.0.0.post1131' python3 -c \
             "import yowasp_yosys, pathlib; print(next(pathlib.Path(yowasp_yosys.__file__).parent.rglob('*.wasm')))")
           test -f "$WASM"
           echo "JACQUARD_YOSYS_WASM=$WASM" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,42 @@ jobs:
           cargo test --manifest-path crates/cell-model-ir/Cargo.toml
           cargo test --manifest-path crates/liberty-to-cellir/Cargo.toml
 
+  # ADR 0021: compile the RTL on-ramp (the `synth` feature pulls heavy
+  # wasmtime/cranelift deps) on Linux, and run the input-classifier unit tests
+  # (pure logic — no yosys.wasm needed; the feature-gated tests are skipped by the
+  # default `cargo test --lib`). The GPU on-ramp e2e lives in the Metal Tests job.
+  synth-onramp:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    name: Synth on-ramp (Linux compile + classifier tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Init required submodules
+        run: git submodule update --init vendor/eda-infra-rs
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          # Separate key: the wasmtime/cranelift deps are large and would thrash
+          # the shared cargo cache used by the no-feature jobs.
+          key: ${{ runner.os }}-cargo-synth-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-synth-
+      - name: Build jacquard (synth on-ramp, no GPU)
+        run: cargo build --release --features synth --bin jacquard
+      - name: Input-classifier unit tests (synth feature)
+        run: cargo test --lib --features synth input_dispatch
+
   # Cosim CpuBackend regression on a free Linux runner (no GPU). Builds the
   # no-feature jacquard binary (CpuBackend) and runs the seven cosim fixtures,
   # diffing each output against the committed golden in tests/*/expected/.
@@ -310,8 +346,10 @@ jobs:
           key: ${{ runner.os }}-cargo-metal-build-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-metal-build-llvm${{ env.LLVM_VERSION }}-
-      - name: Build jacquard (Metal)
-        run: cargo build --release --features metal --bin jacquard
+      - name: Build jacquard (Metal + synth on-ramp)
+        # synth (ADR 0021) embeds YoWASP Yosys so the Metal Tests job can exercise
+        # the behavioral-RTL on-ramp on real GPU. Also gives synth compile coverage.
+        run: cargo build --release --features metal,synth --bin jacquard
       - name: Upload jacquard-metal binary
         uses: actions/upload-artifact@v7
         with:
@@ -398,6 +436,43 @@ jobs:
             grep '^[01]!' tests/timing_test/ci_output.vcd | head -20
             echo ""
             echo "Note: Minor differences may be acceptable depending on signal timing"
+          fi
+
+      # ADR 0021 on-ramp: the gate-level run above used the committed
+      # dff_test_synth.gv fixture. Here we feed the *behavioral* dff_test.v to the
+      # same `sim` — it must detect RTL, synthesize via embedded YoWASP Yosys
+      # (read_slang), and produce waves bit-identical to the fixture run. This is
+      # the only CI coverage of the synth feature on real GPU; the prebuilt binary
+      # was built --features metal,synth by the metal-build job.
+      - name: Set up uv (YoWASP Yosys on-ramp)
+        uses: astral-sh/setup-uv@v7
+
+      - name: Resolve pinned yosys.wasm
+        run: |
+          set -euo pipefail
+          WASM=$(uv run --with yowasp-yosys python3 -c \
+            "import yowasp_yosys, pathlib; print(next(pathlib.Path(yowasp_yosys.__file__).parent.rglob('*.wasm')))")
+          test -f "$WASM"
+          echo "JACQUARD_YOSYS_WASM=$WASM" >> "$GITHUB_ENV"
+          echo "resolved yosys.wasm: $WASM"
+
+      - name: Behavioral RTL on-ramp smoke (ADR 0021)
+        run: |
+          set -euo pipefail
+          target/release/jacquard sim \
+            tests/timing_test/dff_test.v \
+            tests/timing_test/dff_test.vcd \
+            tests/timing_test/onramp_output.vcd \
+            1 --emit-synth tests/timing_test/onramp_synth.gv
+          echo "=== on-ramp synthesized netlist (head) ==="
+          head -8 tests/timing_test/onramp_synth.gv
+          echo "=== compare on-ramp waves vs gate-level fixture run (ci_output.vcd) ==="
+          if diff <(grep '^[01]!' tests/timing_test/ci_output.vcd) \
+                  <(grep '^[01]!' tests/timing_test/onramp_output.vcd); then
+            echo "✓ behavioral on-ramp waves are bit-identical to the fixture run"
+          else
+            echo "✗ on-ramp output diverged from the gate-level fixture run"
+            exit 1
           fi
 
       - name: Run Metal simulation with X-propagation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,12 @@ jobs:
           # binstall requires every non-optional package bin to be in the
           # archive, so it must ship alongside jacquard (it builds without the
           # metal feature, but one invocation keeps the build cache shared).
-          cargo build --release --features metal --bin jacquard --bin timing_analysis
+          # `synth` (ADR 0021): embeds YoWASP Yosys so the shipped binary accepts
+          # behavioral RTL directly (`jacquard sim design.v`). The ~39 MB yosys.wasm
+          # is not bundled yet — auto-fetch is Phase 4; until then the on-ramp needs
+          # `--yosys-wasm` / an installed `yowasp-yosys`. A pre-synthesized netlist
+          # works with no wasm.
+          cargo build --release --features metal,synth --bin jacquard --bin timing_analysis
           cargo build --release --manifest-path crates/opensta-to-ir/Cargo.toml --bin opensta-to-ir
 
       - name: Package

--- a/.github/workflows/user-acceptance.yml
+++ b/.github/workflows/user-acceptance.yml
@@ -42,7 +42,9 @@ jobs:
 
       - name: Build jacquard (Metal) + opensta-to-ir
         run: |
-          cargo build --release --features metal --bin jacquard
+          # synth (ADR 0021): shipped binary accepts behavioral RTL (yosys.wasm
+          # auto-fetch is Phase 4; on-ramp needs --yosys-wasm until then).
+          cargo build --release --features metal,synth --bin jacquard
           cargo build --release --manifest-path crates/opensta-to-ir/Cargo.toml --bin opensta-to-ir
 
       - name: Install to a clean dir (relocated) + run user-acceptance smoke

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ Requires Rust toolchain (via rustup.rs) and either CUDA, HIP (ROCm), or Metal su
 # Initialize submodules (required first time)
 git submodule update --init --recursive
 
-# Build and run mapping tool (no GPU features needed)
-cargo run -r --bin jacquard -- map --help
+# Analyze timing / validate a netlist (no GPU features needed)
+cargo run -r --bin jacquard -- dump-paths --help
 
 # Metal simulation (macOS)
 cargo run -r --features metal --bin jacquard -- sim --help
@@ -29,9 +29,22 @@ cargo run -r --features cuda --bin jacquard -- sim --help
 
 # HIP simulation (Linux/AMD)
 cargo run -r --features hip --bin jacquard -- sim --help
+
+# Metal + behavioral RTL on-ramp (adds the embedded Yosys synth engine)
+cargo run -r --features metal,synth --bin jacquard -- sim --help
 ```
 
 ## Typical Workflow
+
+**RTL on-ramp (easy path):** Pass behavioral RTL directly — synthesis is transparent and cached:
+
+```
+jacquard sim design.v input.vcd output.vcd NUM_BLOCKS
+```
+
+See `docs/accepted-rtl.md` for the accepted language surface, wasm sourcing, and known limits.
+
+**Performance path** (best GPU QoR — synthesis quality drives GPU speed):
 
 1. **Memory synthesis** (Yosys): Map memories using `memlib_yosys.txt` → outputs `memory_mapped.v`
 2. **Logic synthesis** (DC or Yosys): Synthesize to `aigpdk.lib` cells → outputs `gatelevel.gv`
@@ -55,6 +68,7 @@ NetlistDB (Verilog) → AIG → StagedAIG → Partitions → FlattenedScript →
 - **`repcut.rs`**: Hypergraph partitioning using mt-kahypar for mapping to GPU blocks
 - **`pe.rs`**: Partition executor - builds BoomerangStage structures (hierarchical 8192→1 reduction) that map to GPU block resources
 - **`flatten.rs`**: Generates FlattenedScriptV1 - the final GPU execution script with packed instructions
+- **`synth.rs`**: Embedded Yosys synthesis engine (ADR 0021) — behavioral RTL on-ramp, behind the `synth` feature
 
 ### GPU Kernels (`csrc/`)
 
@@ -64,7 +78,7 @@ NetlistDB (Verilog) → AIG → StagedAIG → Partitions → FlattenedScript →
 
 ### Binary Tools (`src/bin/`)
 
-- **`jacquard.rs`**: Unified CLI — `jacquard sim` (GPU simulation), `jacquard cosim` (co-simulation)
+- **`jacquard.rs`**: Unified CLI — `jacquard sim` (GPU simulation), `jacquard cosim` (co-simulation), `jacquard dump-paths` (timing analysis, no GPU)
 - **`timing_analysis.rs`**: Static timing analysis utility (development tool)
 
 ### Dependencies (`vendor/eda-infra-rs` submodule)
@@ -84,6 +98,7 @@ Open-source Rust gate-level EDA infrastructure (https://github.com/gzz2000/eda-i
 - `aigpdk_nomem.lib`: Library without memory cells (for Yosys)
 - `aigpdk.v`: Verilog models including `CKLNQD` clock gate
 - `memlib_yosys.txt`: Memory mapping rules for Yosys
+- `gem_formal.v`: Techmap rules for assertions (`GEM_ASSERT`) and `$display` (`GEM_DISPLAY`)
 
 ## Key Constraints
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,42 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -68,12 +98,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -198,6 +251,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -206,10 +262,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
 name = "cachedhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b7981770fb0e0442d6f95cf0d3bfcc8bb783d2e7a195f3ce589648e99dcf6"
+
+[[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "cap-net-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "rustix 1.1.4",
+ "smallvec",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.52.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
+dependencies = [
+ "ambient-authority",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix 1.1.4",
+ "winx",
+]
 
 [[package]]
 name = "cast"
@@ -335,6 +475,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +533,153 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "libc",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b27381757f9295b67e558f4c64a83bfe7c6e82daad1ba4f8a948482c5de56ee9"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2ef32a4dbf1b380632a889995156080ecc0f1e07ac8eaa3f6325e4bd14ad8a"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b71c01a8007dd54330c8d73edeb82a8fc1a7143884af2f319e97340e290939b"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fef6b39515a0ecfbb9954ab3d2d6740a459a11bef3d0536ef48460e6f6deb5"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2060d8c75772e5208a9d3b766d9eb975bfc18ac459b75a0a2b2a72769a2f6da6"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.15.5",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887e3ab41a8a75cb6b68c5fc686158b6083f1ad49cf52f2da7538fba17ff0be6"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b187cbec77058579b47e8f75b1ce430b0d110df9c38d0fee2f8bd9801fd673"
+
+[[package]]
+name = "cranelift-control"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b421ad1fefa33a1bb278d761d8ad7d49e17b7089f652fc2a1536435c75ff8def"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e3a650a696c3f4c93bb869e7d219ba3abf6e247164aaf7f12dc918a1d52772"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d48f516c004656a85747f6f8ccf6e23d8ec0a0a6dcf75ec85d6f2fa7e12c91"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce7761455ec4977010db897e9ad925200f08e435b9fa17575bd269ba174f33b"
+
+[[package]]
+name = "cranelift-native"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42be1df38c4db6e19ba19d5ab8e65950c2865da0ad9e972a99ef224f1f77b8af"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.124.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fee765d14f3f91dcba44c0e4b0eaece5f89024539b620af15a6aeec485b1170"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -509,6 +805,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dyn-iter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +834,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,10 +871,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -572,6 +917,12 @@ dependencies = [
  "bitflags 2.11.1",
  "rustc_version",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -601,6 +952,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +988,66 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "getrandom"
@@ -639,6 +1070,17 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -675,6 +1117,16 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
@@ -690,6 +1142,139 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "impl-tools"
@@ -740,7 +1325,31 @@ dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
  "rayon",
+ "serde",
+ "serde_core",
 ]
+
+[[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-terminal"
@@ -778,6 +1387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +1405,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 name = "jacquard"
 version = "0.2.4"
 dependencies = [
+ "anyhow",
  "block",
  "cachedhash",
  "cc",
@@ -802,6 +1421,7 @@ dependencies = [
  "itertools 0.13.0",
  "liberty-parse",
  "liberty-to-cellir",
+ "log",
  "metal",
  "mt-kahypar",
  "netlistdb",
@@ -822,6 +1442,8 @@ dependencies = [
  "ucc",
  "ulib",
  "vcd-ng",
+ "wasmtime",
+ "wasmtime-wasi",
 ]
 
 [[package]]
@@ -849,6 +1471,18 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -890,15 +1524,36 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -910,10 +1565,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "memory-stats"
@@ -951,6 +1621,17 @@ name = "mint"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e53debba6bda7a793e5f99b8dacf19e626084f525f7829104ba9898f367d85ff"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "mt-kahypar"
@@ -1035,6 +1716,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1763,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1800,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1150,6 +1876,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5c8a4c6db43cd896bcc33f316c2f449a89fbec962717e9097d88c9c82547ec0"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "573407df6287098f3e9ded7873a768156bc97c6939d077924d70416cb529bab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1278,6 +2027,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70aeee1a07922bfe7c79e148553dee262248d2493d9778eee7551b9b5d7cc651"
 
 [[package]]
+name = "regalloc2"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,12 +2079,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1333,8 +2115,18 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -1369,6 +2161,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1459,6 +2255,25 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1509,10 +2324,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "system-interface"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
+dependencies = [
+ "bitflags 2.11.1",
+ "cap-fs-ext",
+ "cap-std",
+ "fd-lock",
+ "io-lifetimes",
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
+ "winx",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempdir"
@@ -1533,7 +2381,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1544,6 +2392,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1599,6 +2487,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,6 +2504,20 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1648,6 +2560,37 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "tree-sitter"
@@ -1739,6 +2682,30 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1839,6 +2806,331 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3981f3d51f39f24f5fc90f93049a90f08dbbca8deba602cd46bb8ca67a94718"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcab4481a639a8f3413aa011f733db105ecccc1326a51a6f5c7d09c99314f85"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "async-trait",
+ "bitflags 2.11.1",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.1.4",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5f8069e3d2a235a8d273e58fc3b2088c730477fe8d5364495d4bf20ddbc45d"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap 2.14.0",
+ "log",
+ "object",
+ "postcard",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bdb85a6f168e68d3062fe38c784b2735924cb49733c3ce3e2c9679566c8894"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8aa820447f93cfdc089d744361333f16416c1bebc33e234f4fc5d15766dfe8"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38171538c2612e9d07473f06fcf03d872fe1581e3f7c8587e04e2b2f8e47dcab"
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4440d46baa6b12a40ba6beb1476ed023cee02e8fb45629d2666b9a852398c04b"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d776059b7f5674f2823b9d283616acfcd7e45b862bfad7c257485621099dea"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.1.4",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f189b670fe4e668015cace8a1df1faae03ed9f6b2b638a504204336b4b34de2"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f138fe8652acc4cf8d5de15952a6b6c4bdef10479d33199cc6d50c3fbe778cdd"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9a2bff5db67f19f3d2f7b6ed4b4f67def9917111b824595eb84ef8e43c008e"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-slab"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafd48d67f1aae5a188c4842bee9de2c9f0e7a07626136e54223a0eb63bd4bca"
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cb01a1d8cd95583ac06cb82fc2ad465e893c3ed7d9765f750dfd9d2483a411"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d46615cb9e10960b72cc6f4b2220062523c06d25fff33a4e61d525a4f73ee8c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd3b2c652e93a8b3d6499f3299e46cb58db076a4477ddef594be9089f4cac38"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "log",
+ "object",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98aaee67f9f92aa730a0e6e977474d056f7d9c15ba259494574e3c2d0b75e14"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "heck",
+ "indexmap 2.14.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-wasi"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f24c8a0fa2bf87e9f6e14a55e60ce0fd65de268811fc59921457986be560bd67"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.11.1",
+ "bytes",
+ "cap-fs-ext",
+ "cap-net-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "futures",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "system-interface",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtime",
+ "wasmtime-wasi-io",
+ "wiggle",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-wasi-io"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c30989b56fb32b7b25832bd2ae10fae5ea62e34ddbddb798fbf6f5074793c2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "futures",
+ "wasmtime",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,6 +3138,47 @@ checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wiggle"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a792fe35c2ba3092e8ed3b832a5a671f3076861628f9e9810f6ad7de802007"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.11.1",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661421edf501b09b2ae7e2ffd234dd2947be67d4ca320c41da2325592543b181"
+dependencies = [
+ "anyhow",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e2741d47a84e93ae623216d8b6cc2b42e3b659ca987d44fffd4f020a1dc56c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wiggle-generate",
 ]
 
 [[package]]
@@ -1880,10 +3213,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "winch-codegen"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece82b2b1513521f0bf419a61b4a6151bc99ee2906f3d51a75faf92c38c9b041"
+dependencies = [
+ "anyhow",
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1891,7 +3297,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1909,14 +3324,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1926,10 +3358,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1938,10 +3382,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1950,10 +3406,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1962,10 +3430,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -1977,10 +3457,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.11.1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-parser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c92c939d667b7bf0c6bf2d1f67196529758f99a2a45a3355cc56964fd5315d"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -1989,6 +3515,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -2005,6 +3554,60 @@ name = "zerocopy-derive"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,12 @@ toml = "0.8"
 timing-ir = { path = "crates/timing-ir" }
 ulib = { version = "0.3.13", path = "vendor/eda-infra-rs/ulib" }
 vcd-ng = { version = "0.2.0", path = "vendor/eda-infra-rs/vcd-ng" }
+anyhow = "1"
+log = "0.4"
+# `synth` feature only (ADR 0021): run YoWASP Yosys (WASM) in-process for
+# `jacquard build`. Pure-Rust, cross-platform; heavy to compile, so opt-in.
+wasmtime = { version = "37", optional = true, default-features = false, features = ["cranelift", "runtime"] }
+wasmtime-wasi = { version = "37", optional = true }
 
 [build-dependencies]
 ucc = { version = "0.2.5", path = "vendor/eda-infra-rs/ucc" }
@@ -63,6 +69,10 @@ cell-model-ir = { path = "crates/cell-model-ir" }
 cuda = ["ulib/cuda"]
 hip = ["ulib/hip"]
 metal = ["ulib/metal", "dep:metal", "dep:objc", "dep:block"]
+# ADR 0021: `jacquard build` behavioral-RTL on-ramp (embedded YoWASP Yosys).
+# Opt-in because wasmtime+cranelift materially increases compile time; release
+# binaries enable it. GPU features are orthogonal.
+synth = ["dep:wasmtime", "dep:wasmtime-wasi"]
 
 [dependencies.metal]
 version = "0.29"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ mdbook serve   # opens at http://localhost:3000
 
 ## Input
 
-Jacquard is a gate-level **emulator**: the input to `sim` / `cosim` / `map` is a
+Jacquard is a gate-level **emulator**: the input to `sim` / `cosim` is a
 **synthesized gate-level Verilog netlist** (structural Verilog mapped to
 `aigpdk` / SKY130 / GF180MCU cells).
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Installation](installation.md)
 - [Getting Started](getting-started.md)
 - [Input: Netlist Language & RTL](input-netlist.md)
+- [Accepted RTL Surface](accepted-rtl.md)
 - [Synthesis Flow](synthesis-flow.md)
 - [Testbench Interop](interop.md)
 - [Why Jacquard](why-jacquard.md)
@@ -69,4 +70,5 @@
   - [Interactive JTAG debug server](plans/jtag-debug-server.md)
   - [netlist-graph xroots query](plans/netlist-graph-xroots.md)
   - [Cell-model IR](plans/cell-model-ir.md)
+  - [RTL on-ramp folded into sim/cosim](plans/rtl-onramp-sim-integration.md)
 - [Spike — OpenTimer on SKY130](spikes/opentimer-sky130.md)

--- a/docs/accepted-rtl.md
+++ b/docs/accepted-rtl.md
@@ -59,6 +59,14 @@ module). It is located in this order:
 4. **Fetch from release** — a planned follow-up (ADR 0021 / #162 Phase 4); not
    yet implemented. Until then, one of the three methods above is required.
 
+> **Version caveat.** Pin to **`yowasp-yosys==0.64.0.0.post1131`** (the version in
+> the project's `uv.lock`, verified to carry `read_slang`). *Newer* wheels ship a
+> wasm built with the WebAssembly exception-handling proposal, which the current
+> embedded `wasmtime` engine cannot load yet (`pip install yowasp-yosys` gets the
+> latest and may fail with "exception refs not supported"). Loading newer modules
+> is a tracked Phase-4 follow-up; until then, `pip install
+> 'yowasp-yosys==0.64.0.0.post1131'`.
+
 > Released `jacquard` binaries are built with `--features synth` and include
 > the Yosys WASM runtime. Source builds must add `--features synth` explicitly:
 > `cargo build -r --features metal,synth --bin jacquard`.

--- a/docs/accepted-rtl.md
+++ b/docs/accepted-rtl.md
@@ -1,0 +1,186 @@
+# Accepted Behavioral RTL Surface
+
+`jacquard sim` and `jacquard cosim` accept behavioral Verilog / SystemVerilog
+directly — no separate synthesis step, no external toolchain. This page
+describes what the on-ramp synthesizes, what it drops, and where the coverage
+boundary lies.
+
+**One-line summary:** the accepted surface is whatever **YoWASP Yosys** (with
+the **yosys-slang** `read_slang` frontend) can synthesize to an aigpdk netlist.
+Jacquard delegates the elaboration and synthesis; it does not implement a
+Verilog front-end itself.
+
+---
+
+## Invoking the on-ramp
+
+```sh
+# Pass behavioral RTL directly — synthesis is transparent and cached:
+jacquard sim design.v in.vcd out.vcd NUM_BLOCKS
+
+# Cosim works the same way:
+jacquard cosim design.v --config sim_config.json
+```
+
+`sim`/`cosim` classify the input file automatically:
+
+| Input | Dispatch |
+|---|---|
+| Behavioral RTL (structural parse fails) | auto-synthesized via embedded Yosys → simulated |
+| Gate-level netlist, built-in PDK (AIGPDK / SKY130 / GF180MCU) | simulated directly, no synthesis |
+| Gate-level netlist, unrecognized cells | **error** directing you to `--cell-descriptor <path>` |
+
+Override flags:
+- `--rtl` — force the synthesis path (useful if detection misclassifies a file).
+- `--netlist` — force direct gate-level loading, skip detection.
+- `--emit-synth <path>` — also write the intermediate synthesized netlist for
+  inspection or as a fixture.
+
+The simulator always logs its decision:
+```
+design.v: behavioral RTL → synthesized [YoWASP Yosys, functional QoR] → <cache>
+```
+
+---
+
+## Providing `yosys.wasm`
+
+The synthesis engine requires `yosys.wasm` (the YoWASP Yosys WebAssembly
+module). It is located in this order:
+
+1. **`--yosys-wasm /path/to/yosys.wasm`** — CLI flag on `sim`/`cosim` (highest
+   priority; overrides the env var and discovery).
+2. **`JACQUARD_YOSYS_WASM=/path/to/yosys.wasm`** — environment variable.
+3. **Installed `yowasp-yosys`** Python package — discovered automatically via
+   `python3 -c "import yowasp_yosys …"`. Install with:
+   ```sh
+   pip install yowasp-yosys          # or: uvx yowasp-yosys
+   ```
+4. **Fetch from release** — a planned follow-up (ADR 0021 / #162 Phase 4); not
+   yet implemented. Until then, one of the three methods above is required.
+
+> Released `jacquard` binaries are built with `--features synth` and include
+> the Yosys WASM runtime. Source builds must add `--features synth` explicitly:
+> `cargo build -r --features metal,synth --bin jacquard`.
+>
+> A binary built **without** `--features synth` gives an actionable error when
+> handed behavioral RTL, pointing at the synth-enabled build path.
+
+The compiled Yosys module is cached under `$XDG_CACHE_HOME/jacquard` by
+content hash — only the first run of a given wasm pays the ~20 s cranelift
+compile. The synthesized netlist is also cached keyed by (design source + synth
+script + wasm), so repeat `sim` runs skip synthesis entirely.
+
+---
+
+## SystemVerilog frontend
+
+The embedded wasm (pinned `yowasp-yosys 0.64.0.0.post1131`) bundles
+**yosys-slang** — a near-complete SystemVerilog-2017 elaborator. Jacquard
+probes for `read_slang` at startup and uses it when present; it falls back
+gracefully to Yosys's built-in `read_verilog -sv` for older wasm modules.
+
+`read_slang` coverage is substantially broader than `read_verilog -sv`:
+packages, interfaces, structs, enums, and most SV-2017 constructs are handled
+by the slang elaborator before Yosys sees any RTL. If you observe a
+"not supported" message, check whether it names `slang` or `read_verilog` — the
+fallback has a narrower surface.
+
+---
+
+## Supported language subset
+
+The following are synthesizable and produce correct simulation output:
+
+**Verilog-2005 (synthesizable subset):**
+- All combinational logic: `assign`, `always @(*)`, `always @(posedge/negedge)`
+- Synchronous flip-flops (positive or negative edge)
+- Synchronous reset DFFs (`if (rst) Q <= 0; else Q <= D;`)
+- Asynchronous reset / set DFFs (async reset is supported; latches are not)
+- Case and if/else chains
+- Parameterized modules and `generate` blocks
+- Inferred memories (mapped to `RAMGEM` by `memlib_yosys.txt` — see below)
+
+**SystemVerilog-2017 (via yosys-slang `read_slang`):**
+- Packages and package imports
+- Interfaces (including modports)
+- `always_ff`, `always_comb`, `always_latch`
+- `logic`, `enum`, `struct`, `union` (synthesizable forms)
+- Parameters with complex types; advanced `generate` (`if`, `for`, `case`)
+- Casting and type conversions (synthesizable)
+
+This is **not** the narrow subset accepted by Yosys's built-in
+`read_verilog -sv`; it is the slang elaborator's synthesizable coverage, which
+tracks the SystemVerilog-2017 standard closely.
+
+---
+
+## Project-specific mappings
+
+The synthesis script applies three project-specific transformations on top of
+standard Yosys synthesis:
+
+| RTL construct | Result | Notes |
+|---|---|---|
+| `$assert`, `$assume`, immediate `assert property` | `GEM_ASSERT` cell | Visible in simulation as assertion failures. `$cover` is silently dropped. |
+| `$display` (→ Yosys `$print`) | `GEM_DISPLAY` cell | The cell is emitted, but the on-ramp does not yet write the display-info JSON companion the CPU side needs to decode format strings — so `$display` text is **not surfaced through the on-ramp path** yet (tracked as a Phase-4 follow-up). |
+| Inferred synchronous memories | `$__RAMGEM_SYNC_` (RAMGEM) | Mapped via `aigpdk/memlib_yosys.txt`. Asynchronous-read ports generate a warning. |
+
+The techmap rules are in `aigpdk/gem_formal.v`. Pass
+`--strip-assertions` (if available on your build) to use `chformal -remove` and
+drop GEM_ASSERT cells instead, for a pure logic netlist.
+
+---
+
+## Known limits
+
+**Concurrent SVA → synthesizable checker synthesis is partial.** Turning
+concurrent SystemVerilog Assertions (`property` / `sequence` bound to
+`assert property` with a clock) into gate-level checkers is a Yosys formal-flow
+capability — independent of slang's ability to *parse* SVA. This is tracked in
+issues #106 and #107. Immediate assertions (`assert (cond)` inside procedural
+blocks) synthesize correctly via the `GEM_ASSERT` mapping above.
+
+**Testbench-only constructs are dropped.** Synthesis discards constructs that
+have no synthesizable meaning: `#delay` timing controls, most `initial` blocks
+(other than register initialization), `$finish`, `$stop`, and similar testbench
+procedural code. These are silently dropped by Yosys during elaboration, not
+simulated. If a `$display` is inside an `initial` or inside a `#delay`-driven
+block, it may be dropped too.
+
+**Latches are not supported.** Jacquard's GPU emulator core is synchronous
+only — see `docs/synthesis-flow.md` for the latch constraint. A latch inferred
+from RTL causes a synthesis or AIG-load error.
+
+---
+
+## QoR note
+
+YoWASP Yosys produces **functional-grade QoR** — correct results but not
+optimized for GPU speed. Synthesis quality is the primary tuner of simulation
+throughput (the AIG the GPU emulates is only as good as the mapping). For peak
+performance, synthesize your design with a commercial synthesizer (DC) or a
+native Yosys install, and point `jacquard sim` at the resulting gate-level
+netlist directly. See `docs/synthesis-flow.md` for the performance path.
+
+---
+
+## Authoritative surface: empirical coverage (Phase 4)
+
+This prose describes the *intended* surface. Because the accepted RTL surface is
+whatever the embedded Yosys frontend synthesizes, the **authoritative** measure
+is an empirical pass/fail coverage table driven through
+[sv-tests](https://github.com/SymbiFlow/sv-tests) (or a curated subset) — a
+Phase 4 follow-up tracked in `docs/plans/rtl-onramp-sim-integration.md`. Until
+that table exists, hand-claimed feature lists for a delegated frontend are
+inherently approximate. Report gaps as bugs; they will be tracked in the
+coverage table when it ships.
+
+---
+
+## See also
+
+- [Getting Started](getting-started.md) — run bundled designs to verify your build first.
+- [Synthesis Flow](synthesis-flow.md) — the performance path (DC / native Yosys, peak QoR).
+- [ADR 0021](adr/0021-behavioral-rtl-support.md) — the design decision behind the on-ramp.
+- `docs/plans/rtl-onramp-sim-integration.md` — implementation plan and Phase 4 roadmap.

--- a/docs/adr/0021-behavioral-rtl-support.md
+++ b/docs/adr/0021-behavioral-rtl-support.md
@@ -147,11 +147,18 @@ on-ramp.
   pre-synthesized netlist).
 - **The accepted-RTL surface is defined and documented, not implicit.** Because
   synthesis is delegated to Yosys, the accepted behavioral subset *is* the
-  embedded YoWASP Yosys `read_verilog -sv` frontend (no Verific → limited
-  concurrent SVA), plus the project's techmaps (assertions → `GEM_ASSERT`,
-  `$display` → `GEM_DISPLAY`, memories → `RAMGEM`) and minus dropped
-  testbench-only constructs. This gets a dedicated `docs/accepted-rtl.md`, whose
-  authoritative form is an **empirical coverage table** driven through
+  embedded YoWASP Yosys frontend — and that frontend includes **yosys-slang**
+  (`read_slang`), a near-complete SystemVerilog-2017 elaborator, **verified
+  present in the pinned `yowasp-yosys 0.64.0.0.post1131` wasm** (`read_slang` +
+  495 `slang` symbols). So SystemVerilog *language* coverage is strong
+  (packages, interfaces, advanced generate, structs/enums, most of SV), not the
+  narrow built-in-`read_verilog` subset. The remaining bound is **concurrent-SVA
+  synthesis** — turning SVA into synthesizable checkers is a separate Yosys
+  formal capability, still partial (#106/#107), independent of slang's parsing.
+  On top of the frontend sit the project's techmaps (assertions → `GEM_ASSERT`,
+  `$display` → `GEM_DISPLAY`, memories → `RAMGEM`), minus dropped testbench-only
+  constructs. This gets a dedicated `docs/accepted-rtl.md`, whose authoritative
+  form is an **empirical coverage table** driven through
   [sv-tests](https://github.com/SymbiFlow/sv-tests) (follow-up) rather than a
   hand-claimed feature list — hand-claims about a delegated frontend would
   violate the "verify, don't assert" bar.

--- a/docs/adr/0021-behavioral-rtl-support.md
+++ b/docs/adr/0021-behavioral-rtl-support.md
@@ -52,10 +52,21 @@ input, while keeping the emulator's synthesized-netlist core unchanged:
    `aigpdk.lib` logic synthesis) to produce `gatelevel.gv`, which then feeds
    `sim` / `cosim` unchanged. RTL in, netlist out, one command.
 
-2. **Yosys via YoWASP**, not a vendored native build — WASM wheels the workspace
-   already resolves. The front-end **lives in the Python engine** (ADR 0020 P0 /
-   #161), because YoWASP is Python-distributed: `pip install jacquard` then
-   `jacquard build design.v && jacquard sim …` is RTL-to-waves from one install.
+2. **Yosys as WebAssembly, executed in-process from Rust** — not a vendored
+   native build, and *not* via the Python `yowasp-yosys` wrapper. YoWASP ships
+   Yosys as a single self-contained `yosys.wasm` (abc is compiled **in-tree**
+   into that module and called **in-process** — WASI has no `exec`), and the
+   `yowasp-runtime` that runs it is a thin harness over
+   [`wasmtime`](https://wasmtime.dev), which has a first-class Rust crate. So
+   `jacquard build` is a **Rust subcommand of the `jacquard` CLI** that embeds
+   `wasmtime`, loads the (bundled or fetch-on-first-use) `yosys.wasm`, preopens
+   the design + `aigpdk` library files + a temp dir under WASI, and runs the
+   existing synthesis script — caching the compiled module to disk exactly as
+   `yowasp-runtime` does. **No Python interpreter and no external toolchain:**
+   `jacquard build design.v && jacquard sim …` is RTL-to-waves from the single
+   `jacquard` binary. This **decouples the on-ramp from the Python-engine
+   packaging decision** (ADR 0020 / #161) — `build` needs neither PyO3 nor a
+   subprocess-bundled wheel.
 
 3. **Two synthesis tracks, kept explicit** (honouring force #1):
    - **On-ramp:** YoWASP Yosys — easy, functional, the default `jacquard build`.
@@ -79,13 +90,26 @@ std-cell mapping. Jacquard could then thread `\src` through `netlistdb`/AIG so
 GPU-sim results **speak RTL** — `--trace-signals`, timing violations, and
 X-debugging reporting source lines instead of flattened gate names.
 
-The tractable route is **building our own YoWASP from source** rather than
-depending on the upstream `yowasp-yosys` wheels: the same custom WASM build that
-carries the patched yosys can compile the patched abc (#487) alongside it, so
-provenance ships **self-contained in one wheel** — we are not blocked on upstream
-YoWASP adopting the patches, only on the patches themselves (abc#487 is in
-review). Differentiator, but a large build effort; tracked as Phase 2 in #162,
-out of scope for ratifying the on-ramp.
+The tractable route is **building our own `yosys.wasm` from source** rather than
+depending on the stock upstream wheel. YoWASP's build (`build.sh`: wasi-sdk 27 →
+flex → yosys `CONFIG=wasi` + LTO) compiles abc **in-tree from yosys's own bundled
+`abc/` submodule** — verified against the shipped `yosys.wasm`, which embeds the
+abc engine (the build path `…/yosys-src/abc/src/base/abci/…` and the full set of
+`&`-prefixed GIA commands are present in the module). So a provenance build is
+mechanical: **fork [YoWASP/yosys](https://codeberg.org/YoWASP/yosys)** (now on
+Codeberg; the old GitHub repo was archived read-only 2026-03-11), repoint
+`yosys-src` → `robtaylor/yosys@src-retention-y-ext` and yosys's bundled `abc`
+submodule → `robtaylor/abc@origin-tracking-clean` (#487), and rerun `build.sh`.
+Provenance then ships **self-contained in one `.wasm`** — not blocked on upstream
+YoWASP adopting the patches, only on the patches themselves (abc#487 in review).
+
+**Key open risk to spike before committing to WASM provenance:** origin-shell
+validated `\src` retention through **external** abc (`ABCEXTERNAL`, temp `.aig`
+round-trips). The WASM build calls abc **in-process**, a different integration
+surface — the `&origins` data must survive the in-process call path, not a
+temp-file hand-off. This is unproven and is the first Phase-2 task. A large build
+effort overall; tracked as Phase 2 in #162, out of scope for ratifying the
+on-ramp.
 
 ## Consequences
 
@@ -95,12 +119,15 @@ out of scope for ratifying the on-ramp.
 - **A QoR ceiling on the easy path.** YoWASP Yosys is functional-grade; peak GPU
   performance still wants DC. The docs must state this so `jacquard build` isn't
   mistaken for the performance path.
-- **A Python-layer dependency** (`yowasp-yosys`) — but one already in the
-  workspace, and optional (the native `sim`/`cosim`/`map` binary keeps working on
-  a pre-synthesized netlist with no Python).
-- **Reinforces ADR 0020 / #161:** the Python package is now more than a thin
-  binding — it hosts the synthesis front-end. A point in favour of a rich Python
-  layer regardless of the subprocess-vs-PyO3 call.
+- **A Rust `wasmtime` dependency + a `yosys.wasm` asset** — no new Python
+  dependency, and the on-ramp is optional (the `sim`/`cosim`/`map` binary keeps
+  working on a pre-synthesized netlist with `build` unused). The ~39 MB wasm is
+  either bundled into the binary or fetched to a cache on first `build` (open
+  sub-decision, #162).
+- **Decouples the on-ramp from ADR 0020 / #161:** because `build` runs Yosys from
+  Rust via `wasmtime`, it needs neither the PyO3 binding nor a subprocess-bundled
+  Python wheel. The Python-engine packaging call can be made independently; the
+  RTL on-ramp no longer waits on it.
 - **Provenance (Phase 2)** is a large, dependency-gated follow-on, not promised
   by this ADR.
 
@@ -112,6 +139,15 @@ out of scope for ratifying the on-ramp.
 - **Vendor/embed native Yosys (C++).** Heavy build + distribution burden across
   macOS/Linux/arch. YoWASP's WASM wheels are the lightweight embed that makes
   this decision cheap.
+- **Python-hosted front-end via the `yowasp-yosys` wrapper** (the original shape
+  of this ADR). Rejected once inspection showed the wrapper is a ~1 KB shim and
+  `yowasp-runtime` a ~100-line harness over `wasmtime`: hosting `build` in Python
+  would force the user to have Python + pip + the wheel present (reintroducing an
+  install dependency) and couple the on-ramp to the unresolved #161 packaging
+  decision — all to avoid porting a small WASI harness the Rust `wasmtime` crate
+  supports directly. `scripts/local_synth.py` (which drives
+  `yowasp_yosys.run_yosys` for the sky130 flow) remains a useful reference for the
+  synthesis-script *content*, even though the runtime is now Rust.
 - **A Nix environment instead of (or alongside) YoWASP.** origin-shell is itself
   a Nix flake pinning patched yosys + abc + librelane. A Nix devshell is a viable
   alternative back-end for `jacquard build`: **native** binaries (better QoR and

--- a/docs/adr/0021-behavioral-rtl-support.md
+++ b/docs/adr/0021-behavioral-rtl-support.md
@@ -23,7 +23,7 @@ RTL *is* the intended design input. But it is an **emulator** (GEM =
 GPU-Emulator-inspired; [ADR 0014](0014-aig-as-simulation-ir.md)): it maps a
 *synthesized* and-inverter graph onto a virtual manycore, exactly as an
 FPGA-based emulator runs a synthesized bitstream, not behavioral source. So the
-input to `jacquard sim` / `cosim` / `map` is a **gate-level netlist** —
+input to `jacquard sim` / `cosim` is a **gate-level netlist** —
 structural Verilog mapped to `aigpdk` / SKY130 / GF180MCU cells — and the parser
 (`sverilogparse`) is structural-only.
 

--- a/docs/adr/0021-behavioral-rtl-support.md
+++ b/docs/adr/0021-behavioral-rtl-support.md
@@ -2,6 +2,13 @@
 
 **Status:** Proposed
 
+> **Revised 2026-07-03 (pre-ratification, still Proposed):** the entry point
+> moved from a standalone **`jacquard build`** command to **folding synthesis
+> into `sim`/`cosim`** — RTL is simulated with one command, no separate build
+> step. The embedded-Yosys/`wasmtime` engine (Decision §2) is unchanged; only
+> the *surface* changed. The original `build`-command shape is preserved in
+> "Alternatives considered" for the audit trail. Rationale below.
+
 **Relates to:** [ADR 0014](0014-aig-as-simulation-ir.md) (AIG / emulator model —
 why synthesis is a front-end at all), the Python-engine work
 ([#161](https://github.com/gpu-eda/Jacquard/issues/161), ADR 0020 pending) that
@@ -47,10 +54,25 @@ Two forces shape the fix:
 Add an **embedded synthesis front-end** so behavioral RTL is a first-class
 input, while keeping the emulator's synthesized-netlist core unchanged:
 
-1. **`jacquard build <design.v…>`** drives Yosys through the *existing*
-   `docs/synthesis-flow.md` scripts (`memlib_yosys.txt` memory synthesis →
-   `aigpdk.lib` logic synthesis) to produce `gatelevel.gv`, which then feeds
-   `sim` / `cosim` unchanged. RTL in, netlist out, one command.
+1. **`sim` / `cosim` accept behavioral RTL directly** — synthesis is a
+   *transparent, cached pre-processor* inside those commands, not a separate
+   user step. There is **no `jacquard build` command**. On the input path, the
+   command classifies what it was handed and dispatches three ways:
+
+   | Input | Structural parse (`sverilogparse`) | Cell family | Action |
+   |---|---|---|---|
+   | Gate-level, **built-in** PDK | parses | matches an `is_*_stdcell` family | **simulate directly** — the embedded descriptor supplies logic + timing (corner via `--corner`, ADR 0019) |
+   | Gate-level, **unknown** PDK | parses | matches nothing | **error, actionable**: "gate-level netlist with unrecognized cells — pass `--cell-descriptor <path>`" (ADR 0019 D8). *Not synthesized* — it is already a netlist. |
+   | **Behavioral** RTL | fails (`always`/`if`/`case`/operators are not structural) | n/a | **synthesize** → aigpdk → simulate, via the embedded Yosys (Decision §2), caching the result |
+
+   The command **prints what it decided** (e.g. `design.v: behavioral RTL →
+   synthesized [YoWASP Yosys, functional QoR] → <cache>`), so synthesis is
+   never silent (honouring force #1 below). `--rtl` / `--netlist` override the
+   auto-detection; a syntax error in a netlist that falls through to the synth
+   path surfaces **both** the structural and the Yosys diagnostics. The
+   gate-level artefact is dumpable for inspection/fixtures via `--emit-synth
+   <path>`. RTL in, waveform out, one command — driving the *existing*
+   `docs/synthesis-flow.md` scripts (`memlib_yosys.txt` → `aigpdk.lib`).
 
 2. **Yosys as WebAssembly, executed in-process from Rust** — not a vendored
    native build, and *not* via the Python `yowasp-yosys` wrapper. YoWASP ships
@@ -58,25 +80,32 @@ input, while keeping the emulator's synthesized-netlist core unchanged:
    into that module and called **in-process** — WASI has no `exec`), and the
    `yowasp-runtime` that runs it is a thin harness over
    [`wasmtime`](https://wasmtime.dev), which has a first-class Rust crate. So
-   `jacquard build` is a **Rust subcommand of the `jacquard` CLI** that embeds
-   `wasmtime`, loads the (bundled or fetch-on-first-use) `yosys.wasm`, preopens
-   the design + `aigpdk` library files + a temp dir under WASI, and runs the
-   existing synthesis script — caching the compiled module to disk exactly as
-   `yowasp-runtime` does. **No Python interpreter and no external toolchain:**
-   `jacquard build design.v && jacquard sim …` is RTL-to-waves from the single
-   `jacquard` binary. This **decouples the on-ramp from the Python-engine
-   packaging decision** (ADR 0020 / #161) — `build` needs neither PyO3 nor a
-   subprocess-bundled wheel.
+   the synthesis engine is a **Rust component (`src/synth.rs`) embedded in the
+   `jacquard` binary** that embeds `wasmtime`, loads the (bundled or
+   fetch-on-first-use) `yosys.wasm`, preopens the design + `aigpdk` library
+   files + a temp dir under WASI, and runs the existing synthesis script —
+   caching the compiled module *and* the synthesized netlist to disk (by
+   content hash) exactly as `yowasp-runtime` does. It is invoked *transparently*
+   by `sim`/`cosim` on the behavioral-input path (Decision §1), behind the
+   opt-in **`synth` feature** (`wasmtime`+cranelift are heavy to compile). **No
+   Python interpreter and no external toolchain:** `jacquard sim design.v …` is
+   RTL-to-waves from the single `jacquard` binary. This **decouples the on-ramp
+   from the Python-engine packaging decision** (ADR 0020 / #161) — it needs
+   neither PyO3 nor a subprocess-bundled wheel.
 
 3. **Two synthesis tracks, kept explicit** (honouring force #1):
-   - **On-ramp:** YoWASP Yosys — easy, functional, the default `jacquard build`.
+   - **On-ramp:** YoWASP Yosys — easy, functional; the default when `sim`/`cosim`
+     are handed behavioral RTL.
    - **Performance:** bring-your-own DC (or native Yosys) → `gatelevel.gv` →
-     `jacquard sim` directly. Documented as the path to peak GPU speed.
+     `jacquard sim` directly (the "gate-level, built-in PDK" row above).
+     Documented as the path to peak GPU speed.
 
-4. **The emulator core does not change.** `jacquard build` is a *pre-processor*
-   that produces the same structural netlist users synthesize by hand today; the
-   AIG/boomerang pipeline (ADR 0014/0015) and the structural `sverilogparse`
-   input are untouched. Behavioral elaboration stays Yosys's job — we do not
+4. **The emulator core does not change.** Synthesis is a transparent
+   *pre-processor* inside `sim`/`cosim` that produces the same structural
+   netlist users synthesize by hand today; the AIG/boomerang pipeline (ADR
+   0014/0015) and the structural `sverilogparse` input are untouched — the
+   behavioral path simply feeds them a just-synthesized netlist instead of a
+   hand-written one. Behavioral elaboration stays Yosys's job — we do not
    reimplement an RTL front-end.
 
 Implementation phasing lives in **[#162](https://github.com/gpu-eda/Jacquard/issues/162)**.
@@ -116,18 +145,35 @@ on-ramp.
 - **RTL becomes a first-class, single-command input** — the onboarding cliff is
   removed, and "what does it accept?" has a clean answer: *your RTL* (or a
   pre-synthesized netlist).
+- **The accepted-RTL surface is defined and documented, not implicit.** Because
+  synthesis is delegated to Yosys, the accepted behavioral subset *is* the
+  embedded YoWASP Yosys `read_verilog -sv` frontend (no Verific → limited
+  concurrent SVA), plus the project's techmaps (assertions → `GEM_ASSERT`,
+  `$display` → `GEM_DISPLAY`, memories → `RAMGEM`) and minus dropped
+  testbench-only constructs. This gets a dedicated `docs/accepted-rtl.md`, whose
+  authoritative form is an **empirical coverage table** driven through
+  [sv-tests](https://github.com/SymbiFlow/sv-tests) (follow-up) rather than a
+  hand-claimed feature list — hand-claims about a delegated frontend would
+  violate the "verify, don't assert" bar.
 - **A QoR ceiling on the easy path.** YoWASP Yosys is functional-grade; peak GPU
-  performance still wants DC. The docs must state this so `jacquard build` isn't
-  mistaken for the performance path.
+  performance still wants DC. The auto-synth path *prints its QoR tier* and the
+  docs must state this, so the on-ramp isn't mistaken for the performance path.
 - **A Rust `wasmtime` dependency + a `yosys.wasm` asset** — no new Python
-  dependency, and the on-ramp is optional (the `sim`/`cosim`/`map` binary keeps
-  working on a pre-synthesized netlist with `build` unused). The ~39 MB wasm is
-  either bundled into the binary or fetched to a cache on first `build` (open
-  sub-decision, #162).
-- **Decouples the on-ramp from ADR 0020 / #161:** because `build` runs Yosys from
-  Rust via `wasmtime`, it needs neither the PyO3 binding nor a subprocess-bundled
-  Python wheel. The Python-engine packaging call can be made independently; the
-  RTL on-ramp no longer waits on it.
+  dependency. The `synth` feature is opt-in *at compile time* (heavy cranelift
+  build), but because behavioral input is now a `sim`/`cosim` capability rather
+  than a separate command, **released binaries must be built `--features synth`**
+  — otherwise `sim design.v` on RTL fails with a build-without-synth message.
+  A pre-synthesized netlist still simulates with the feature off. The ~39 MB
+  wasm is either bundled into the binary or fetched to a cache on first use
+  (open sub-decision, #162).
+- **Decouples the on-ramp from ADR 0020 / #161:** because synthesis runs Yosys
+  from Rust via `wasmtime`, it needs neither the PyO3 binding nor a
+  subprocess-bundled Python wheel. The Python-engine packaging call can be made
+  independently; the RTL on-ramp no longer waits on it.
+- **Timing stays descriptor-aligned, not `.lib`-coupled.** The on-ramp does not
+  reintroduce a `--liberty` runtime path: for built-in PDKs, logic *and* timing
+  come from the embedded cell-model descriptor (ADR 0019 D5), corner-selected
+  via `--corner`. `--liberty` / `--cell-descriptor` remain for user/custom PDKs.
 - **Provenance (Phase 2)** is a large, dependency-gated follow-on, not promised
   by this ADR.
 
@@ -160,6 +206,16 @@ on-ramp.
   WASM build. `jacquard build` should abstract the synthesis back-end so it can
   dispatch to whichever (YoWASP wheel, Nix devshell, or a plain system Yosys/DC)
   is present.
+- **A standalone `jacquard build <design.v>` command** producing `gatelevel.gv`
+  as an explicit user step (the original shape of this ADR; implemented on the
+  first cut of PR #167). Revised away before ratification: it reinstated the very
+  multi-command ceremony ("build, then point `sim` at the output") the ADR set
+  out to remove, and the artefact boundary it justified turned out unneeded — the
+  committed `*_synth.gv` test fixtures are each written **once** by the test that
+  introduces them and never regenerated, so no standing "rebuild the fixtures"
+  workflow depends on a `build` command; `--emit-synth` covers one-off fixture
+  authoring. Folding synthesis into `sim`/`cosim` (Decision §1) keeps the
+  one-command promise while the same `src/synth.rs` engine still backs it.
 - **Elaborate behavioral RTL directly inside Jacquard** (no synthesis). Rejected:
   it contradicts the emulator model (ADR 0014) and would reimplement a Verilog
   front-end Yosys already provides — enormous scope for no architectural gain.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,11 +5,12 @@ increasing order of realism. Every command here runs against designs that ship
 **in the repository** — no synthesis, no large downloads, no extra EDA tools.
 Each one is also a CI job, so it is known-green.
 
-> **Already have your own RTL?** This page runs *bundled* designs to prove your
-> build works. To prepare and run *your own* design (memory + logic synthesis,
-> VCD scope handling, timing back-annotation) see the
-> [Synthesis Flow](synthesis-flow.md). For UVM/cocotb/SVA questions see
-> [Testbench Interop](interop.md).
+> **Already have your own RTL?** Pass it directly to `jacquard sim design.v …`
+> — the simulator auto-detects behavioral Verilog / SystemVerilog and
+> synthesizes it transparently (see [Accepted RTL surface](accepted-rtl.md)).
+> For peak GPU performance, or to use a commercial synthesizer (DC) for best
+> mapping quality, see [Synthesis Flow](synthesis-flow.md). For UVM/cocotb/SVA
+> questions see [Testbench Interop](interop.md).
 
 ## Prerequisites
 
@@ -145,7 +146,8 @@ run `jacquard sim` exactly as in 3a.
 
 | You want to… | Go to |
 |---|---|
-| Prepare and run **your own RTL** (synthesis, memory mapping, scopes) | [Synthesis Flow](synthesis-flow.md) |
+| Simulate **your own behavioral RTL** (one command, auto-synthesized) | [Accepted RTL surface](accepted-rtl.md) |
+| Prepare a **high-QoR gate-level netlist** (DC / Yosys, memory mapping) | [Synthesis Flow](synthesis-flow.md) |
 | Run the large research **benchmarks** (NVDLA, Rocket, Gemmini) | [`benchmarks/README.md`](https://github.com/gpu-eda/Jacquard/blob/main/benchmarks/README.md) |
 | Add **timing** (Liberty / SDF / violation checks) | [Timing Simulation](timing-simulation.md) |
 | Use **UVM / cocotb / SVA**, or understand interop limits | [Testbench Interop](interop.md) |

--- a/docs/handoffs/adr-0021-behavioral-rtl-handoff.md
+++ b/docs/handoffs/adr-0021-behavioral-rtl-handoff.md
@@ -1,96 +1,100 @@
-# Handoff — ADR 0021 behavioral-RTL on-ramp (`jacquard build` via YoWASP)
+# Handoff — ADR 0021 behavioral-RTL on-ramp (`jacquard build`)
 
-**Created:** 2026-07-01
-**Working tree:** clean
-**Branch:** main
+**Updated:** 2026-07-03
+**Branch:** `feat/rtl-onramp-build` (PR [#167](https://github.com/gpu-eda/Jacquard/pull/167), **draft**, CI green)
+**Working tree:** clean (only `.env` untracked)
 
 ## Goal & next-up
 
-**Goal of this session:** clarify Jacquard's input story (external feedback: "not
-clear what netlist language you accept") and record the decision to make
-behavioral RTL first-class. Shipped the docs + [ADR 0021](../adr/0021-behavioral-rtl-support.md)
-(Proposed) in PR #163; filed the implementation tracker
-[#162](https://github.com/gpu-eda/Jacquard/issues/162). **No implementation
-started** — the ADR is ratified as *Proposed*, the code is the next arc.
+**This session:** implemented **Phase 1** of ADR 0021 / [#162](https://github.com/gpu-eda/Jacquard/issues/162)
+— `jacquard build <design.v…>` synthesizes behavioral RTL → gate-level aigpdk
+netlist that feeds `sim`/`cosim`, with **no Python and no external toolchain**.
+Shipped on PR #167 (draft, CI green on the branch and on `main`). The ADR was
+amended to record the **Rust + `wasmtime`** shape (was "Python-hosted").
 
-**Next session should pick up:** **Phase 1** of #162 — implement
-**`jacquard build <design.v>`**: shell out to Yosys (via `yowasp-yosys`) running
-the *existing* synthesis scripts, producing `gatelevel.gv`, then hand off to
-`sim`. The scripts already exist — memory synthesis uses `aigpdk/memlib_yosys.txt`
-(`memory_libmap`), logic synthesis maps to `aigpdk/aigpdk.lib` cells; the full
-manual flow is [`docs/synthesis-flow.md`](../synthesis-flow.md). Start by wiring
-`yowasp-yosys` (already resolved — see below) to run those two steps.
+**Next session should pick up** (priority order):
+1. **Un-draft PR #167** and get it reviewed/merged (nothing blocking; CI green).
+2. **CI coverage for the `synth` feature** — it's opt-in (not default), so current
+   CI (`cargo test --lib`, `cargo build -r --bin jacquard`) never compiles it. Add
+   a `cargo build --features synth` job + a `jacquard build` smoke test, and add
+   `--features synth` to `release.yml` / `user-acceptance.yml` so shipped binaries
+   include the on-ramp. **Without this the feature ships in no binary.**
+3. **Fetch-from-GitHub-release** (increment 2): publish the pinned `yosys.wasm` as
+   a Jacquard release asset; `build` fetches to `$XDG_CACHE_HOME/jacquard` + sha256.
+   Same mechanism will later deliver the Phase-2 patched wasm. Aligns with ADR 0018.
 
-**Verification command:**
+**Verification:**
 ```sh
-# ADR + docs are on main:
-ls docs/adr/0021-behavioral-rtl-support.md docs/input-netlist.md
-grep -n "0021" docs/adr/README.md docs/SUMMARY.md
-uv run python scripts/check_doc_links.py     # Expect: "All rendered-page links resolve"
-# YoWASP Yosys is already a resolved dependency:
-grep -n "yowasp-yosys" uv.lock                # Expect: present (via amaranth[builtin-yosys])
+# feature builds + runs (needs a yosys.wasm; e.g. from an installed yowasp-yosys wheel):
+cargo build --release --features synth --bin jacquard
+JACQUARD_YOSYS_WASM=<path/to/yosys.wasm> \
+  ./target/release/jacquard build <design.v> -o /tmp/gl.gv     # → aigpdk netlist
+./target/release/jacquard dump-paths /tmp/gl.gv --liberty aigpdk/aigpdk.lib   # parses → AIG
+cargo build --bin jacquard        # default build: `build` cleanly absent (feature-gated)
+gh pr checks 167
 ```
 
 ## Done this session
 
-| PR / issue | What |
+| What | Where |
 |---|---|
-| **#163** (merged, `559f4766`) | README `## Input`; `docs/input-netlist.md` (full structural-Verilog subset + SVA status); ADR 0021 (Proposed) |
-| **#162** (open) | Implementation tracker — Phase 1 (`jacquard build`/YoWASP) + Phase 2 (`\src` provenance) |
+| ADR 0021 amended: Rust+wasmtime decision, abc-in-tree/in-process finding, Codeberg fork recipe, in-process-`\src` risk, Python-hosted alt rejected | `docs/adr/0021-behavioral-rtl-support.md` |
+| Spike preserved (reference) | `docs/spikes/rust-wasmtime-yosys/` |
+| `jacquard build` implementation | `src/synth.rs` (new), `src/bin/jacquard.rs` (`Build` subcmd, `cmd_build`), `src/lib.rs`, `Cargo.toml` (`synth` feature + wasmtime/anyhow/log deps) |
+| Repo-wide `cargo fmt` | separate commit on **`main`** (`49aa9cff`); branch rebased on it |
+| fmt-before-commit hook (needs `/hooks` reload to activate) | `.claude/settings.json` (gitignored) |
 
-## Open follow-ups (priority order)
+Validated: **counter** (logic+DFF), **assert_test** (→ `GEM_ASSERT`), **mem_test**
+(→ `RAMGEM`) all synthesize to aigpdk cells, zero leftover `$`-cells; outputs
+parse + build an AIG via `dump-paths`.
 
-### 1. Phase 1 — `jacquard build` via stock YoWASP (the on-ramp)
-Drive `yowasp-yosys` through `aigpdk/memlib_yosys.txt` + `aigpdk/aigpdk.lib`
-synthesis → `gatelevel.gv` → `sim`. Micro-decisions still open (see ADR 0021 /
-#162): command name (**`build`** chosen) vs `--rtl` flag; **Rust subcommand vs
-Python entry** (leaning Python, since YoWASP is a Python package and this homes in
-the Python engine — #161); how `--top-module` and clock-gating (`CKLNQD`) config
-surface. Back-end should be abstracted so it can dispatch to YoWASP wheel · Nix
-devshell · system Yosys/DC.
+## Critical context / decisions
 
-### 2. Phase 2 — `\src` provenance (the moat), gated on upstreaming
-Patched (self-built) YoWASP carrying origin-shell's source pass-through → thread
-`\src` through `netlistdb`/AIG so `--trace-signals` / timing / X-debug speak RTL.
-**Blocked on** berkeley-abc **#487** landing (in review) + a patched-YoWASP or Nix
-build. Not startable until #487 is in.
+- **Rust + wasmtime, not Python.** `yowasp_runtime` is a ~100-line `wasmtime`+WASI
+  harness; `src/synth.rs` ports it. `build` is a clap subcommand behind the opt-in
+  **`synth` feature** (wasmtime+cranelift are heavy to compile). Decoupled from the
+  #161 Python-engine decision.
+- **abc is compiled in-tree into `yosys.wasm`, called in-process** (WASI has no
+  `exec`) — verified from the shipped module. This de-risks Phase 2: the only
+  remaining `\src`-provenance unknown is whether `&origins` data survives the
+  *in-process* abc path (origin-shell only validated the **external**-abc path).
+- **Synthesis script** (`src/synth.rs::synth_script`): `read_verilog -sv` → flatten
+  → `memory_libmap` (memlib_yosys.txt) → `synth -run coarse:` → **`techmap -map
+  gem_formal.v`** (assertions → `GEM_ASSERT`; `--strip-assertions` uses `chformal
+  -remove`) → dfflibmap/abc to aigpdk. Support files embedded via `include_str!`.
+  Do **not** `read_verilog -lib aigpdk.v` — it fails to parse (`aigpdk.v:64`); cells
+  emit fine as blackboxes.
+- **wasm compile is cached** to `$XDG_CACHE_HOME/jacquard` by content hash
+  (`load_module`), so only the first run pays the (large, ~20 s) cranelift compile.
+  **Debug builds are ~50× slower to compile the wasm** — always test with
+  `--release`. cranelift's DEBUG log torrent is clipped to Info around the compile.
+- **wasm sourcing:** now via `--yosys-wasm` / `JACQUARD_YOSYS_WASM` / installed
+  `yowasp-yosys` discovery. Chosen fetch default = **GitHub release asset** (above).
+- **No `map` subcommand exists** (CLAUDE.md/docs references are stale) — use
+  `dump-paths` (no GPU) to validate a netlist parses.
+- **Non-synthesizable constructs:** testbench-only (`$display`, delays) dropped by
+  synth; immediate assertions → `GEM_ASSERT`; concurrent SVA limited by YoWASP
+  Yosys (no Verific) — broader SVA is the #106/#107 roadmap.
 
-## Critical context
+## Phase 2 (roadmap, unchanged, not started)
 
-- **YoWASP is already in `uv.lock`** (transitively via `amaranth[builtin-yosys]`
-  in `designs/mcu_soc_sky130/`), so Phase 1 adds *no new heavy dependency* — the
-  WASM Yosys wheel is already resolved for the workspace.
-- **QoR split is load-bearing:** YoWASP Yosys is functional-grade; **bring-your-own
-  DC stays the performance path** (synthesis quality sets Jacquard's GPU speed,
-  per `synthesis-flow.md`). Don't let `jacquard build` be mistaken for the fast
-  path — document both.
-- **origin-shell PoC** (for Phase 2) lives at `~/Code/ChipFlow/reference/origin-shell`
-  (GitHub `robtaylor/origin-shell`) — a Nix flake pinning patched abc (#487) +
-  yosys (`src-retention-y-ext`) + librelane (`SYNTH_ABC_BACKEND=origins`). It
-  keeps `\src` alive through std-cell mapping at ~100% coverage. Building *our
-  own* YoWASP lets us compile the patched abc to WASM alongside yosys, so
-  provenance can ship self-contained in one wheel.
-- **Emulator core untouched:** `jacquard build` is a *pre-processor* producing the
-  same structural netlist users synthesize by hand today. The AIG/boomerang
-  pipeline (ADR 0014/0015) and the structural `sverilogparse` input don't change.
-- **Home tie:** this lands in the Python engine, whose *packaging* decision
-  (subprocess wheel vs PyO3) is itself deferred — ADR 0020 is **Draft**, tracked
-  in [#161](https://github.com/gpu-eda/Jacquard/issues/161) (PyO3 leaning). Phase 1
-  doesn't need that resolved, but the two share the Python layer.
+`\src` provenance: fork [YoWASP/yosys](https://codeberg.org/YoWASP/yosys) (now on
+Codeberg; GitHub mirror archived 2026-03-11), repoint `yosys-src` →
+`robtaylor/yosys@src-retention-y-ext` and yosys's bundled `abc` submodule →
+`robtaylor/abc@origin-tracking-clean` (abc#487), rerun `build.sh` (wasi-sdk 27).
+**First task = spike whether `\src` survives in-process abc** before committing.
+
+## Follow-ups not yet filed
+- CI `--features synth` coverage (see next-up #2) — **most important**, feature
+  ships in no binary until done.
+- Stale `jacquard map` references in `CLAUDE.md` / `docs/`.
+- Activate the fmt hook (`.claude/settings.json`) via `/hooks` reload.
 
 ## References
-
-- [ADR 0021](../adr/0021-behavioral-rtl-support.md) — the decision (+ Nix
-  alternative, Phase-2 provenance).
-- [#162](https://github.com/gpu-eda/Jacquard/issues/162) — implementation tracker.
-- [`docs/synthesis-flow.md`](../synthesis-flow.md) — the manual flow `jacquard build` wraps.
-- [`docs/input-netlist.md`](../input-netlist.md) — what the netlist input accepts today.
-- [ADR 0014](../adr/0014-aig-as-simulation-ir.md) — why synthesis is a front-end.
-- #161 / ADR 0020 — the Python engine that hosts this. berkeley-abc #487 — the Phase-2 gate.
+- [ADR 0021](../adr/0021-behavioral-rtl-support.md) · [#162](https://github.com/gpu-eda/Jacquard/issues/162) · PR [#167](https://github.com/gpu-eda/Jacquard/pull/167)
+- [`docs/spikes/rust-wasmtime-yosys/`](../spikes/rust-wasmtime-yosys/) — the proving spike
+- [`docs/synthesis-flow.md`](../synthesis-flow.md) · [`docs/input-netlist.md`](../input-netlist.md)
+- Assertion techmap: `aigpdk/gem_formal.v`; GEM_ASSERT cell: `aigpdk/aigpdk.v:174`, `src/aigpdk.rs:52,91`
 
 ---
-
-**Resume in a new session with:**
-```
-/resume_handoff docs/handoffs/adr-0021-behavioral-rtl-handoff.md
-```
+**Resume with:** `/resume_handoff docs/handoffs/adr-0021-behavioral-rtl-handoff.md`

--- a/docs/handoffs/adr-0021-behavioral-rtl-handoff.md
+++ b/docs/handoffs/adr-0021-behavioral-rtl-handoff.md
@@ -26,7 +26,7 @@ and in the working tree for human review.
 3. **Phase 4 follow-ups** (not gating, tracked in `docs/plans/rtl-onramp-sim-integration.md`):
    - Fetch `yosys.wasm` from GitHub release asset automatically on first use (ADR 0018 / #162 increment 2).
    - `--synth-target sky130|gf180` — synthesize to a real PDK for timing-accurate on-ramp runs.
-   - Wire `TimingLibrary::from_cell_model_ir` onto the runtime timing path (ADR 0019 C2 / `--corner` on-ramp timing).
+   - ~~Wire `TimingLibrary::from_cell_model_ir` onto the runtime timing path~~ — **landed on `main`** (`de8255f3`, ADR 0019 D5); `--corner` on-ramp timing for built-in PDKs is now live.
    - Empirical SV/Verilog coverage table via sv-tests — makes `docs/accepted-rtl.md` authoritative rather than prose.
 
 **Verification (Phases 1+2, already committed):**

--- a/docs/handoffs/adr-0021-behavioral-rtl-handoff.md
+++ b/docs/handoffs/adr-0021-behavioral-rtl-handoff.md
@@ -1,100 +1,139 @@
-# Handoff — ADR 0021 behavioral-RTL on-ramp (`jacquard build`)
+# Handoff — ADR 0021 behavioral-RTL on-ramp (folded into `sim`/`cosim`)
 
-**Updated:** 2026-07-03
-**Branch:** `feat/rtl-onramp-build` (PR [#167](https://github.com/gpu-eda/Jacquard/pull/167), **draft**, CI green)
-**Working tree:** clean (only `.env` untracked)
+**Updated:** 2026-07-04
+**Branch:** `feat/rtl-onramp-build` (PR [#167](https://github.com/gpu-eda/Jacquard/pull/167), draft)
+**Working tree:** Phase 3 doc changes uncommitted (human review requested); code is clean
 
 ## Goal & next-up
 
-**This session:** implemented **Phase 1** of ADR 0021 / [#162](https://github.com/gpu-eda/Jacquard/issues/162)
-— `jacquard build <design.v…>` synthesizes behavioral RTL → gate-level aigpdk
-netlist that feeds `sim`/`cosim`, with **no Python and no external toolchain**.
-Shipped on PR #167 (draft, CI green on the branch and on `main`). The ADR was
-amended to record the **Rust + `wasmtime`** shape (was "Python-hosted").
+**Goal:** Behavioral Verilog / SystemVerilog becomes a first-class one-command input —
+`jacquard sim design.v in.vcd out.vcd N` detects behavioral RTL, synthesizes it
+transparently via embedded YoWASP Yosys, and simulates. No `build` step, no Python,
+no external toolchain.
 
-**Next session should pick up** (priority order):
-1. **Un-draft PR #167** and get it reviewed/merged (nothing blocking; CI green).
-2. **CI coverage for the `synth` feature** — it's opt-in (not default), so current
-   CI (`cargo test --lib`, `cargo build -r --bin jacquard`) never compiles it. Add
-   a `cargo build --features synth` job + a `jacquard build` smoke test, and add
-   `--features synth` to `release.yml` / `user-acceptance.yml` so shipped binaries
-   include the on-ramp. **Without this the feature ships in no binary.**
-3. **Fetch-from-GitHub-release** (increment 2): publish the pinned `yosys.wasm` as
-   a Jacquard release asset; `build` fetches to `$XDG_CACHE_HOME/jacquard` + sha256.
-   Same mechanism will later deliver the Phase-2 patched wasm. Aligns with ADR 0018.
+**Phases 1 and 2 are done and committed on this branch** (CI green). Phase 3
+(documentation) is in progress — the changes from this session are uncommitted
+and in the working tree for human review.
 
-**Verification:**
+**Next session should pick up (priority order):**
+
+1. **Review and commit Phase 3 doc changes.** Files changed this session:
+   `docs/accepted-rtl.md` (new), `docs/getting-started.md`, `docs/installation.md`,
+   `CLAUDE.md`, `docs/synthesis-flow.md`, `docs/plans/cell-model-ir.md`,
+   this handoff. Human review first; then commit.
+2. **Un-draft PR #167** and request review / merge. Nothing blocking; CI is green
+   on the branch.
+3. **Phase 4 follow-ups** (not gating, tracked in `docs/plans/rtl-onramp-sim-integration.md`):
+   - Fetch `yosys.wasm` from GitHub release asset automatically on first use (ADR 0018 / #162 increment 2).
+   - `--synth-target sky130|gf180` — synthesize to a real PDK for timing-accurate on-ramp runs.
+   - Wire `TimingLibrary::from_cell_model_ir` onto the runtime timing path (ADR 0019 C2 / `--corner` on-ramp timing).
+   - Empirical SV/Verilog coverage table via sv-tests — makes `docs/accepted-rtl.md` authoritative rather than prose.
+
+**Verification (Phases 1+2, already committed):**
 ```sh
-# feature builds + runs (needs a yosys.wasm; e.g. from an installed yowasp-yosys wheel):
-cargo build --release --features synth --bin jacquard
-JACQUARD_YOSYS_WASM=<path/to/yosys.wasm> \
-  ./target/release/jacquard build <design.v> -o /tmp/gl.gv     # → aigpdk netlist
-./target/release/jacquard dump-paths /tmp/gl.gv --liberty aigpdk/aigpdk.lib   # parses → AIG
-cargo build --bin jacquard        # default build: `build` cleanly absent (feature-gated)
+# RTL synthesis + simulation (needs yosys.wasm):
+JACQUARD_YOSYS_WASM=/path/to/yosys.wasm \
+  cargo run -r --features metal,synth --bin jacquard -- \
+    sim tests/counter/counter.v tests/counter/in.vcd /tmp/out.vcd 1
+# Expect: "behavioral RTL → synthesized [YoWASP Yosys, functional QoR]"
+
+# Confirm no `build` subcommand:
+cargo run -r --bin jacquard -- build 2>&1 | grep -i "unrecognized\|error" || true
+
+# CI:
 gh pr checks 167
 ```
 
-## Done this session
+## Done this session (Phases 1 + 2, committed)
 
 | What | Where |
 |---|---|
-| ADR 0021 amended: Rust+wasmtime decision, abc-in-tree/in-process finding, Codeberg fork recipe, in-process-`\src` risk, Python-hosted alt rejected | `docs/adr/0021-behavioral-rtl-support.md` |
+| ADR 0021 amended: no standalone `build` command; synthesis folds into `sim`/`cosim`; Rust+wasmtime decision recorded | `docs/adr/0021-behavioral-rtl-support.md` |
+| `Build` subcommand removed; `resolve_netlist_input` classifier added | `src/bin/jacquard.rs`, `src/sim/setup.rs` |
+| `--rtl`, `--netlist`, `--emit-synth` flags added to `SimArgs` and `CosimArgs` | `src/bin/jacquard.rs` |
+| CI `--features synth` build + behavioral smoke test added; `synth` added to `release.yml` / `user-acceptance.yml` (Phase 2) | `.github/workflows/` |
+| Phase 3 doc changes (not yet committed — this session) | `docs/accepted-rtl.md` (new), `docs/getting-started.md`, `docs/installation.md`, `CLAUDE.md`, `docs/synthesis-flow.md`, `docs/plans/cell-model-ir.md` |
+
+Earlier session (initial implementation — `src/synth.rs` engine):
+
+| What | Where |
+|---|---|
+| Embedded Yosys synthesis engine (wasmtime, wasm caching, `read_slang` probe) | `src/synth.rs` |
+| Synthesis script: slang/read_verilog → memory → assertions → aigpdk | `src/synth.rs::synth_script` |
 | Spike preserved (reference) | `docs/spikes/rust-wasmtime-yosys/` |
-| `jacquard build` implementation | `src/synth.rs` (new), `src/bin/jacquard.rs` (`Build` subcmd, `cmd_build`), `src/lib.rs`, `Cargo.toml` (`synth` feature + wasmtime/anyhow/log deps) |
-| Repo-wide `cargo fmt` | separate commit on **`main`** (`49aa9cff`); branch rebased on it |
-| fmt-before-commit hook (needs `/hooks` reload to activate) | `.claude/settings.json` (gitignored) |
+| Validated: counter, assert_test, mem_test synthesize to aigpdk — zero leftover `$`-cells | tests/ |
 
-Validated: **counter** (logic+DFF), **assert_test** (→ `GEM_ASSERT`), **mem_test**
-(→ `RAMGEM`) all synthesize to aigpdk cells, zero leftover `$`-cells; outputs
-parse + build an AIG via `dump-paths`.
+## Critical context
 
-## Critical context / decisions
+**RTL detection heuristic.** `sverilogparse` is a structural-only parser;
+behavioral constructs (`always`, arithmetic/logic operators in `assign`,
+`if`/`case`) cause parse failure, which routes to synthesis. Pure net-alias
+`assign`s and `wire` decls parse structurally (they appear in gate-level too)
+and do not trigger synthesis. Use `--rtl` to force synthesis if detection
+misclassifies; use `--netlist` to force direct gate-level loading.
 
-- **Rust + wasmtime, not Python.** `yowasp_runtime` is a ~100-line `wasmtime`+WASI
-  harness; `src/synth.rs` ports it. `build` is a clap subcommand behind the opt-in
-  **`synth` feature** (wasmtime+cranelift are heavy to compile). Decoupled from the
-  #161 Python-engine decision.
-- **abc is compiled in-tree into `yosys.wasm`, called in-process** (WASI has no
-  `exec`) — verified from the shipped module. This de-risks Phase 2: the only
-  remaining `\src`-provenance unknown is whether `&origins` data survives the
-  *in-process* abc path (origin-shell only validated the **external**-abc path).
-- **Synthesis script** (`src/synth.rs::synth_script`): `read_verilog -sv` → flatten
-  → `memory_libmap` (memlib_yosys.txt) → `synth -run coarse:` → **`techmap -map
-  gem_formal.v`** (assertions → `GEM_ASSERT`; `--strip-assertions` uses `chformal
-  -remove`) → dfflibmap/abc to aigpdk. Support files embedded via `include_str!`.
-  Do **not** `read_verilog -lib aigpdk.v` — it fails to parse (`aigpdk.v:64`); cells
-  emit fine as blackboxes.
-- **wasm compile is cached** to `$XDG_CACHE_HOME/jacquard` by content hash
-  (`load_module`), so only the first run pays the (large, ~20 s) cranelift compile.
-  **Debug builds are ~50× slower to compile the wasm** — always test with
-  `--release`. cranelift's DEBUG log torrent is clipped to Info around the compile.
-- **wasm sourcing:** now via `--yosys-wasm` / `JACQUARD_YOSYS_WASM` / installed
-  `yowasp-yosys` discovery. Chosen fetch default = **GitHub release asset** (above).
-- **No `map` subcommand exists** (CLAUDE.md/docs references are stale) — use
-  `dump-paths` (no GPU) to validate a netlist parses.
-- **Non-synthesizable constructs:** testbench-only (`$display`, delays) dropped by
-  synth; immediate assertions → `GEM_ASSERT`; concurrent SVA limited by YoWASP
-  Yosys (no Verific) — broader SVA is the #106/#107 roadmap.
+**Wasm sourcing.** `sim`/`cosim` locate `yosys.wasm` in priority order:
+`--yosys-wasm <path>` flag → `JACQUARD_YOSYS_WASM` env var → installed
+`yowasp-yosys` Python package (`pip install yowasp-yosys`). The `--yosys-wasm`
+flag was added this session (Phase 3 review) — the field was already plumbed
+(`InputDispatch.yosys_wasm` → `SynthOptions` → `locate_yosys_wasm`) but the two
+`cmd_sim`/`cmd_cosim` construction sites hardcoded `None`; they now read
+`args.yosys_wasm`. The `src/synth.rs` error message ("Pass `--yosys-wasm <path>`,
+set `JACQUARD_YOSYS_WASM`, …") is now accurate. Fetch-from-release is a Phase 4
+item.
 
-## Phase 2 (roadmap, unchanged, not started)
+**`read_slang` (yosys-slang).** Probed once at startup via `help read_slang`.
+Pinned wasm `yowasp-yosys 0.64.0.0.post1131` includes it (verified: `read_slang`
++ 495 `slang` symbols in the 39 MB module). Older wasm modules fall back to
+`read_verilog -sv` gracefully.
 
-`\src` provenance: fork [YoWASP/yosys](https://codeberg.org/YoWASP/yosys) (now on
-Codeberg; GitHub mirror archived 2026-03-11), repoint `yosys-src` →
-`robtaylor/yosys@src-retention-y-ext` and yosys's bundled `abc` submodule →
-`robtaylor/abc@origin-tracking-clean` (abc#487), rerun `build.sh` (wasi-sdk 27).
-**First task = spike whether `\src` survives in-process abc** before committing.
+**Synthesis script.** `read_slang|read_verilog -sv` → `hierarchy` → flatten +
+proc + memory → `memory_libmap` (memlib_yosys.txt, RAMGEM) → `synth -run coarse:`
+→ `techmap -map gem_formal.v` (maps `$check`/`$assert`/`$assume` → `GEM_ASSERT`,
+`$print`/`$display` → `GEM_DISPLAY`, `$cover` → silently dropped) → dfflibmap +
+abc (aigpdk_nomem.lib) → `write_verilog gatelevel.gv`. Techmap rules verified in
+`aigpdk/gem_formal.v`.
 
-## Follow-ups not yet filed
-- CI `--features synth` coverage (see next-up #2) — **most important**, feature
-  ships in no binary until done.
-- Stale `jacquard map` references in `CLAUDE.md` / `docs/`.
-- Activate the fmt hook (`.claude/settings.json`) via `/hooks` reload.
+**Wasm caching.** Compiled WASM module cached under `$XDG_CACHE_HOME/jacquard`
+by content hash; first run pays ~20 s cranelift compile. Debug builds are ~50×
+slower — always use `--release` for testing. The synthesized netlist is also
+cached (keyed by design source + script + wasm hash), so repeat `sim` runs skip
+synthesis.
+
+**`dump-paths`, not `map`.** There is no `map` subcommand. To validate that a
+netlist parses and inspect its timing paths (no GPU needed), use
+`jacquard dump-paths <netlist> --liberty aigpdk/aigpdk.lib`.
+
+**Actual error messages from `src/sim/setup.rs`:**
+- Unknown cells (gate-level, not synthesized): `"gate-level netlist with unrecognized cell type(s): {cells}. This is already a netlist (not behavioral RTL)… Pass \`--cell-descriptor <path>\` (ADR 0019)…"`
+- Both structural parse and synthesis fail: `"could not load as a gate-level netlist, and synthesizing it as behavioral RTL also failed"` (both errors surfaced).
+- Synth path but binary built without `--features synth`: `"input looks like behavioral RTL, but this jacquard binary was built without synthesis support. Rebuild with \`--features synth\`…"`
+- Success log line: `"{}: behavioral RTL → synthesized [YoWASP Yosys, functional QoR] → {}"`
+
+**abc is compiled in-tree into `yosys.wasm`, called in-process** — WASI has no
+`exec`. This matters for the ADR 0021 Phase 2 provenance spike: whether `\src`
+data survives the in-process abc path is unproven and is the first thing to spike.
+
+## ADR 0021 Phase 2 — `\src` provenance (unchanged, separate)
+
+Fork [YoWASP/yosys](https://codeberg.org/YoWASP/yosys) (GitHub mirror archived
+2026-03-11), repoint `yosys-src` → `robtaylor/yosys@src-retention-y-ext` and
+bundled abc submodule → `robtaylor/abc@origin-tracking-clean` (abc#487), rerun
+`build.sh` (wasi-sdk 27). First task = spike whether `\src` survives in-process
+abc before committing to the WASM build effort.
 
 ## References
-- [ADR 0021](../adr/0021-behavioral-rtl-support.md) · [#162](https://github.com/gpu-eda/Jacquard/issues/162) · PR [#167](https://github.com/gpu-eda/Jacquard/pull/167)
-- [`docs/spikes/rust-wasmtime-yosys/`](../spikes/rust-wasmtime-yosys/) — the proving spike
-- [`docs/synthesis-flow.md`](../synthesis-flow.md) · [`docs/input-netlist.md`](../input-netlist.md)
-- Assertion techmap: `aigpdk/gem_formal.v`; GEM_ASSERT cell: `aigpdk/aigpdk.v:174`, `src/aigpdk.rs:52,91`
+
+- [ADR 0021](../adr/0021-behavioral-rtl-support.md) — the decision (Decision §1 dispatch table, Consequences accepted-RTL surface)
+- [Plan: RTL on-ramp sim integration](../plans/rtl-onramp-sim-integration.md) — Phase 4 roadmap
+- [Accepted RTL surface](../accepted-rtl.md) — user-facing doc (new, Phase 3)
+- [#162](https://github.com/gpu-eda/Jacquard/issues/162) · PR [#167](https://github.com/gpu-eda/Jacquard/pull/167)
+- Assertion techmap: `aigpdk/gem_formal.v`; GEM_ASSERT: `aigpdk/aigpdk.v:174`, `src/aigpdk.rs:52,91`
+- Spike reference: `docs/spikes/rust-wasmtime-yosys/`
 
 ---
-**Resume with:** `/resume_handoff docs/handoffs/adr-0021-behavioral-rtl-handoff.md`
+
+**Resume in a new session with:**
+```
+/resume_handoff docs/handoffs/adr-0021-behavioral-rtl-handoff.md
+```

--- a/docs/input-netlist.md
+++ b/docs/input-netlist.md
@@ -5,7 +5,7 @@
 Jacquard is a gate-level **emulator** — it maps a *synthesized* and-inverter
 graph onto a virtual manycore GPU processor (see
 [ADR 0014](adr/0014-aig-as-simulation-ir.md)). So the direct input to
-`jacquard sim` / `cosim` / `map` is a **gate-level Verilog netlist**: structural
+`jacquard sim` / `cosim` is a **gate-level Verilog netlist**: structural
 Verilog whose leaf cells are `aigpdk`, SKY130, or GF180MCU standard cells.
 
 **Behavioral RTL is the intended design input — via a synthesis step.** You

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,8 @@ brew install gpu-eda/tap/jacquard      # installs jacquard + opensta-to-ir
 ```
 
 The cleanest path on a Mac. Requires an Apple Silicon machine with a
-Metal GPU.
+Metal GPU. The Homebrew formula is built with `--features synth`, so
+behavioral RTL input works out of the box — see [Accepted RTL surface](accepted-rtl.md).
 
 ### cargo binstall — prebuilt binary, no toolchain build
 
@@ -40,6 +41,9 @@ straight from the repo rather than looking the crate up on the registry.
 Linux is **not** binstall-able: there are two GPU backends (CUDA, HIP) for
 one target triple, so it can't be auto-selected — use the release tarball
 for your backend, a container, or build from source.
+
+Release binaries are built with `--features synth` and support behavioral RTL
+input directly.
 
 > **Runtime dependency — Homebrew LLVM.** The prebuilt macOS binary links
 > Homebrew LLVM's `libc++` and `libomp` (the build uses LLVM clang for
@@ -67,13 +71,39 @@ git clone https://github.com/gpu-eda/Jacquard.git
 cd Jacquard
 git submodule update --init --recursive
 
-cargo build -r --features metal --bin jacquard   # macOS / Apple Silicon
-cargo build -r --features cuda  --bin jacquard   # NVIDIA (CUDA toolkit)
-cargo build -r --features hip   --bin jacquard   # AMD (ROCm)
+cargo build -r --features metal --bin jacquard         # macOS / Apple Silicon
+cargo build -r --features cuda  --bin jacquard         # NVIDIA (CUDA toolkit)
+cargo build -r --features hip   --bin jacquard         # AMD (ROCm)
 ```
 
 The binary lands at `target/release/jacquard`. See the README's
 *Dependencies* table for optional tooling (`flatc`, `mdbook`, OpenSTA).
+
+**Behavioral RTL on-ramp** (`jacquard sim design.v …`) requires the `synth`
+feature (embedded YoWASP Yosys engine). Add it to your build:
+
+```sh
+cargo build -r --features metal,synth --bin jacquard   # macOS + RTL synthesis
+cargo build -r --features cuda,synth  --bin jacquard   # NVIDIA + RTL synthesis
+cargo build -r --features hip,synth   --bin jacquard   # AMD + RTL synthesis
+```
+
+A binary built without `synth` still simulates pre-synthesized gate-level
+netlists; it gives an actionable error if handed behavioral RTL.
+
+**Providing `yosys.wasm` for RTL synthesis** — the synth engine needs the
+YoWASP Yosys wasm module. Discovery order:
+
+1. **`--yosys-wasm <path>`** flag on `sim`/`cosim` (overrides the rest).
+2. **`JACQUARD_YOSYS_WASM=/path/to/yosys.wasm`** environment variable.
+3. **Installed `yowasp-yosys`** Python package, found automatically:
+   ```sh
+   pip install yowasp-yosys
+   ```
+4. Fetch-from-release is a planned follow-up (not yet implemented).
+
+Prebuilt and Homebrew binaries include the `synth` feature; the wasm is still
+found via the flag, env var, or installed Python package until auto-fetch ships.
 
 ## The signal-analysis companion (`netlist-graph`)
 
@@ -108,5 +138,6 @@ jacquard cosim tests/apb_trace/apb_trace_synth.gv \
     --bus-trace-csv /tmp/apb.csv
 ```
 
-Then head to [Getting Started](getting-started.md) to run bundled designs, or the
-[Synthesis Flow](synthesis-flow.md) to prepare your own RTL.
+Then head to [Getting Started](getting-started.md) to run bundled designs,
+[Accepted RTL surface](accepted-rtl.md) to simulate your own behavioral RTL,
+or [Synthesis Flow](synthesis-flow.md) to prepare a high-QoR gate-level netlist.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -31,6 +31,7 @@ persistent plans here.
 | [Multi-clock and stimulus architecture](multi-clock-and-stimulus-architecture.md) | Exploratory — demand-driven |
 | [Cosim backend portability](cosim-backend-portability.md) | Active — design captured (#105); see ADR 0017 amendment |
 | [Cell-model IR](cell-model-ir.md) | Proposed — realises ADR 0019 (#130, #67) |
+| [RTL on-ramp folded into `sim`/`cosim`](rtl-onramp-sim-integration.md) | Active — reworks #167, realises ADR 0021 (#162) |
 
 ## Reading order for new contributors
 

--- a/docs/plans/rtl-onramp-sim-integration.md
+++ b/docs/plans/rtl-onramp-sim-integration.md
@@ -66,6 +66,13 @@ present.
   cached gate-level `.gv` path. Cache keyed by content hash of (design sources +
   synth script + yosys.wasm hash), under `$XDG_CACHE_HOME/jacquard` alongside the
   compiled-module cache.
+- **Use `read_slang` for the SV frontend.** The pinned `yowasp-yosys
+  0.64.0.0.post1131` wasm bundles **yosys-slang** (verified: `read_slang` +
+  495 `slang` symbols in the 39 MB module) — a near-complete SV-2017 elaborator,
+  far beyond built-in `read_verilog -sv`. Update `synth_script` to front SV input
+  with `read_slang` (fall back to `read_verilog -sv` if `read_slang` errors or is
+  absent in an older wasm — probe `help read_slang` once and cache the result, so
+  the on-ramp degrades gracefully on a pre-slang module).
 - Add the input-dispatch classifier (above) to the shared `sim`/`cosim` netlist
   load path.
 - Add CLI flags to `SimArgs` / `CosimArgs`: `--emit-synth <path>` (dump the
@@ -105,18 +112,20 @@ the feature; green on the branch.
   any `synthesis-flow.md` cross-links to the single-command story.
 - **Write `docs/accepted-rtl.md` — the accepted behavioral-RTL surface.** The
   honest framing: what `sim`/`cosim` accept as behavioral input is exactly what
-  the embedded **YoWASP Yosys `read_verilog -sv` frontend synthesizes** (no
-  Verific in the open-source build), *plus* the project's techmaps and *minus*
-  testbench-only constructs. Document:
-  - **Supported (delegated to Yosys):** synthesizable Verilog-2005 + the Yosys
-    SystemVerilog subset (packages, structs/enums, `always_ff`/`always_comb`,
-    parameters, generate, memories).
+  the embedded **YoWASP Yosys frontend synthesizes** — and that frontend bundles
+  **yosys-slang** (`read_slang`, verified in the pinned 0.64 wasm), *plus* the
+  project's techmaps and *minus* testbench-only constructs. Document:
+  - **Supported (delegated to Yosys + slang):** synthesizable Verilog-2005 and a
+    broad **SystemVerilog-2017** surface via slang (packages, interfaces,
+    structs/enums, `always_ff`/`always_comb`, parameters, advanced generate,
+    memories) — not the narrow built-in `read_verilog -sv` subset.
   - **Project-specific mappings:** immediate assertions → `GEM_ASSERT`
     (`--strip-assertions` removes via `chformal`); `$display` → `GEM_DISPLAY`;
     inferred memories → `RAMGEM` via `memlib_yosys.txt`.
-  - **Known limits:** no Verific → **concurrent SVA is limited** (see #106/#107
-    roadmap); testbench-only constructs (`$display`-as-TB, `#delays`, most
-    `initial`) are dropped by synthesis, not simulated.
+  - **Known limits:** **concurrent-SVA → checker synthesis is partial** (a Yosys
+    formal-flow bound, *independent* of slang's parsing; #106/#107);
+    testbench-only constructs (`#delays`, most `initial`, TB `$display`) are
+    dropped by synthesis, not simulated.
   - State plainly that the *authoritative* accepted-surface is the empirical
     coverage table (Phase 4), not this prose — prose is the orientation.
   - Cross-link from `getting-started.md`.

--- a/docs/plans/rtl-onramp-sim-integration.md
+++ b/docs/plans/rtl-onramp-sim-integration.md
@@ -141,6 +141,13 @@ ceremony; `map`/`build` stale refs gone.
 
 ### Phase 4 — Follow-ups (deferred, not gating)
 
+- **Load exception-handling wasm** — newer `yowasp-yosys` wheels build the wasm
+  with the WebAssembly exception-handling proposal, which our `wasmtime` engine
+  (`Engine::default()`, no `gc` feature) rejects: *"exception refs not supported
+  without the exception handling feature."* `Config::wasm_exceptions(true)` exists
+  but is `#[cfg(feature = "gc")]`, so it needs the `gc` feature **and** a spike
+  confirming wasm-EH actually *runs* yosys (not just parses). Until then CI + docs
+  pin `yowasp-yosys==0.64.0.0.post1131`. Removing that pin is the exit criterion.
 - **Fetch `yosys.wasm` from GitHub release** (increment 2, ADR 0018): publish the
   pinned wasm as a Jacquard release asset; first behavioral run fetches to cache
   + sha256-verifies.

--- a/docs/plans/rtl-onramp-sim-integration.md
+++ b/docs/plans/rtl-onramp-sim-integration.md
@@ -1,0 +1,161 @@
+# Plan — RTL on-ramp folded into `sim`/`cosim`
+
+**Status:** Active — reworks draft PR [#167](https://github.com/gpu-eda/Jacquard/pull/167)
+
+**ADRs:** [0021](../adr/0021-behavioral-rtl-support.md) (Revised 2026-07-03 —
+synth folds into `sim`/`cosim`, no `build` command), aligns with
+[0019](../adr/0019-cell-model-ir.md) (descriptor-supplied logic + timing) and
+[0018](../adr/0018-distribution-and-installation.md) (wasm distribution).
+
+**Predecessors:** #167 shipped the `src/synth.rs` embedded-Yosys engine and a
+`jacquard build` subcommand + `synth` feature (CI green, draft). This plan keeps
+the engine and **removes the standalone command**, wiring synthesis into the
+simulation input path instead.
+
+**Tracking:** [#162](https://github.com/gpu-eda/Jacquard/issues/162).
+
+---
+
+## Goal
+
+Behavioral RTL becomes a first-class **one-command** input:
+`jacquard sim design.v in.vcd out.vcd N` (and the `cosim` equivalent) detects
+behavioral RTL, synthesizes it transparently to an aigpdk netlist (cached), and
+simulates — no separate `build` step, no Python, no external toolchain. A
+pre-synthesized netlist continues to simulate unchanged.
+
+## Input dispatch (the core behaviour — ADR 0021 §1)
+
+On the netlist-input path of `sim`/`cosim`:
+
+1. Attempt structural parse (`NetlistDB::from_sverilog_file`).
+2. **Parse succeeds** → enumerate instantiated cells, test against the built-in
+   stdcell recognizers (the `is_*_stdcell` helpers introduced by #160 / ADR 0019):
+   - **All recognized** → gate-level, built-in PDK → **simulate directly.**
+     Logic + timing come from the embedded descriptor (`--corner`); no `.lib`.
+   - **Any unrecognized** → gate-level, unknown PDK → **error**, listing the
+     unrecognized cell types: *"gate-level netlist with unrecognized cells —
+     pass `--cell-descriptor <path>`"* (ADR 0019 D8). **Do not synthesize.**
+3. **Parse fails** → treat as behavioral → **synthesize** (embedded Yosys) →
+   parse the result → simulate. If synthesis *also* fails, surface **both** the
+   structural parse error and the Yosys diagnostics (a genuine netlist syntax
+   error must not masquerade as "tried to synthesize your RTL").
+
+**Overrides:** `--rtl` forces the synth path; `--netlist` forces
+direct-structural (skip detection). **Transparency:** always print the decision,
+including the QoR tier on the synth path (e.g.
+`design.v: behavioral RTL → synthesized [YoWASP Yosys, functional QoR] → <cache>`).
+
+> Detection is a heuristic on a structural-only parser; the explicit flags are
+> the escape hatch. Pure net-alias `assign`s parse structurally (they occur in
+> gate-level too) — only real behavioral constructs (`always`, arithmetic/logic
+> `assign`, `if`/`case`) trip the parse and route to synth. Confirm the exact
+> `is_*_stdcell` API against `src/` during Phase 1 (do not assume names).
+
+---
+
+## Phases
+
+### Phase 1 — Fold synth into `sim`/`cosim`; remove `build`
+
+**Entry:** #167 branch (`feat/rtl-onramp-build`), `synth` feature + `src/synth.rs`
+present.
+
+- Extract the synthesis invocation from `cmd_build` into a reusable
+  `synth::synthesize(design: &Path, opts) -> Result<PathBuf>` returning the
+  cached gate-level `.gv` path. Cache keyed by content hash of (design sources +
+  synth script + yosys.wasm hash), under `$XDG_CACHE_HOME/jacquard` alongside the
+  compiled-module cache.
+- Add the input-dispatch classifier (above) to the shared `sim`/`cosim` netlist
+  load path.
+- Add CLI flags to `SimArgs` / `CosimArgs`: `--emit-synth <path>` (dump the
+  intermediate netlist), `--rtl`, `--netlist`.
+- **Delete** `Build`, `BuildArgs`, `cmd_build` from `src/bin/jacquard.rs`.
+- Graceful message when the binary is built without `--features synth` and given
+  behavioral input: point at the synth-enabled build / release binary.
+
+**Exit:** `jacquard sim counter.v in.vcd out.vcd 1 --features synth` runs
+end-to-end (behavioral → waves); the three #167 validation designs (counter,
+assert_test, mem_test) simulate from RTL directly; a gate-level fixture still
+simulates with the feature **off**; an unknown-cell netlist errors toward
+`--cell-descriptor`; `--emit-synth` writes a parseable `.gv`; no `build`
+subcommand exists.
+
+### Phase 2 — CI coverage + distribution (blocking: feature ships in no binary)
+
+**Entry:** Phase 1 merged to the branch.
+
+- Add `--features synth` to `release.yml` and `user-acceptance.yml` so shipped
+  binaries include the on-ramp.
+- Add a CI job to `ci.yml`: `cargo build --release --features synth` + a
+  `jacquard sim <behavioral.v>` smoke run. Resolve `yosys.wasm` sourcing in CI
+  (install a pinned `yowasp-yosys` wheel and discover it, matching local
+  verification; or fetch the release asset once increment 2 lands).
+- Confirm `--features synth` compile time is tolerable in CI (cache the cranelift
+  build if needed).
+
+**Exit:** CI proves `sim` consumes behavioral RTL; release/UA binaries contain
+the feature; green on the branch.
+
+### Phase 3 — Docs + stale-reference cleanup
+
+**Entry:** Phases 1–2 green.
+
+- Rewrite the RTL flow in `docs/getting-started.md`, `docs/installation.md`, and
+  any `synthesis-flow.md` cross-links to the single-command story.
+- **Write `docs/accepted-rtl.md` — the accepted behavioral-RTL surface.** The
+  honest framing: what `sim`/`cosim` accept as behavioral input is exactly what
+  the embedded **YoWASP Yosys `read_verilog -sv` frontend synthesizes** (no
+  Verific in the open-source build), *plus* the project's techmaps and *minus*
+  testbench-only constructs. Document:
+  - **Supported (delegated to Yosys):** synthesizable Verilog-2005 + the Yosys
+    SystemVerilog subset (packages, structs/enums, `always_ff`/`always_comb`,
+    parameters, generate, memories).
+  - **Project-specific mappings:** immediate assertions → `GEM_ASSERT`
+    (`--strip-assertions` removes via `chformal`); `$display` → `GEM_DISPLAY`;
+    inferred memories → `RAMGEM` via `memlib_yosys.txt`.
+  - **Known limits:** no Verific → **concurrent SVA is limited** (see #106/#107
+    roadmap); testbench-only constructs (`$display`-as-TB, `#delays`, most
+    `initial`) are dropped by synthesis, not simulated.
+  - State plainly that the *authoritative* accepted-surface is the empirical
+    coverage table (Phase 4), not this prose — prose is the orientation.
+  - Cross-link from `getting-started.md`.
+- Fix stale `jacquard map` references (`CLAUDE.md`, docs) → `dump-paths`.
+- Correct the `docs/plans/cell-model-ir.md` "Status: Proposed — not started"
+  header (C3 partly shipped via #160); note L4-descriptor projection exists but
+  is not yet on the runtime timing path.
+- Update `docs/handoffs/adr-0021-behavioral-rtl-handoff.md` (or resolve/fold it
+  per handoff-discipline once this ships).
+
+**Exit:** No doc describes a `jacquard build` command or the old multi-tool
+ceremony; `map`/`build` stale refs gone.
+
+### Phase 4 — Follow-ups (deferred, not gating)
+
+- **Fetch `yosys.wasm` from GitHub release** (increment 2, ADR 0018): publish the
+  pinned wasm as a Jacquard release asset; first behavioral run fetches to cache
+  + sha256-verifies.
+- **`--synth-target sky130|gf180`** — synthesize to a real PDK (uses #160
+  descriptors) for timing-accurate on-ramp runs.
+- **Empirical SV/Verilog coverage table** — turn the `docs/accepted-rtl.md`
+  prose surface into a measured pass/fail matrix by running
+  [SymbiFlow/sv-tests](https://github.com/SymbiFlow/sv-tests) (or a curated
+  subset) through the embedded YoWASP Yosys frontend and recording which
+  constructs synthesize. Because the accepted surface *is* the Yosys frontend,
+  this is the only trustworthy way to enumerate it (vs hand-claiming a feature
+  list). Publish the table into `docs/accepted-rtl.md`; automatable as a CI job
+  so the coverage claim stays current as the pinned `yosys.wasm` moves.
+- **Wire L4-from-descriptor onto the runtime timing path** (`from_cell_model_ir`
+  is built + unit-tested but has no runtime caller) — ADR 0019 C2/C3;
+  independent of this plan but the natural partner for `--corner` on-ramp timing.
+- **Project manifest (`Jacquard.toml`)** — collapse the positional
+  `sim netlist in.vcd out.vcd N` arg soup and hold synth-target/top/sources,
+  referencing the existing `sim_config.json`. Its own ADR when scheduled.
+
+---
+
+## Non-goals
+
+- No config/manifest format this pass (Phase 4).
+- No Phase-2 `\src`-provenance work (ADR 0021 Phase 2 roadmap, unchanged).
+- No change to the AIG/boomerang core or `sverilogparse` (ADR 0021 §4).

--- a/docs/plans/rtl-onramp-sim-integration.md
+++ b/docs/plans/rtl-onramp-sim-integration.md
@@ -130,9 +130,9 @@ the feature; green on the branch.
     coverage table (Phase 4), not this prose — prose is the orientation.
   - Cross-link from `getting-started.md`.
 - Fix stale `jacquard map` references (`CLAUDE.md`, docs) → `dump-paths`.
-- Correct the `docs/plans/cell-model-ir.md` "Status: Proposed — not started"
-  header (C3 partly shipped via #160); note L4-descriptor projection exists but
-  is not yet on the runtime timing path.
+- `docs/plans/cell-model-ir.md` status — **reconciled with `main`** during rebase:
+  its status is now "Largely delivered" (C3 + the D5 L4-from-descriptor runtime
+  wiring landed on `main` via `de8255f3`), so no further edit here.
 - Update `docs/handoffs/adr-0021-behavioral-rtl-handoff.md` (or resolve/fold it
   per handoff-discipline once this ships).
 
@@ -154,9 +154,10 @@ ceremony; `map`/`build` stale refs gone.
   this is the only trustworthy way to enumerate it (vs hand-claiming a feature
   list). Publish the table into `docs/accepted-rtl.md`; automatable as a CI job
   so the coverage claim stays current as the pinned `yosys.wasm` moves.
-- **Wire L4-from-descriptor onto the runtime timing path** (`from_cell_model_ir`
-  is built + unit-tested but has no runtime caller) — ADR 0019 C2/C3;
-  independent of this plan but the natural partner for `--corner` on-ramp timing.
+- ~~**Wire L4-from-descriptor onto the runtime timing path**~~ — **landed on
+  `main`** (`de8255f3`, ADR 0019 D5): all runtime timing paths now source L4 from
+  the cell-model-IR descriptor, so `--corner` on-ramp timing for built-in PDKs is
+  live. No longer a follow-up.
 - **Project manifest (`Jacquard.toml`)** — collapse the positional
   `sim netlist in.vcd out.vcd N` arg soup and hold synth-target/top/sources,
   referencing the existing `sim_config.json`. Its own ADR when scheduled.

--- a/docs/spikes/rust-wasmtime-yosys/.gitignore
+++ b/docs/spikes/rust-wasmtime-yosys/.gitignore
@@ -1,0 +1,4 @@
+/target
+/Cargo.lock
+work/aigpdk_nomem.lib
+work/gatelevel.gv

--- a/docs/spikes/rust-wasmtime-yosys/Cargo.toml
+++ b/docs/spikes/rust-wasmtime-yosys/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "build-spike"
+version = "0.0.0"
+edition = "2021"
+
+[[bin]]
+name = "build-spike"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+wasmtime = "37"
+wasmtime-wasi = "37"
+
+[profile.release]
+opt-level = 2

--- a/docs/spikes/rust-wasmtime-yosys/README.md
+++ b/docs/spikes/rust-wasmtime-yosys/README.md
@@ -1,0 +1,49 @@
+# Spike — `jacquard build` via Rust + `wasmtime` (no Python)
+
+Throwaway proof backing [ADR 0021](../../adr/0021-behavioral-rtl-support.md):
+can a Rust process drive YoWASP's stock `yosys.wasm` to run the aigpdk
+synthesis flow, with **no Python interpreter and no external toolchain**?
+
+**Result: yes, end-to-end.** This directory is preserved as an implementation
+reference; the real feature is `jacquard build` (see
+[#162](https://github.com/gpu-eda/Jacquard/issues/162)).
+
+## What it does
+
+`src/main.rs` is a ~55-line faithful port of `yowasp_runtime.run_wasm`'s WASI
+setup into the `wasmtime` Rust crate: load `yosys.wasm`, preopen the design dir
+(cwd), the YoWASP `share/` dir as `/share`, and a temp dir as `/tmp`, set argv
+`["yosys", "-s", "synth.ys"]`, run `_start`, and handle the WASI exit trap.
+
+`work/synth.ys` runs the aigpdk logic-synthesis flow from
+[`docs/synthesis-flow.md`](../../synthesis-flow.md) Step 2 (Yosys path) against
+`work/counter.v` (a trivial 8-bit synchronous counter).
+
+## Run
+
+```sh
+# yosys.wasm + share/ come from the resolved yowasp-yosys wheel (uv.lock);
+# locate them under the uv cache, e.g.:
+#   python -c "import yowasp_yosys, pathlib; print(pathlib.Path(yowasp_yosys.__file__).parent)"
+cargo run --release -- <yosys.wasm> <yowasp-share-dir> "$PWD/work"
+```
+
+## What the spike proved
+
+1. **No Python needed** — the wasmtime Rust crate runs the stock wheel's
+   `yosys.wasm` unmodified.
+2. **The aigpdk flow runs in WASM** — `read_verilog → synth → dfflibmap → abc
+   → techmap → abc → write_verilog`, producing `work/gatelevel.gv` mapped
+   entirely to aigpdk cells (`AND2_*`, `INV`, `DFF`), zero leftover `$` cells.
+3. **In-process abc works under WASI** — the ABC pass ran to completion with no
+   `exec`. This directly de-risks the Phase-2 provenance toolchain: the
+   remaining unknown is only whether `&origins`/`\src` *data* survives the
+   in-process abc path, not whether in-process abc functions at all.
+
+## Not covered here (real `build` work, #162)
+
+- Assertion lowering to `GEM_ASSERT` + default `read_verilog -sv` (so immediate
+  assertions/`$finish` survive — see ADR 0021 / `docs/input-netlist.md`).
+- Memory synthesis (`memlib_yosys.txt`) for designs with RAM.
+- wasm asset sourcing (bundle-in-binary vs fetch-to-cache).
+- `--top-module`, clock-gating config, back-end abstraction (YoWASP/Nix/system).

--- a/docs/spikes/rust-wasmtime-yosys/src/main.rs
+++ b/docs/spikes/rust-wasmtime-yosys/src/main.rs
@@ -1,0 +1,57 @@
+// Spike: run YoWASP's stock `yosys.wasm` from Rust via wasmtime, driving the
+// aigpdk synthesis flow. Proves the on-ramp needs no Python — a faithful port
+// of yowasp_runtime.run_wasm's WASI setup into the wasmtime Rust crate.
+
+use anyhow::{Context, Result};
+use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime_wasi::p1::{self, WasiP1Ctx};
+use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtxBuilder};
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let wasm_path = &args[1]; // path to yosys.wasm
+    let share_dir = &args[2]; // yowasp share/ dir -> guest /share
+    let work_dir = &args[3]; // design dir (cwd, holds counter.v / synth.ys)
+
+    let engine = Engine::default();
+    println!("[spike] compiling {wasm_path} ...");
+    let module = Module::from_file(&engine, wasm_path)
+        .with_context(|| format!("loading {wasm_path}"))?;
+
+    let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
+    p1::add_to_linker_sync(&mut linker, |t| t)?;
+
+    let mut builder = WasiCtxBuilder::new();
+    builder.inherit_stdin().inherit_stdout().inherit_stderr();
+    // argv[0] is the program name; then the yosys CLI args.
+    builder.args(&["yosys", "-s", "synth.ys"]);
+    // cwd -> the design/work dir (relative reads+writes land here)
+    builder.preopened_dir(work_dir, ".", DirPerms::all(), FilePerms::all())?;
+    // yosys's built-in data dir is compiled to /share in the wasi build
+    builder.preopened_dir(share_dir, "/share", DirPerms::all(), FilePerms::all())?;
+    // yosys wants a writable /tmp
+    let tmp = std::env::temp_dir();
+    builder.preopened_dir(tmp, "/tmp", DirPerms::all(), FilePerms::all())?;
+
+    let wasi = builder.build_p1();
+    let mut store = Store::new(&engine, wasi);
+
+    let instance = linker.instantiate(&mut store, &module)?;
+    let start = instance.get_typed_func::<(), ()>(&mut store, "_start")?;
+
+    println!("[spike] running yosys -s synth.ys ...");
+    match start.call(&mut store, ()) {
+        Ok(()) => {
+            println!("[spike] yosys returned (no explicit exit)");
+            Ok(())
+        }
+        Err(e) => {
+            if let Some(exit) = e.downcast_ref::<I32Exit>() {
+                let code = exit.0;
+                println!("[spike] yosys exited with code {code}");
+                std::process::exit(code);
+            }
+            Err(e)
+        }
+    }
+}

--- a/docs/spikes/rust-wasmtime-yosys/work/counter.v
+++ b/docs/spikes/rust-wasmtime-yosys/work/counter.v
@@ -1,0 +1,14 @@
+// Trivial synchronous RTL to exercise the aigpdk synthesis flow.
+module counter (
+    input  wire       clk,
+    input  wire       rst,
+    input  wire       en,
+    output reg  [7:0] count
+);
+    always @(posedge clk) begin
+        if (rst)
+            count <= 8'd0;
+        else if (en)
+            count <= count + 8'd1;
+    end
+endmodule

--- a/docs/spikes/rust-wasmtime-yosys/work/synth.ys
+++ b/docs/spikes/rust-wasmtime-yosys/work/synth.ys
@@ -1,0 +1,15 @@
+# aigpdk logic-synthesis flow (Yosys path from docs/synthesis-flow.md Step 2).
+# No memory in this design, so memory synthesis (Step 1) is skipped.
+read_verilog counter.v
+hierarchy -check -top counter
+synth -flatten
+delete t:$print
+dfflibmap -liberty aigpdk_nomem.lib
+opt_clean -purge
+abc -liberty aigpdk_nomem.lib
+opt_clean -purge
+techmap
+abc -liberty aigpdk_nomem.lib
+opt_clean -purge
+write_verilog gatelevel.gv
+stat

--- a/docs/synthesis-flow.md
+++ b/docs/synthesis-flow.md
@@ -2,8 +2,14 @@
 
 > **New to Jacquard?** Start with [Getting Started](getting-started.md), which
 > runs bundled designs in a few seconds with no synthesis. This page is the
-> deeper path: preparing **your own RTL** — memory and logic synthesis, scope
-> handling, and timing — for simulation.
+> deeper path: preparing **your own RTL** for peak GPU performance using a
+> commercial synthesizer (DC) or a native Yosys install.
+>
+> **Behavioral RTL shortcut:** `jacquard sim design.v in.vcd out.vcd N` accepts
+> behavioral Verilog / SystemVerilog directly — synthesis is automatic and
+> transparent. See [Accepted RTL surface](accepted-rtl.md). This page covers
+> the **performance path** where synthesis quality is the primary tuner of
+> simulation throughput.
 
 **Caveats**: `jacquard sim` drives the design from a static input waveform (e.g. VCD); for reactive testbenches use `jacquard cosim`. Storage must be **edge-triggered flip-flops** — *latches* (level-sensitive storage) are not supported. Asynchronous **set/reset on flip-flops is fine** (async reset is *not* the restriction); what's excluded is latch-based / level-sensitive sequential logic.
 
@@ -125,11 +131,11 @@ git submodule update --init --recursive
 
 Jacquard supports two GPU backends: **CUDA** (NVIDIA GPUs on Linux) and **Metal** (Apple Silicon Macs).
 
-All functionality is accessed through the `jacquard` CLI, which provides `map`, `sim`, and `cosim` subcommands:
+All functionality is accessed through the `jacquard` CLI, which provides `sim`, `cosim`, `dump-paths`, and other subcommands:
 
 ``` sh
-# Mapping (no GPU features needed)
-cargo run -r --bin jacquard -- map --help
+# Analyze timing / validate a netlist (no GPU features needed)
+cargo run -r --bin jacquard -- dump-paths --help
 
 # Simulation (Metal - macOS)
 cargo run -r --features metal --bin jacquard -- sim --help

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -132,6 +132,43 @@ enum Commands {
     /// Point it at the port the server logs, then `openocd -f openocd.cfg`.
     /// See `docs/jtag-debug.md`. No GPU required.
     JtagOpenocdConfig(JtagOpenocdConfigArgs),
+
+    /// Synthesize behavioral RTL to a gate-level aigpdk netlist (ADR 0021).
+    ///
+    /// The RTL on-ramp: runs YoWASP Yosys (WebAssembly, in-process via
+    /// wasmtime — no Python, no external toolchain) through the aigpdk
+    /// memory + logic synthesis flow (`docs/synthesis-flow.md`), producing a
+    /// `gatelevel.gv` that feeds `sim`/`cosim` unchanged. YoWASP Yosys is the
+    /// functional on-ramp; bring-your-own DC remains the performance path.
+    /// Requires building with `--features synth`. No GPU required.
+    #[cfg(feature = "synth")]
+    Build(BuildArgs),
+}
+
+/// Arguments for `jacquard build` (ADR 0021).
+#[cfg(feature = "synth")]
+#[derive(Parser)]
+struct BuildArgs {
+    /// Behavioral / RTL Verilog source file(s).
+    #[clap(required = true)]
+    inputs: Vec<PathBuf>,
+
+    /// Output gate-level netlist path.
+    #[clap(short = 'o', long = "output", default_value = "gatelevel.gv")]
+    output: PathBuf,
+
+    /// Top module name (else auto-detected by Yosys `hierarchy`).
+    #[clap(long)]
+    top_module: Option<String>,
+
+    /// Explicit path to `yosys.wasm`. Overrides `JACQUARD_YOSYS_WASM` and
+    /// installed-`yowasp-yosys` discovery.
+    #[clap(long, value_name = "PATH")]
+    yosys_wasm: Option<PathBuf>,
+
+    /// Strip assertions instead of lowering them to `GEM_ASSERT` cells.
+    #[clap(long)]
+    strip_assertions: bool,
 }
 
 #[derive(Parser)]
@@ -2086,6 +2123,33 @@ fn main() {
         Commands::DumpPaths(args) => cmd_dump_paths(args),
         Commands::Xsources(args) => cmd_xsources(args),
         Commands::JtagOpenocdConfig(args) => cmd_jtag_openocd_config(args),
+        #[cfg(feature = "synth")]
+        Commands::Build(args) => cmd_build(args),
+    }
+}
+
+/// `jacquard build` — synthesize behavioral RTL to a gate-level aigpdk netlist.
+#[cfg(feature = "synth")]
+fn cmd_build(args: BuildArgs) {
+    let opts = jacquard::synth::BuildOptions {
+        inputs: args.inputs,
+        output: args.output,
+        top_module: args.top_module,
+        yosys_wasm: args.yosys_wasm,
+        keep_assertions: !args.strip_assertions,
+    };
+    match jacquard::synth::run_build(&opts) {
+        Ok(path) => {
+            println!("gate-level netlist written to {}", path.display());
+            println!(
+                "next: jacquard sim {} <input.vcd> <output.vcd> 1",
+                path.display()
+            );
+        }
+        Err(e) => {
+            clilog::error!("jacquard build failed: {e:#}");
+            std::process::exit(1);
+        }
     }
 }
 

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -308,6 +308,11 @@ struct SimArgs {
     /// intermediate synthesized gate-level netlist here for inspection.
     #[clap(long = "emit-synth", value_name = "PATH")]
     emit_synth: Option<PathBuf>,
+
+    /// Explicit path to `yosys.wasm` for the RTL on-ramp. Overrides the
+    /// `JACQUARD_YOSYS_WASM` env var and installed-`yowasp-yosys` discovery.
+    #[clap(long = "yosys-wasm", value_name = "PATH")]
+    yosys_wasm: Option<PathBuf>,
 }
 
 #[derive(Parser)]
@@ -490,6 +495,11 @@ struct CosimArgs {
     /// intermediate synthesized gate-level netlist here for inspection.
     #[clap(long = "emit-synth", value_name = "PATH")]
     emit_synth: Option<PathBuf>,
+
+    /// Explicit path to `yosys.wasm` for the RTL on-ramp. Overrides the
+    /// `JACQUARD_YOSYS_WASM` env var and installed-`yowasp-yosys` discovery.
+    #[clap(long = "yosys-wasm", value_name = "PATH")]
+    yosys_wasm: Option<PathBuf>,
 }
 
 #[derive(Parser)]
@@ -626,7 +636,7 @@ fn cmd_sim(args: SimArgs) {
         force_rtl: args.rtl,
         force_netlist: args.netlist,
         emit_synth: args.emit_synth.clone(),
-        yosys_wasm: None,
+        yosys_wasm: args.yosys_wasm.clone(),
         top_module: args.top_module.clone(),
         has_cell_hint: args.cell_descriptor.is_some()
             || !args.cell_library.is_empty()
@@ -2250,7 +2260,7 @@ fn cmd_cosim(args: CosimArgs) {
             force_rtl: args.rtl,
             force_netlist: args.netlist,
             emit_synth: args.emit_synth.clone(),
-            yosys_wasm: None,
+            yosys_wasm: args.yosys_wasm.clone(),
             top_module: args.top_module.clone(),
             has_cell_hint: args.cell_descriptor.is_some()
                 || !args.cell_library.is_empty()

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -132,43 +132,6 @@ enum Commands {
     /// Point it at the port the server logs, then `openocd -f openocd.cfg`.
     /// See `docs/jtag-debug.md`. No GPU required.
     JtagOpenocdConfig(JtagOpenocdConfigArgs),
-
-    /// Synthesize behavioral RTL to a gate-level aigpdk netlist (ADR 0021).
-    ///
-    /// The RTL on-ramp: runs YoWASP Yosys (WebAssembly, in-process via
-    /// wasmtime — no Python, no external toolchain) through the aigpdk
-    /// memory + logic synthesis flow (`docs/synthesis-flow.md`), producing a
-    /// `gatelevel.gv` that feeds `sim`/`cosim` unchanged. YoWASP Yosys is the
-    /// functional on-ramp; bring-your-own DC remains the performance path.
-    /// Requires building with `--features synth`. No GPU required.
-    #[cfg(feature = "synth")]
-    Build(BuildArgs),
-}
-
-/// Arguments for `jacquard build` (ADR 0021).
-#[cfg(feature = "synth")]
-#[derive(Parser)]
-struct BuildArgs {
-    /// Behavioral / RTL Verilog source file(s).
-    #[clap(required = true)]
-    inputs: Vec<PathBuf>,
-
-    /// Output gate-level netlist path.
-    #[clap(short = 'o', long = "output", default_value = "gatelevel.gv")]
-    output: PathBuf,
-
-    /// Top module name (else auto-detected by Yosys `hierarchy`).
-    #[clap(long)]
-    top_module: Option<String>,
-
-    /// Explicit path to `yosys.wasm`. Overrides `JACQUARD_YOSYS_WASM` and
-    /// installed-`yowasp-yosys` discovery.
-    #[clap(long, value_name = "PATH")]
-    yosys_wasm: Option<PathBuf>,
-
-    /// Strip assertions instead of lowering them to `GEM_ASSERT` cells.
-    #[clap(long)]
-    strip_assertions: bool,
 }
 
 #[derive(Parser)]
@@ -331,6 +294,20 @@ struct SimArgs {
     /// intended one.
     #[clap(long)]
     timing_corner: Option<String>,
+
+    /// Force the behavioral-RTL synthesis path (ADR 0021), overriding
+    /// auto-detection. Requires a `--features synth` build.
+    #[clap(long, conflicts_with = "netlist")]
+    rtl: bool,
+
+    /// Force direct gate-level loading, skipping RTL auto-detection.
+    #[clap(long)]
+    netlist: bool,
+
+    /// When the input is (or is forced to be) behavioral RTL, also write the
+    /// intermediate synthesized gate-level netlist here for inspection.
+    #[clap(long = "emit-synth", value_name = "PATH")]
+    emit_synth: Option<PathBuf>,
 }
 
 #[derive(Parser)]
@@ -499,6 +476,20 @@ struct CosimArgs {
     /// `docs/plans/bus-transaction-tracing.md`.
     #[clap(long = "bus-trace-csv", value_name = "PATH")]
     bus_trace_csv: Option<PathBuf>,
+
+    /// Force the behavioral-RTL synthesis path (ADR 0021), overriding
+    /// auto-detection. Requires a `--features synth` build.
+    #[clap(long, conflicts_with = "netlist")]
+    rtl: bool,
+
+    /// Force direct gate-level loading, skipping RTL auto-detection.
+    #[clap(long)]
+    netlist: bool,
+
+    /// When the input is (or is forced to be) behavioral RTL, also write the
+    /// intermediate synthesized gate-level netlist here for inspection.
+    #[clap(long = "emit-synth", value_name = "PATH")]
+    emit_synth: Option<PathBuf>,
 }
 
 #[derive(Parser)]
@@ -629,8 +620,28 @@ fn cmd_sim(args: SimArgs) {
     use jacquard::sim::setup;
     use jacquard::sim::vcd_io;
 
+    // ADR 0021 §1: classify the input (gate-level netlist vs behavioral RTL)
+    // and, for RTL, synthesize transparently. Returns the path to load.
+    let dispatch = setup::InputDispatch {
+        force_rtl: args.rtl,
+        force_netlist: args.netlist,
+        emit_synth: args.emit_synth.clone(),
+        yosys_wasm: None,
+        top_module: args.top_module.clone(),
+        has_cell_hint: args.cell_descriptor.is_some()
+            || !args.cell_library.is_empty()
+            || args.bundled_descriptor.is_some(),
+    };
+    let netlist_path = match setup::resolve_netlist_input(&args.netlist_verilog, &dispatch) {
+        Ok(p) => p,
+        Err(e) => {
+            clilog::error!("{e:#}");
+            std::process::exit(1);
+        }
+    };
+
     let design_args = DesignArgs {
-        netlist_verilog: args.netlist_verilog.clone(),
+        netlist_verilog: netlist_path.clone(),
         top_module: args.top_module.clone(),
         level_split: args.level_split.clone(),
         num_blocks: args.num_blocks,
@@ -2123,33 +2134,6 @@ fn main() {
         Commands::DumpPaths(args) => cmd_dump_paths(args),
         Commands::Xsources(args) => cmd_xsources(args),
         Commands::JtagOpenocdConfig(args) => cmd_jtag_openocd_config(args),
-        #[cfg(feature = "synth")]
-        Commands::Build(args) => cmd_build(args),
-    }
-}
-
-/// `jacquard build` — synthesize behavioral RTL to a gate-level aigpdk netlist.
-#[cfg(feature = "synth")]
-fn cmd_build(args: BuildArgs) {
-    let opts = jacquard::synth::BuildOptions {
-        inputs: args.inputs,
-        output: args.output,
-        top_module: args.top_module,
-        yosys_wasm: args.yosys_wasm,
-        keep_assertions: !args.strip_assertions,
-    };
-    match jacquard::synth::run_build(&opts) {
-        Ok(path) => {
-            println!("gate-level netlist written to {}", path.display());
-            println!(
-                "next: jacquard sim {} <input.vcd> <output.vcd> 1",
-                path.display()
-            );
-        }
-        Err(e) => {
-            clilog::error!("jacquard build failed: {e:#}");
-            std::process::exit(1);
-        }
     }
 }
 
@@ -2260,8 +2244,28 @@ fn cmd_cosim(args: CosimArgs) {
             .flat_map(jacquard::sim::models::bus_trace::observed_net_names)
             .collect();
 
+        // ADR 0021 §1: classify the input (gate-level netlist vs behavioral
+        // RTL) and, for RTL, synthesize transparently. Returns the path to load.
+        let dispatch = setup::InputDispatch {
+            force_rtl: args.rtl,
+            force_netlist: args.netlist,
+            emit_synth: args.emit_synth.clone(),
+            yosys_wasm: None,
+            top_module: args.top_module.clone(),
+            has_cell_hint: args.cell_descriptor.is_some()
+                || !args.cell_library.is_empty()
+                || args.bundled_descriptor.is_some(),
+        };
+        let netlist_path = match setup::resolve_netlist_input(&args.netlist_verilog, &dispatch) {
+            Ok(p) => p,
+            Err(e) => {
+                clilog::error!("{e:#}");
+                std::process::exit(1);
+            }
+        };
+
         let design_args = DesignArgs {
-            netlist_verilog: args.netlist_verilog.clone(),
+            netlist_verilog: netlist_path.clone(),
             top_module: args.top_module.clone(),
             level_split: args.level_split.clone(),
             num_blocks: args.num_blocks,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,3 +78,7 @@ pub mod display;
 pub mod testbench;
 
 pub mod sim;
+
+// ADR 0021: behavioral-RTL on-ramp (`jacquard build`) via embedded YoWASP Yosys.
+#[cfg(feature = "synth")]
+pub mod synth;

--- a/src/sim/setup.rs
+++ b/src/sim/setup.rs
@@ -216,6 +216,163 @@ pub fn build_netlist_and_aig(
     (netlistdb, aig)
 }
 
+// ============================================================================
+// Input dispatch (ADR 0021 §1): behavioral RTL vs gate-level netlist.
+// ============================================================================
+
+/// Overrides and options for the `sim`/`cosim` input classifier
+/// ([`resolve_netlist_input`]).
+pub struct InputDispatch {
+    /// `--rtl`: force the synthesis path regardless of detection.
+    pub force_rtl: bool,
+    /// `--netlist`: force direct-structural loading, skipping detection.
+    pub force_netlist: bool,
+    /// `--emit-synth <path>`: dump the intermediate gate-level netlist.
+    pub emit_synth: Option<PathBuf>,
+    /// Explicit `yosys.wasm` path for synthesis (else env / discovery).
+    pub yosys_wasm: Option<PathBuf>,
+    /// Top module passed to synthesis (from `--top-module`).
+    pub top_module: Option<String>,
+    /// True when the user supplied `--cell-descriptor`, `--cell-library`, or
+    /// `--bundled-descriptor` — i.e. they have already described a non-built-in
+    /// PDK, so unrecognized cells are expected input, not an error.
+    pub has_cell_hint: bool,
+}
+
+/// Classify a `sim`/`cosim` netlist input (ADR 0021 §1) and return the path to
+/// actually load: the original file for a gate-level netlist, or a freshly
+/// synthesized `.gv` for behavioral RTL.
+///
+/// Dispatch:
+/// - `--netlist` → load `design` directly (skip detection).
+/// - `--rtl` → synthesize `design`, load the result.
+/// - otherwise: attempt a structural parse (`sverilogparse`). If it parses,
+///   the input is gate-level — every instantiated leaf cell is tested against
+///   the built-in stdcell recognizers. All recognized (or the user supplied a
+///   cell hint) → load directly; any unrecognized → error toward
+///   `--cell-descriptor` (it is already a netlist, not synthesized). If the
+///   structural parse fails, the input is behavioral → synthesize; a synthesis
+///   failure surfaces *both* the structural and Yosys diagnostics.
+pub fn resolve_netlist_input(design: &Path, d: &InputDispatch) -> anyhow::Result<PathBuf> {
+    use anyhow::bail;
+
+    if d.force_netlist && d.force_rtl {
+        bail!("--rtl and --netlist are mutually exclusive");
+    }
+    if d.force_netlist {
+        clilog::info!(
+            "{}: --netlist → loading as gate-level directly",
+            design.display()
+        );
+        return Ok(design.to_path_buf());
+    }
+    if d.force_rtl {
+        clilog::info!("{}: --rtl → synthesizing", design.display());
+        return synth_input(design, d);
+    }
+
+    match sverilogparse::SVerilog::parse_file(design) {
+        Ok(sv) => {
+            let unrecognized = unrecognized_cells(&sv);
+            if unrecognized.is_empty() || d.has_cell_hint {
+                clilog::info!(
+                    "{}: gate-level netlist → simulating directly",
+                    design.display()
+                );
+                Ok(design.to_path_buf())
+            } else {
+                bail!(
+                    "{}: gate-level netlist with unrecognized cell type(s): {}. \
+                     This is already a netlist (not behavioral RTL), so it is not \
+                     synthesized. Pass `--cell-descriptor <path>` (ADR 0019) to \
+                     describe the cell library, or `--cell-library <file.v>` for \
+                     pin definitions. Use `--rtl` to force synthesis instead.",
+                    design.display(),
+                    unrecognized.join(", ")
+                );
+            }
+        }
+        Err(parse_err) => {
+            clilog::info!(
+                "{}: not structural Verilog → treating as behavioral RTL",
+                design.display()
+            );
+            synth_input(design, d).map_err(|synth_err| {
+                anyhow::anyhow!(
+                    "{design}: could not load as a gate-level netlist, and \
+                     synthesizing it as behavioral RTL also failed.\n  \
+                     - structural parse error: {parse_err}\n  \
+                     - synthesis error: {synth_err:#}",
+                    design = design.display()
+                )
+            })
+        }
+    }
+}
+
+/// Instantiated leaf-cell types not matched by any built-in stdcell recognizer.
+/// Submodule instantiations (types that are themselves defined modules in the
+/// same file) are excluded — only leaf cells are classified.
+fn unrecognized_cells(sv: &sverilogparse::SVerilog) -> Vec<String> {
+    use std::collections::BTreeSet;
+    let defined: BTreeSet<&str> = sv.modules.iter().map(|(name, _)| name.as_str()).collect();
+    let mut out: BTreeSet<String> = BTreeSet::new();
+    for (_, m) in &sv.modules {
+        for cell in &m.cells {
+            let ty = cell.macro_name.as_str();
+            if defined.contains(ty) {
+                continue; // hierarchical submodule, not a leaf cell
+            }
+            if !is_recognized_cell(ty) {
+                out.insert(ty.to_string());
+            }
+        }
+    }
+    out.into_iter().collect()
+}
+
+/// True if `celltype` belongs to a built-in stdcell library (SKY130, GF180MCU,
+/// or AIGPDK) — the families [`detect_library`] dispatches on.
+fn is_recognized_cell(celltype: &str) -> bool {
+    crate::sky130::is_sky130_cell(celltype)
+        || crate::gf180mcu::is_gf180mcu_cell(celltype)
+        || crate::sky130::is_aigpdk_cell(celltype)
+}
+
+/// Synthesize `design` via the embedded Yosys engine, or (without the `synth`
+/// feature) return an actionable message pointing at a synth-enabled build.
+#[allow(unused_variables)]
+fn synth_input(design: &Path, d: &InputDispatch) -> anyhow::Result<PathBuf> {
+    #[cfg(feature = "synth")]
+    {
+        let opts = crate::synth::SynthOptions {
+            top_module: d.top_module.clone(),
+            yosys_wasm: d.yosys_wasm.clone(),
+            keep_assertions: true,
+            emit_synth: d.emit_synth.clone(),
+        };
+        let out = crate::synth::synthesize(design, &opts)?;
+        clilog::info!(
+            "{}: behavioral RTL → synthesized [YoWASP Yosys, functional QoR] → {}",
+            design.display(),
+            out.display()
+        );
+        Ok(out)
+    }
+    #[cfg(not(feature = "synth"))]
+    {
+        anyhow::bail!(
+            "{}: input looks like behavioral RTL, but this jacquard binary was \
+             built without synthesis support. Rebuild with `--features synth` \
+             (or use a release binary, which bundles it) to synthesize RTL \
+             on-the-fly, or pass a pre-synthesized gate-level netlist. If this \
+             really is a gate-level netlist that failed to parse, fix the syntax \
+             or pass `--netlist` to force direct loading.",
+            design.display()
+        )
+    }
+}
+
 /// Load a design through the full pipeline: netlist → AIG → staged → script.
 ///
 /// Detects cell library (AIGPDK, SKY130, or GF180MCU), loads display info
@@ -733,4 +890,144 @@ fn generate_partitions(
             effective_parts
         })
         .collect::<Vec<_>>()
+}
+
+#[cfg(test)]
+mod input_dispatch_tests {
+    //! ADR 0021 §1 input classifier — the three dispatch branches.
+    use super::*;
+    use std::io::Write;
+
+    fn write_tmp(name: &str, body: &str) -> (tempdir::TempDir, PathBuf) {
+        let dir = tempdir::TempDir::new("jacquard-dispatch-test").unwrap();
+        let path = dir.path().join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        (dir, path)
+    }
+
+    fn dispatch(has_cell_hint: bool) -> InputDispatch {
+        InputDispatch {
+            force_rtl: false,
+            force_netlist: false,
+            emit_synth: None,
+            yosys_wasm: None,
+            top_module: None,
+            has_cell_hint,
+        }
+    }
+
+    // A structural gate-level netlist of only recognized (AIGPDK) cells.
+    const GATELEVEL_AIGPDK: &str = "\
+module top(a, clk, y);
+  input a;
+  input clk;
+  output y;
+  wire w;
+  INV g0 (.A(a), .Y(w));
+  DFF g1 (.D(w), .CK(clk), .Q(y));
+endmodule
+";
+
+    // A structural netlist referencing an unknown (non-built-in) cell type.
+    const GATELEVEL_UNKNOWN: &str = "\
+module top(a, y);
+  input a;
+  output y;
+  FOO_UNKNOWN_CELL g0 (.A(a), .Y(y));
+endmodule
+";
+
+    // Behavioral RTL — `always` is not structural, so `sverilogparse` rejects it.
+    const BEHAVIORAL_RTL: &str = "\
+module counter(clk, q);
+  input clk;
+  output reg [3:0] q;
+  always @(posedge clk) q <= q + 1;
+endmodule
+";
+
+    #[test]
+    fn branch_gate_level_recognized_simulates_directly() {
+        let (_d, path) = write_tmp("gate.v", GATELEVEL_AIGPDK);
+        // Structural parse must succeed (precondition for this branch).
+        assert!(sverilogparse::SVerilog::parse_file(&path).is_ok());
+        let out = resolve_netlist_input(&path, &dispatch(false)).expect("recognized netlist loads");
+        assert_eq!(out, path, "recognized gate-level netlist loads as-is");
+    }
+
+    #[test]
+    fn branch_unknown_cells_errors_toward_cell_descriptor() {
+        let (_d, path) = write_tmp("unknown.v", GATELEVEL_UNKNOWN);
+        assert!(sverilogparse::SVerilog::parse_file(&path).is_ok());
+        let err = resolve_netlist_input(&path, &dispatch(false))
+            .expect_err("unknown-cell netlist must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("FOO_UNKNOWN_CELL"),
+            "lists the unknown cell: {msg}"
+        );
+        assert!(
+            msg.contains("--cell-descriptor"),
+            "points at --cell-descriptor: {msg}"
+        );
+    }
+
+    #[test]
+    fn unknown_cells_accepted_when_user_supplies_a_cell_hint() {
+        // A user PDK (e.g. IHP sg13g2) is passed via --cell-library/--cell-descriptor;
+        // its cells aren't built-in recognizers, so has_cell_hint suppresses the error.
+        let (_d, path) = write_tmp("unknown.v", GATELEVEL_UNKNOWN);
+        let out = resolve_netlist_input(&path, &dispatch(true))
+            .expect("cell-hint suppresses unknown-cell error");
+        assert_eq!(out, path);
+    }
+
+    #[test]
+    fn force_netlist_skips_detection() {
+        let (_d, path) = write_tmp("weird.v", GATELEVEL_UNKNOWN);
+        let mut d = dispatch(false);
+        d.force_netlist = true;
+        let out = resolve_netlist_input(&path, &d).expect("--netlist bypasses classification");
+        assert_eq!(out, path);
+    }
+
+    #[test]
+    fn behavioral_rtl_is_not_structural() {
+        // The routing precondition for the synth branch: behavioral constructs
+        // trip the structural parser (ADR 0021 §1).
+        let (_d, path) = write_tmp("counter.v", BEHAVIORAL_RTL);
+        assert!(
+            sverilogparse::SVerilog::parse_file(&path).is_err(),
+            "behavioral RTL must fail the structural parse"
+        );
+    }
+
+    #[cfg(not(feature = "synth"))]
+    #[test]
+    fn behavioral_rtl_without_synth_feature_gives_actionable_message() {
+        let (_d, path) = write_tmp("counter.v", BEHAVIORAL_RTL);
+        let err = resolve_netlist_input(&path, &dispatch(false))
+            .expect_err("RTL without synth support must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("--features synth"),
+            "points at synth build: {msg}"
+        );
+    }
+
+    #[test]
+    fn unrecognized_cells_excludes_hierarchical_submodules() {
+        // A submodule instantiation whose type is a defined module is not a leaf
+        // cell and must not be flagged as unrecognized.
+        let src = "\
+module leaf(a, y); input a; output y; INV g (.A(a), .Y(y)); endmodule
+module top(a, y); input a; output y; leaf u0 (.a(a), .y(y)); endmodule
+";
+        let sv = sverilogparse::SVerilog::parse_str(src).expect("structural parse");
+        assert!(
+            unrecognized_cells(&sv).is_empty(),
+            "submodule `leaf` and recognized `INV` yield no unrecognized cells"
+        );
+    }
 }

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -1,4 +1,4 @@
-//! `jacquard build` — behavioral RTL → gate-level aigpdk netlist.
+//! Embedded synthesis on-ramp — behavioral RTL → gate-level aigpdk netlist.
 //!
 //! Runs YoWASP's Yosys (a single self-contained `yosys.wasm`, abc compiled
 //! in-tree and called in-process) directly from Rust via `wasmtime` — no Python
@@ -6,11 +6,13 @@
 //! [ADR 0021](../docs/adr/0021-behavioral-rtl-support.md) and the proving spike
 //! at `docs/spikes/rust-wasmtime-yosys/`.
 //!
-//! This is a *pre-processor*: it produces the same structural aigpdk netlist a
-//! user would synthesize by hand (`docs/synthesis-flow.md`), which then feeds
-//! `jacquard sim`/`cosim` unchanged. YoWASP Yosys is the functional on-ramp;
-//! bring-your-own DC remains the performance path (synthesis quality sets GPU
-//! speed).
+//! This is a *pre-processor* invoked transparently by `jacquard sim`/`cosim`
+//! when handed behavioral RTL (ADR 0021 §1): it produces the same structural
+//! aigpdk netlist a user would synthesize by hand (`docs/synthesis-flow.md`),
+//! which then feeds the emulator pipeline unchanged. The synthesized netlist is
+//! cached by content hash so repeat runs skip synthesis. YoWASP Yosys is the
+//! functional on-ramp; bring-your-own DC remains the performance path
+//! (synthesis quality sets GPU speed).
 
 use anyhow::{bail, Context, Result};
 use std::path::{Path, PathBuf};
@@ -24,93 +26,184 @@ const AIGPDK_NOMEM_LIB: &str = include_str!("../aigpdk/aigpdk_nomem.lib");
 const MEMLIB_YOSYS: &str = include_str!("../aigpdk/memlib_yosys.txt");
 const GEM_FORMAL_V: &str = include_str!("../aigpdk/gem_formal.v");
 
-/// Inputs for a `jacquard build` run.
-pub struct BuildOptions {
-    /// Behavioral / RTL Verilog source files.
-    pub inputs: Vec<PathBuf>,
-    /// Where to write the gate-level netlist.
-    pub output: PathBuf,
+/// Options controlling an embedded-Yosys synthesis run (ADR 0021).
+pub struct SynthOptions {
     /// Explicit top module (else Yosys auto-detects via `hierarchy`).
     pub top_module: Option<String>,
-    /// Explicit path to `yosys.wasm` (`--yosys-wasm`); else env / discovery.
+    /// Explicit path to `yosys.wasm`; else `JACQUARD_YOSYS_WASM` / discovery.
     pub yosys_wasm: Option<PathBuf>,
     /// Keep assertions as `GEM_ASSERT` cells (default). When false, strip them
     /// for a pure logic netlist.
     pub keep_assertions: bool,
+    /// When set (`--emit-synth`), also copy the synthesized netlist here for
+    /// inspection / fixture authoring.
+    pub emit_synth: Option<PathBuf>,
 }
 
-/// Synthesize `opts.inputs` to a gate-level aigpdk netlist at `opts.output`.
-/// Returns the output path on success.
-pub fn run_build(opts: &BuildOptions) -> Result<PathBuf> {
-    if opts.inputs.is_empty() {
-        bail!("no input Verilog files given");
-    }
-    let (wasm_path, share_dir) = locate_yosys_wasm(opts.yosys_wasm.as_deref())?;
-    clilog::info!(
-        "jacquard build: using yosys.wasm at {}",
-        wasm_path.display()
-    );
-
-    // Everything Yosys reads/writes lives in one temp dir, preopened as cwd.
-    // This avoids WASI path-escaping and keeps a single preopen for inputs.
-    let work = tempdir::TempDir::new("jacquard-build").context("creating temp work directory")?;
-    let wp = work.path();
-    std::fs::write(wp.join("aigpdk_nomem.lib"), AIGPDK_NOMEM_LIB)?;
-    std::fs::write(wp.join("memlib_yosys.txt"), MEMLIB_YOSYS)?;
-    std::fs::write(wp.join("gem_formal.v"), GEM_FORMAL_V)?;
-
-    let mut input_names = Vec::with_capacity(opts.inputs.len());
-    for (i, inp) in opts.inputs.iter().enumerate() {
-        // Flatten to a unique basename inside the work dir.
-        let base = inp
-            .file_name()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_else(|| format!("input{i}.v"));
-        let name = if input_names.contains(&base) {
-            format!("input{i}_{base}")
-        } else {
-            base
-        };
-        std::fs::copy(inp, wp.join(&name))
-            .with_context(|| format!("reading input {}", inp.display()))?;
-        input_names.push(name);
-    }
-
-    let script = synth_script(
-        &input_names,
-        opts.top_module.as_deref(),
-        opts.keep_assertions,
-    );
-    std::fs::write(wp.join("synth.ys"), &script)?;
-
-    run_yosys_wasm(&wasm_path, &share_dir, wp).context("running YoWASP Yosys synthesis")?;
-
-    let produced = wp.join("gatelevel.gv");
-    if !produced.exists() {
-        bail!(
-            "Yosys ran but produced no gatelevel.gv — synthesis likely failed \
-             (re-run is verbose). Script:\n{script}"
-        );
-    }
-    if let Some(parent) = opts.output.parent() {
-        if !parent.as_os_str().is_empty() {
-            std::fs::create_dir_all(parent).ok();
+impl Default for SynthOptions {
+    fn default() -> Self {
+        Self {
+            top_module: None,
+            yosys_wasm: None,
+            keep_assertions: true,
+            emit_synth: None,
         }
     }
-    std::fs::copy(&produced, &opts.output)
-        .with_context(|| format!("writing output netlist {}", opts.output.display()))?;
-    clilog::info!("jacquard build: wrote {}", opts.output.display());
-    Ok(opts.output.clone())
+}
+
+/// Synthesize a single behavioral RTL `design` to a gate-level aigpdk netlist,
+/// returning the path to the (cached) `.gv`.
+///
+/// The result is cached under `$XDG_CACHE_HOME/jacquard` keyed by the content
+/// hash of the design source, the generated synthesis script, and the
+/// `yosys.wasm` module — so a repeat `sim`/`cosim` run of the same RTL skips
+/// synthesis entirely (mirroring the compiled-module cache next to it).
+pub fn synthesize(design: &Path, opts: &SynthOptions) -> Result<PathBuf> {
+    let (wasm_path, share_dir) = locate_yosys_wasm(opts.yosys_wasm.as_deref())?;
+
+    let design_bytes =
+        std::fs::read(design).with_context(|| format!("reading design {}", design.display()))?;
+    let wasm_bytes =
+        std::fs::read(&wasm_path).with_context(|| format!("reading {}", wasm_path.display()))?;
+
+    // Pick the SystemVerilog frontend once per wasm module (probe + cache).
+    let use_slang = read_slang_available(&wasm_path, &share_dir);
+
+    // The design is copied into the work dir under its basename; the script
+    // references that basename.
+    let base = design
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "input.v".to_string());
+    let script = synth_script(
+        std::slice::from_ref(&base),
+        opts.top_module.as_deref(),
+        opts.keep_assertions,
+        use_slang,
+    );
+
+    // Cache key: design source + generated script + wasm module (+ crate
+    // version, to invalidate across incompatible synth-engine changes).
+    let cache_key = {
+        use std::hash::{Hash, Hasher};
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        design_bytes.hash(&mut h);
+        script.hash(&mut h);
+        wasm_bytes.hash(&mut h);
+        env!("CARGO_PKG_VERSION").hash(&mut h);
+        format!("synth-{:016x}.gv", h.finish())
+    };
+    let cache_dir = cache_dir();
+    let cached = cache_dir.join(&cache_key);
+
+    if cached.is_file() {
+        clilog::info!("synth: cache hit {}", cached.display());
+    } else {
+        clilog::info!("synth: using yosys.wasm at {}", wasm_path.display());
+        // Everything Yosys reads/writes lives in one temp dir, preopened as cwd.
+        // This avoids WASI path-escaping and keeps a single preopen for inputs.
+        let work =
+            tempdir::TempDir::new("jacquard-synth").context("creating temp work directory")?;
+        let wp = work.path();
+        std::fs::write(wp.join("aigpdk_nomem.lib"), AIGPDK_NOMEM_LIB)?;
+        std::fs::write(wp.join("memlib_yosys.txt"), MEMLIB_YOSYS)?;
+        std::fs::write(wp.join("gem_formal.v"), GEM_FORMAL_V)?;
+        std::fs::write(wp.join(&base), &design_bytes)?;
+        std::fs::write(wp.join("synth.ys"), &script)?;
+
+        run_yosys_wasm(&wasm_path, &share_dir, wp, &["yosys", "-s", "synth.ys"])
+            .context("running YoWASP Yosys synthesis")?;
+
+        let produced = wp.join("gatelevel.gv");
+        if !produced.exists() {
+            bail!(
+                "Yosys ran but produced no gatelevel.gv — synthesis likely failed \
+                 (re-run is verbose). Script:\n{script}"
+            );
+        }
+        std::fs::create_dir_all(&cache_dir).ok();
+        std::fs::copy(&produced, &cached)
+            .with_context(|| format!("caching synthesized netlist to {}", cached.display()))?;
+    }
+
+    if let Some(emit) = &opts.emit_synth {
+        if let Some(parent) = emit.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).ok();
+            }
+        }
+        std::fs::copy(&cached, emit)
+            .with_context(|| format!("writing --emit-synth {}", emit.display()))?;
+        clilog::info!("synth: wrote intermediate netlist to {}", emit.display());
+    }
+
+    Ok(cached)
+}
+
+/// Whether the embedded Yosys exposes `read_slang` (yosys-slang, a
+/// near-complete SV-2017 elaborator). Probed once via `help read_slang` and
+/// cached for the process; falls back to `read_verilog -sv` when slang is
+/// absent (an older wasm) so the on-ramp degrades gracefully.
+fn read_slang_available(wasm_path: &Path, share_dir: &Path) -> bool {
+    static CACHE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| match probe_help(wasm_path, share_dir, "read_slang") {
+        Ok(log) => {
+            // Yosys prints "No such command or cell type: read_slang" when the
+            // command is absent; otherwise it prints the command's help text.
+            let present = !log.contains("No such command");
+            clilog::info!(
+                "synth: SV frontend = {}",
+                if present {
+                    "read_slang (yosys-slang)"
+                } else {
+                    "read_verilog -sv (slang absent)"
+                }
+            );
+            present
+        }
+        Err(e) => {
+            clilog::warn!("synth: read_slang probe failed ({e:#}); using read_verilog -sv");
+            false
+        }
+    })
+}
+
+/// Run `help <cmd>` and return Yosys's captured log text. Uses `yosys -l
+/// <logfile>` (written into the preopened work dir) rather than WASI stdout
+/// capture — robust across wasmtime-wasi API surfaces.
+fn probe_help(wasm_path: &Path, share_dir: &Path, cmd: &str) -> Result<String> {
+    let work = tempdir::TempDir::new("jacquard-probe").context("creating probe work dir")?;
+    let wp = work.path();
+    std::fs::write(wp.join("probe.ys"), format!("help {cmd}\n"))?;
+    run_yosys_wasm(
+        wasm_path,
+        share_dir,
+        wp,
+        &["yosys", "-q", "-l", "probe.log", "-s", "probe.ys"],
+    )
+    .context("probing Yosys command set")?;
+    Ok(std::fs::read_to_string(wp.join("probe.log")).unwrap_or_default())
 }
 
 /// Generate the aigpdk synthesis script (Yosys path of `docs/synthesis-flow.md`,
-/// plus memory mapping and assertion lowering).
-fn synth_script(inputs: &[String], top: Option<&str>, keep_assertions: bool) -> String {
-    let reads = inputs
-        .iter()
-        .map(|f| format!("read_verilog -sv {f}"))
-        .collect::<Vec<_>>()
-        .join("\n");
+/// plus memory mapping and assertion lowering). Fronts SystemVerilog with
+/// `read_slang` when available (`use_slang`), else `read_verilog -sv`.
+fn synth_script(
+    inputs: &[String],
+    top: Option<&str>,
+    keep_assertions: bool,
+    use_slang: bool,
+) -> String {
+    let reads = if use_slang {
+        // yosys-slang is a whole-program elaborator: read all files in one call.
+        format!("read_slang {}", inputs.join(" "))
+    } else {
+        inputs
+            .iter()
+            .map(|f| format!("read_verilog -sv {f}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
     let top_arg = top.map(|t| format!(" -top {t}")).unwrap_or_default();
     // `hierarchy` needs a top; auto-detect when the user didn't name one.
     let hierarchy = if top.is_some() {
@@ -127,7 +220,8 @@ fn synth_script(inputs: &[String], top: Option<&str>, keep_assertions: bool) -> 
     };
     format!(
         "\
-# Generated by `jacquard build` (ADR 0021). aigpdk logic + memory synthesis.
+# Generated by the jacquard sim/cosim synthesis on-ramp (ADR 0021).
+# aigpdk logic + memory synthesis.
 # GEM_ASSERT and aigpdk cells are emitted as blackbox instances (no defs needed).
 {reads}
 {hierarchy}
@@ -248,7 +342,7 @@ fn load_module(engine: &Engine, wasm_path: &Path) -> Result<Module> {
         }
     }
 
-    clilog::info!("jacquard build: compiling yosys.wasm (first run; cached after)");
+    clilog::info!("synth: compiling yosys.wasm (first run; cached after)");
     // cranelift/wasmtime log a torrent of DEBUG/TRACE through the `log` facade;
     // clip it to Info for the compile so the netlist output isn't buried, then
     // restore. Yosys's own stdout/stderr is inherited (not via `log`), so this
@@ -283,9 +377,15 @@ fn cache_dir() -> PathBuf {
     std::env::temp_dir().join("jacquard")
 }
 
-/// Run `yosys -s synth.ys` inside `work_dir` from the WASM module — a Rust port
+/// Run Yosys (`argv`) inside `work_dir` from the WASM module — a Rust port
 /// of `yowasp_runtime.run_wasm`'s WASI setup (preopen cwd, `/share`, `/tmp`).
-fn run_yosys_wasm(wasm_path: &Path, share_dir: &Path, work_dir: &Path) -> Result<()> {
+/// `argv[0]` is the program name; the rest are Yosys arguments.
+fn run_yosys_wasm(
+    wasm_path: &Path,
+    share_dir: &Path,
+    work_dir: &Path,
+    argv: &[&str],
+) -> Result<()> {
     let engine = Engine::default();
     let module = load_module(&engine, wasm_path)?;
 
@@ -294,7 +394,7 @@ fn run_yosys_wasm(wasm_path: &Path, share_dir: &Path, work_dir: &Path) -> Result
 
     let mut builder = WasiCtxBuilder::new();
     builder.inherit_stdin().inherit_stdout().inherit_stderr();
-    builder.args(&["yosys", "-s", "synth.ys"]);
+    builder.args(argv);
     // cwd -> work dir (relative reads/writes land here)
     builder.preopened_dir(work_dir, ".", DirPerms::all(), FilePerms::all())?;
     // Yosys's built-in datadir is compiled to /share in the wasi build.

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -1,0 +1,323 @@
+//! `jacquard build` — behavioral RTL → gate-level aigpdk netlist.
+//!
+//! Runs YoWASP's Yosys (a single self-contained `yosys.wasm`, abc compiled
+//! in-tree and called in-process) directly from Rust via `wasmtime` — no Python
+//! interpreter and no external toolchain. See
+//! [ADR 0021](../docs/adr/0021-behavioral-rtl-support.md) and the proving spike
+//! at `docs/spikes/rust-wasmtime-yosys/`.
+//!
+//! This is a *pre-processor*: it produces the same structural aigpdk netlist a
+//! user would synthesize by hand (`docs/synthesis-flow.md`), which then feeds
+//! `jacquard sim`/`cosim` unchanged. YoWASP Yosys is the functional on-ramp;
+//! bring-your-own DC remains the performance path (synthesis quality sets GPU
+//! speed).
+
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
+use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime_wasi::p1::{self, WasiP1Ctx};
+use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtxBuilder};
+
+// aigpdk synthesis-support files, embedded so `build` is self-contained (small;
+// unlike the ~39 MB wasm these are a few KB each).
+const AIGPDK_NOMEM_LIB: &str = include_str!("../aigpdk/aigpdk_nomem.lib");
+const MEMLIB_YOSYS: &str = include_str!("../aigpdk/memlib_yosys.txt");
+const GEM_FORMAL_V: &str = include_str!("../aigpdk/gem_formal.v");
+
+/// Inputs for a `jacquard build` run.
+pub struct BuildOptions {
+    /// Behavioral / RTL Verilog source files.
+    pub inputs: Vec<PathBuf>,
+    /// Where to write the gate-level netlist.
+    pub output: PathBuf,
+    /// Explicit top module (else Yosys auto-detects via `hierarchy`).
+    pub top_module: Option<String>,
+    /// Explicit path to `yosys.wasm` (`--yosys-wasm`); else env / discovery.
+    pub yosys_wasm: Option<PathBuf>,
+    /// Keep assertions as `GEM_ASSERT` cells (default). When false, strip them
+    /// for a pure logic netlist.
+    pub keep_assertions: bool,
+}
+
+/// Synthesize `opts.inputs` to a gate-level aigpdk netlist at `opts.output`.
+/// Returns the output path on success.
+pub fn run_build(opts: &BuildOptions) -> Result<PathBuf> {
+    if opts.inputs.is_empty() {
+        bail!("no input Verilog files given");
+    }
+    let (wasm_path, share_dir) = locate_yosys_wasm(opts.yosys_wasm.as_deref())?;
+    clilog::info!(
+        "jacquard build: using yosys.wasm at {}",
+        wasm_path.display()
+    );
+
+    // Everything Yosys reads/writes lives in one temp dir, preopened as cwd.
+    // This avoids WASI path-escaping and keeps a single preopen for inputs.
+    let work = tempdir::TempDir::new("jacquard-build").context("creating temp work directory")?;
+    let wp = work.path();
+    std::fs::write(wp.join("aigpdk_nomem.lib"), AIGPDK_NOMEM_LIB)?;
+    std::fs::write(wp.join("memlib_yosys.txt"), MEMLIB_YOSYS)?;
+    std::fs::write(wp.join("gem_formal.v"), GEM_FORMAL_V)?;
+
+    let mut input_names = Vec::with_capacity(opts.inputs.len());
+    for (i, inp) in opts.inputs.iter().enumerate() {
+        // Flatten to a unique basename inside the work dir.
+        let base = inp
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| format!("input{i}.v"));
+        let name = if input_names.contains(&base) {
+            format!("input{i}_{base}")
+        } else {
+            base
+        };
+        std::fs::copy(inp, wp.join(&name))
+            .with_context(|| format!("reading input {}", inp.display()))?;
+        input_names.push(name);
+    }
+
+    let script = synth_script(
+        &input_names,
+        opts.top_module.as_deref(),
+        opts.keep_assertions,
+    );
+    std::fs::write(wp.join("synth.ys"), &script)?;
+
+    run_yosys_wasm(&wasm_path, &share_dir, wp).context("running YoWASP Yosys synthesis")?;
+
+    let produced = wp.join("gatelevel.gv");
+    if !produced.exists() {
+        bail!(
+            "Yosys ran but produced no gatelevel.gv — synthesis likely failed \
+             (re-run is verbose). Script:\n{script}"
+        );
+    }
+    if let Some(parent) = opts.output.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent).ok();
+        }
+    }
+    std::fs::copy(&produced, &opts.output)
+        .with_context(|| format!("writing output netlist {}", opts.output.display()))?;
+    clilog::info!("jacquard build: wrote {}", opts.output.display());
+    Ok(opts.output.clone())
+}
+
+/// Generate the aigpdk synthesis script (Yosys path of `docs/synthesis-flow.md`,
+/// plus memory mapping and assertion lowering).
+fn synth_script(inputs: &[String], top: Option<&str>, keep_assertions: bool) -> String {
+    let reads = inputs
+        .iter()
+        .map(|f| format!("read_verilog -sv {f}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let top_arg = top.map(|t| format!(" -top {t}")).unwrap_or_default();
+    // `hierarchy` needs a top; auto-detect when the user didn't name one.
+    let hierarchy = if top.is_some() {
+        format!("hierarchy -check{top_arg}")
+    } else {
+        "hierarchy -check -auto-top".to_string()
+    };
+    // Lower $assert/$assume/$cover/$check/$print -> GEM_ASSERT (aigpdk.v), so the
+    // emulator sees them; or delete them for a pure netlist.
+    let assertion_step = if keep_assertions {
+        "techmap -map gem_formal.v"
+    } else {
+        "chformal -remove\n        delete t:$print"
+    };
+    format!(
+        "\
+# Generated by `jacquard build` (ADR 0021). aigpdk logic + memory synthesis.
+# GEM_ASSERT and aigpdk cells are emitted as blackbox instances (no defs needed).
+{reads}
+{hierarchy}
+
+# Flatten + memory synthesis: recognize + map RAM blocks (memlib_yosys.txt).
+flatten
+proc
+opt_expr; opt_dff; opt_clean
+memory -nomap
+memory_libmap -lib memlib_yosys.txt -logic-cost-rom 100 -logic-cost-ram 100
+
+# Logic synthesis to aigpdk cells (begin phase already done above).
+synth{top_arg} -run coarse:
+{assertion_step}
+dfflibmap -liberty aigpdk_nomem.lib
+opt_clean -purge
+abc -liberty aigpdk_nomem.lib
+opt_clean -purge
+techmap
+abc -liberty aigpdk_nomem.lib
+opt_clean -purge
+
+write_verilog -noattr gatelevel.gv
+stat
+"
+    )
+}
+
+/// Resolve `yosys.wasm` and its `share/` dir: explicit arg → `JACQUARD_YOSYS_WASM`
+/// env → a discovered `yowasp_yosys` Python install. (Fetch-from-release is a
+/// planned follow-up — see ADR 0021 / #162.)
+fn locate_yosys_wasm(explicit: Option<&Path>) -> Result<(PathBuf, PathBuf)> {
+    if let Some(p) = explicit {
+        return with_share(p.to_path_buf());
+    }
+    if let Ok(env) = std::env::var("JACQUARD_YOSYS_WASM") {
+        if !env.is_empty() {
+            return with_share(PathBuf::from(env));
+        }
+    }
+    if let Some(found) = discover_yowasp() {
+        return Ok(found);
+    }
+    bail!(
+        "could not find yosys.wasm. Pass --yosys-wasm <path>, set \
+         JACQUARD_YOSYS_WASM, or install the YoWASP Yosys wheel \
+         (`pip install yowasp-yosys`). Automatic fetch is a planned follow-up \
+         (ADR 0021 / #162)."
+    )
+}
+
+/// Given a `yosys.wasm` path, locate its sibling `share/` dir (the layout in the
+/// YoWASP wheel: `<pkg>/yosys.wasm` + `<pkg>/share`).
+fn with_share(wasm: PathBuf) -> Result<(PathBuf, PathBuf)> {
+    if !wasm.is_file() {
+        bail!("yosys.wasm not found at {}", wasm.display());
+    }
+    let share = wasm
+        .parent()
+        .map(|d| d.join("share"))
+        .filter(|s| s.is_dir())
+        .with_context(|| {
+            format!(
+                "no `share/` dir beside {} (expected the YoWASP wheel layout)",
+                wasm.display()
+            )
+        })?;
+    Ok((wasm, share))
+}
+
+/// Best-effort discovery of an installed `yowasp_yosys` package via Python.
+fn discover_yowasp() -> Option<(PathBuf, PathBuf)> {
+    for py in ["python3", "python"] {
+        let out = std::process::Command::new(py)
+            .args([
+                "-c",
+                "import yowasp_yosys, pathlib; \
+                 p = pathlib.Path(yowasp_yosys.__file__).parent; \
+                 print(p / 'yosys.wasm'); print(p / 'share')",
+            ])
+            .output()
+            .ok()?;
+        if out.status.success() {
+            let text = String::from_utf8_lossy(&out.stdout);
+            let mut lines = text.lines();
+            let wasm = PathBuf::from(lines.next()?.trim());
+            let share = PathBuf::from(lines.next()?.trim());
+            if wasm.is_file() && share.is_dir() {
+                return Some((wasm, share));
+            }
+        }
+    }
+    None
+}
+
+/// Compile `yosys.wasm` to native, caching the result on disk keyed by content
+/// hash — mirrors `yowasp_runtime`'s serialize/deserialize cache so only the
+/// first `build` pays the (large) cranelift compile.
+fn load_module(engine: &Engine, wasm_path: &Path) -> Result<Module> {
+    let bytes =
+        std::fs::read(wasm_path).with_context(|| format!("reading {}", wasm_path.display()))?;
+
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    // Distinguish incompatible serialized formats across wasmtime versions.
+    env!("CARGO_PKG_VERSION").hash(&mut hasher);
+    let key = format!("yosys-{:016x}.cwasm", hasher.finish());
+
+    let cache_dir = cache_dir();
+    let cache_file = cache_dir.join(&key);
+
+    if cache_file.is_file() {
+        // SAFETY: file is one we wrote with a matching engine/version key; any
+        // mismatch is caught and we fall back to a fresh compile.
+        if let Ok(m) = unsafe { Module::deserialize_file(engine, &cache_file) } {
+            return Ok(m);
+        }
+    }
+
+    clilog::info!("jacquard build: compiling yosys.wasm (first run; cached after)");
+    // cranelift/wasmtime log a torrent of DEBUG/TRACE through the `log` facade;
+    // clip it to Info for the compile so the netlist output isn't buried, then
+    // restore. Yosys's own stdout/stderr is inherited (not via `log`), so this
+    // doesn't hide synthesis messages.
+    let prior = log::max_level();
+    if prior > log::LevelFilter::Info {
+        log::set_max_level(log::LevelFilter::Info);
+    }
+    let module = Module::from_binary(engine, &bytes).context("compiling yosys.wasm");
+    log::set_max_level(prior);
+    let module = module?;
+    if let Ok(serialized) = module.serialize() {
+        let _ = std::fs::create_dir_all(&cache_dir);
+        let _ = std::fs::write(&cache_file, serialized);
+    }
+    Ok(module)
+}
+
+/// Persistent cache dir: `$XDG_CACHE_HOME/jacquard` or `$HOME/.cache/jacquard`,
+/// falling back to the system temp dir.
+fn cache_dir() -> PathBuf {
+    if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        if !xdg.is_empty() {
+            return PathBuf::from(xdg).join("jacquard");
+        }
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.is_empty() {
+            return PathBuf::from(home).join(".cache").join("jacquard");
+        }
+    }
+    std::env::temp_dir().join("jacquard")
+}
+
+/// Run `yosys -s synth.ys` inside `work_dir` from the WASM module — a Rust port
+/// of `yowasp_runtime.run_wasm`'s WASI setup (preopen cwd, `/share`, `/tmp`).
+fn run_yosys_wasm(wasm_path: &Path, share_dir: &Path, work_dir: &Path) -> Result<()> {
+    let engine = Engine::default();
+    let module = load_module(&engine, wasm_path)?;
+
+    let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
+    p1::add_to_linker_sync(&mut linker, |t| t)?;
+
+    let mut builder = WasiCtxBuilder::new();
+    builder.inherit_stdin().inherit_stdout().inherit_stderr();
+    builder.args(&["yosys", "-s", "synth.ys"]);
+    // cwd -> work dir (relative reads/writes land here)
+    builder.preopened_dir(work_dir, ".", DirPerms::all(), FilePerms::all())?;
+    // Yosys's built-in datadir is compiled to /share in the wasi build.
+    builder.preopened_dir(share_dir, "/share", DirPerms::all(), FilePerms::all())?;
+    // Yosys (and in-process abc) want a writable /tmp.
+    builder.preopened_dir(
+        std::env::temp_dir(),
+        "/tmp",
+        DirPerms::all(),
+        FilePerms::all(),
+    )?;
+
+    let wasi = builder.build_p1();
+    let mut store = Store::new(&engine, wasi);
+    let instance = linker.instantiate(&mut store, &module)?;
+    let start = instance.get_typed_func::<(), ()>(&mut store, "_start")?;
+
+    match start.call(&mut store, ()) {
+        Ok(()) => Ok(()),
+        Err(e) => match e.downcast_ref::<I32Exit>() {
+            Some(exit) if exit.0 == 0 => Ok(()),
+            Some(exit) => bail!("Yosys exited with code {}", exit.0),
+            None => Err(e).context("Yosys WASM trap"),
+        },
+    }
+}


### PR DESCRIPTION
Implements the **behavioral-RTL on-ramp** (ADR 0021): `jacquard sim design.v in.vcd out.vcd N` and `jacquard cosim design.v --config …` now accept **behavioral Verilog/SystemVerilog directly** — synthesis is a transparent, cached pre-processor. No separate `build` step, no Python, no external toolchain.

> **Design note:** this PR was re-scoped before merge from a standalone `jacquard build` command to **folding synthesis into `sim`/`cosim`**. The embedded-Yosys/`wasmtime` engine is unchanged; only the entry point moved. See the ADR's "Revised 2026-07-03" note and the Alternatives section for the rationale.

## What lands

**Input dispatch** (`src/sim/setup.rs::resolve_netlist_input`, ADR §1):
- Behavioral RTL (structural parse fails) → synthesize via embedded YoWASP Yosys → simulate.
- Gate-level netlist, built-in PDK cells → simulate directly.
- Gate-level netlist, **unrecognized** cells → actionable error toward `--cell-descriptor` (not synthesized — it's already a netlist).
- `--rtl` / `--netlist` override detection; `--emit-synth <path>` dumps the intermediate netlist; `--yosys-wasm <path>` points at the wasm.

**SystemVerilog frontend:** fronted with **yosys-slang** (`read_slang`, verified present in the pinned `yowasp-yosys 0.64` wasm — a near-complete SV-2017 elaborator), falling back to `read_verilog -sv` on older modules.

**Distribution & CI (Phase 2):** released binaries build `--features metal,synth`; new Linux `synth-onramp` job (compile + classifier tests) and a Metal on-ramp smoke that synthesizes `dff_test.v` on real GPU and asserts **bit-identical** waves to the committed gate-level fixture.

**Docs (Phase 3):** new `docs/accepted-rtl.md` (the accepted RTL surface — slang coverage, project mappings, known limits, sv-tests as the authoritative measure); getting-started/installation/synthesis-flow/CLAUDE.md rewritten to the single-command story; stale `jacquard map` references removed.

## Verification
- `cargo test --lib` (+ `--features synth` classifier tests) green; CI green including the new synth jobs.
- Metal e2e: behavioral `dff_test.v` → auto-synth → GPU produces waves bit-identical to `dff_test_synth.gv`.

## Not in this PR (ADR 0021 Phase 4, tracked in `docs/plans/rtl-onramp-sim-integration.md`)
Fetch-`yosys.wasm`-from-release, `--synth-target sky130|gf180`, wiring L4 timing from the descriptor onto the runtime path, the sv-tests coverage table, and the `$display` display-info JSON companion. **Phase 2 (`\src` provenance)** remains a separate roadmap item.

Refs #162.
