### PR TITLE
feat(timing): source L4 from the cell-model-IR descriptor everywhere (ADR 0019 D5)

### DIFF
--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -498,6 +498,21 @@ struct DumpPathsArgs {
     #[clap(long)]
     timing_ir: Option<PathBuf>,
 
+    /// Generated cell-model-IR descriptor (ADR 0019), same as `sim`/`cosim`.
+    /// When set (or auto-selected from the netlist), supplies L4 timing.
+    #[clap(long = "cell-descriptor", value_name = "PATH")]
+    cell_descriptor: Option<PathBuf>,
+
+    /// Build-time-embedded cell-model-IR descriptor by name (ADR 0019 D7),
+    /// same as `sim`/`cosim`.
+    #[clap(long = "bundled-descriptor", value_name = "NAME")]
+    bundled_descriptor: Option<String>,
+
+    /// PVT corner to read L4 timing from in the descriptor (ADR 0019 D5).
+    /// Absent uses the descriptor's `default_corner`.
+    #[clap(long = "corner", value_name = "NAME")]
+    corner: Option<String>,
+
     /// Number of critical paths to dump (default: 5).
     #[clap(long, default_value = "5")]
     limit: usize,
@@ -597,15 +612,24 @@ fn cmd_sim(args: SimArgs) {
         bundled_descriptor: args.bundled_descriptor.clone(),
         trace_signals: args.trace_signals.clone(),
         extra_observable_signals: Vec::new(),
+        corner: args.corner.clone(),
+        timed: args.timed,
     };
 
     #[allow(unused_mut)]
     let mut design = setup::load_design(&design_args);
 
-    // Enable timing arrival readback if --timed is set
+    // Enable timing arrival readback if --timed is set. ADR 0019 D5: --timed no
+    // longer strictly requires --sdf/--liberty/--timing-ir — a matching cell-
+    // model-IR descriptor supplies L4, loaded into the script by load_design.
+    // Require that *some* timing source ended up loaded rather than a specific
+    // flag.
     if args.timed {
-        if args.sdf.is_none() && args.liberty.is_none() && args.timing_ir.is_none() {
-            eprintln!("Error: --timed requires --sdf, --liberty, or --timing-ir");
+        if !design.script.timing_enabled {
+            eprintln!(
+                "Error: --timed requires a timing source (--sdf, --liberty, \
+                 --timing-ir, or a cell-model-IR descriptor matching the netlist)"
+            );
             std::process::exit(1);
         }
         design.script.enable_timing_arrivals();
@@ -1851,8 +1875,6 @@ fn run_timing_analysis(
     netlistdb: &netlistdb::NetlistDB,
     args: &SimArgs,
 ) {
-    use jacquard::liberty_parser::TimingLibrary;
-
     clilog::info!("Running timing analysis on GPU simulation results...");
     let timer_timing = clilog::stimer!("timing_analysis");
 
@@ -1861,36 +1883,15 @@ fn run_timing_analysis(
     // parse. Descriptor selection mirrors the functional path's C3.2 precedence
     // (explicit file > bundled name > netlist-prefix auto-match); the same
     // descriptor that built the AIG also supplies its timing. Falls back to
-    // `--liberty` / the AIGPDK default when nothing matches.
-    let descriptor = jacquard::bundled_descriptors::resolve(
+    // `--liberty` / the AIGPDK default when nothing matches. Shared with the
+    // no-SDF pre-layout timing path via `resolve_timing_library`.
+    let lib = jacquard::liberty_parser::resolve_timing_library(
+        netlistdb.celltypes.iter().map(|s| s.as_str()),
         args.cell_descriptor.as_deref(),
         args.bundled_descriptor.as_deref(),
-    )
-    .or_else(|| {
-        jacquard::bundled_descriptors::auto_select(netlistdb.celltypes.iter().map(|s| s.as_str()))
-            .unwrap_or_else(|e| panic!("{e}"))
-    });
-    let lib = if let Some(ir) = descriptor {
-        let corner_name = args.corner.as_deref().unwrap_or(&ir.default_corner);
-        let corner_index = ir.corner_index(corner_name).unwrap_or_else(|| {
-            panic!(
-                "--corner '{}' not found in descriptor corner set {:?}",
-                corner_name,
-                ir.corners.iter().map(|c| &c.name).collect::<Vec<_>>()
-            )
-        });
-        clilog::info!(
-            "L4 timing from cell-model-IR descriptor '{}' at corner '{}' (index {})",
-            ir.library.name,
-            corner_name,
-            corner_index
-        );
-        TimingLibrary::from_cell_model_ir(&ir, corner_index)
-    } else if let Some(lib_path) = &args.liberty {
-        TimingLibrary::from_file(lib_path).expect("Failed to load Liberty library")
-    } else {
-        TimingLibrary::load_aigpdk().expect("Failed to load default AIGPDK library")
-    };
+        args.corner.as_deref(),
+        args.liberty.as_deref(),
+    );
     clilog::info!("Loaded Liberty library: {}", lib.name);
 
     aig.load_timing_library(&lib);
@@ -1955,7 +1956,6 @@ fn run_timing_analysis(
 }
 
 fn cmd_dump_paths(args: DumpPathsArgs) {
-    use jacquard::liberty_parser::TimingLibrary;
     use jacquard::sim::setup;
 
     clilog::info!("Loading design for critical path analysis...");
@@ -1977,21 +1977,28 @@ fn cmd_dump_paths(args: DumpPathsArgs) {
         timing_ir: args.timing_ir.clone(),
         timing_corner: None,
         cell_library: Vec::new(),
-        cell_descriptor: None,
-        bundled_descriptor: None,
+        cell_descriptor: args.cell_descriptor.clone(),
+        bundled_descriptor: args.bundled_descriptor.clone(),
         trace_signals: None,
         extra_observable_signals: Vec::new(),
+        corner: args.corner.clone(),
+        timed: false,
     };
 
     let mut design = setup::load_design(&design_args);
     clilog::finish!(timer);
 
     clilog::info!("Loading timing library...");
-    let lib = if let Some(lib_path) = &args.liberty {
-        TimingLibrary::from_file(lib_path).expect("Failed to load Liberty library")
-    } else {
-        TimingLibrary::load_aigpdk().expect("Failed to load default AIGPDK library")
-    };
+    // ADR 0019 D5: descriptor L4 (explicit > bundled > netlist-prefix
+    // auto-select) → `--liberty` override → AIGPDK default, via the shared
+    // `resolve_timing_library` — same precedence as `run_timing_analysis`.
+    let lib = jacquard::liberty_parser::resolve_timing_library(
+        design.netlistdb.celltypes.iter().map(|s| s.as_str()),
+        args.cell_descriptor.as_deref(),
+        args.bundled_descriptor.as_deref(),
+        args.corner.as_deref(),
+        args.liberty.as_deref(),
+    );
     clilog::info!("Loaded Liberty library: {}", lib.name);
 
     let aig = &mut design.aig;
@@ -2209,6 +2216,11 @@ fn cmd_cosim(args: CosimArgs) {
             bundled_descriptor: args.bundled_descriptor.clone(),
             trace_signals: args.trace_signals.clone(),
             extra_observable_signals: bus_trace_signals,
+            // cosim has no `--corner`/`--timed`; its no-SDF path stays off
+            // unless a timing IR is supplied (handled by load_timing_ir, whose
+            // descriptor fallback still uses `default_corner`).
+            corner: None,
+            timed: false,
         };
 
         let mut design = setup::load_design(&design_args);

--- a/src/bin/timing_analysis.rs
+++ b/src/bin/timing_analysis.rs
@@ -10,7 +10,6 @@
 
 use jacquard::aig::AIG;
 use jacquard::aigpdk::AIGPDKLeafPins;
-use jacquard::liberty_parser::TimingLibrary;
 use netlistdb::NetlistDB;
 use std::path::PathBuf;
 
@@ -71,15 +70,7 @@ fn main() {
     let args = <Args as clap::Parser>::parse();
     clilog::info!("Timing analysis args:\n{:#?}", args);
 
-    // Load Liberty library
-    let lib = if let Some(lib_path) = &args.liberty {
-        TimingLibrary::from_file(lib_path).expect("Failed to load Liberty library")
-    } else {
-        TimingLibrary::load_aigpdk().expect("Failed to load default AIGPDK library")
-    };
-    clilog::info!("Loaded Liberty library: {}", lib.name);
-
-    // Load netlist
+    // Load netlist first so descriptor auto-selection can key on its cell types.
     clilog::info!("Loading netlist: {:?}", args.netlist_verilog);
     let netlistdb = NetlistDB::from_sverilog_file(
         &args.netlist_verilog,
@@ -87,6 +78,21 @@ fn main() {
         &AIGPDKLeafPins(),
     )
     .expect("Failed to build netlist");
+
+    // ADR 0019 D5: timing via the shared `resolve_timing_library` — descriptor
+    // L4 (netlist-prefix auto-select) → `--liberty` override → AIGPDK default.
+    // This dev tool parses AIGPDK netlists only (no `--cell-descriptor` flag),
+    // so auto-select finds no prefix match and it resolves to `--liberty` or the
+    // bundled AIGPDK default — its historical behaviour, with no raw runtime
+    // `.lib` parse of its own.
+    let lib = jacquard::liberty_parser::resolve_timing_library(
+        netlistdb.celltypes.iter().map(|s| s.as_str()),
+        None,
+        None,
+        None,
+        args.liberty.as_deref(),
+    );
+    clilog::info!("Loaded Liberty library: {}", lib.name);
 
     clilog::info!(
         "Netlist loaded: {} pins, {} cells",

--- a/src/liberty_parser.rs
+++ b/src/liberty_parser.rs
@@ -142,6 +142,59 @@ pub struct TimingLibrary {
     pub cells: IndexMap<String, CellTiming>,
 }
 
+/// Resolve the runtime [`TimingLibrary`] a run should consume, applying the
+/// ADR 0019 D5 precedence — the single implementation shared by the `sim
+/// --timed` static-timing path, the no-SDF pre-layout timing path
+/// (`src/sim/setup.rs`), the SDF / timing-IR `liberty_fallback`, and the
+/// `dump-paths` / standalone `timing_analysis` dev tools.
+///
+/// Precedence:
+/// 1. **descriptor L4** — cell-model-IR (ADR 0019): explicit
+///    `--cell-descriptor <path>` > `--bundled-descriptor <name>` >
+///    netlist-cell-prefix auto-select. Corner is `corner` (`--corner`) or the
+///    descriptor's `default_corner`.
+/// 2. **`--liberty <path>`** — an explicit runtime `.lib` parse, kept as an
+///    override for libraries without a bundled/auto-selectable descriptor.
+/// 3. **AIGPDK default** — `aigpdk/aigpdk.lib`, matching `pdk::resolve_library`.
+///
+/// `cell_types` is the netlist's cell-type set, used only for the auto-select
+/// tier. Panics with an actionable message on a bad `--corner`, a bad
+/// `--cell-descriptor` path/unknown bundled name (via
+/// [`crate::bundled_descriptors::resolve`]), or an ambiguous auto-select.
+pub fn resolve_timing_library<'a>(
+    cell_types: impl Iterator<Item = &'a str>,
+    cell_descriptor: Option<&Path>,
+    bundled_descriptor: Option<&str>,
+    corner: Option<&str>,
+    liberty: Option<&Path>,
+) -> TimingLibrary {
+    let descriptor = crate::bundled_descriptors::resolve(cell_descriptor, bundled_descriptor)
+        .or_else(|| {
+            crate::bundled_descriptors::auto_select(cell_types).unwrap_or_else(|e| panic!("{e}"))
+        });
+    if let Some(ir) = descriptor {
+        let corner_name = corner.unwrap_or(&ir.default_corner);
+        let corner_index = ir.corner_index(corner_name).unwrap_or_else(|| {
+            panic!(
+                "--corner '{}' not found in descriptor corner set {:?}",
+                corner_name,
+                ir.corners.iter().map(|c| &c.name).collect::<Vec<_>>()
+            )
+        });
+        clilog::info!(
+            "L4 timing from cell-model-IR descriptor '{}' at corner '{}' (index {})",
+            ir.library.name,
+            corner_name,
+            corner_index
+        );
+        TimingLibrary::from_cell_model_ir(&ir, corner_index)
+    } else if let Some(lib_path) = liberty {
+        TimingLibrary::from_file(lib_path).expect("Failed to load Liberty library")
+    } else {
+        TimingLibrary::load_aigpdk().expect("Failed to load default AIGPDK library")
+    }
+}
+
 impl TimingLibrary {
     /// Load a Liberty library from a file path.
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self, String> {
@@ -1008,5 +1061,51 @@ library ("sky130_fd_sc_hd__tt_025C_1v80") {
         let lib = TimingLibrary::parse_unchecked(no_cells)
             .expect("parse_unchecked should accept zero-cell Liberty");
         assert!(lib.cells.is_empty());
+    }
+
+    /// ADR 0019 D5: a built-in-PDK design with **no `--liberty`** must get its
+    /// L4 timing from the embedded cell-model-IR descriptor. A SKY130 cell-type
+    /// set auto-selects the SKY130 descriptor through `resolve_timing_library`
+    /// (no `cell_descriptor`/`bundled_descriptor`/`liberty` supplied), yielding a
+    /// non-empty timing library named after that descriptor — proving the no-
+    /// `--liberty` timed path is served entirely from the embedded descriptor.
+    #[test]
+    fn no_liberty_timed_run_gets_l4_from_embedded_descriptor() {
+        // SKY130 may be empty in a submodule-absent build; only assert when its
+        // declared prefix is present (mirrors the bundled_descriptors tests).
+        let sky = crate::bundled_descriptors::load("sky130").expect("sky130 descriptor must load");
+        if sky.library.prefixes.is_empty() {
+            eprintln!("skipping: sky130 submodule absent at build time");
+            return;
+        }
+
+        let cells = [
+            "sky130_fd_sc_hd__inv_2",
+            "sky130_fd_sc_hd__nand2_1",
+            "sky130_fd_sc_hd__dfxtp_1",
+        ];
+        // No cell_descriptor, no bundled_descriptor, no --corner, no --liberty:
+        // the netlist prefix alone selects the embedded SKY130 descriptor.
+        let lib = resolve_timing_library(cells.iter().copied(), None, None, None, None);
+
+        assert!(
+            lib.name.starts_with("sky130_fd_sc_hd__"),
+            "expected the SKY130 descriptor library, got '{}'",
+            lib.name
+        );
+        assert!(
+            !lib.cells.is_empty(),
+            "descriptor L4 must yield a non-empty timing library"
+        );
+        // The DFF cell must carry real timing arcs (setup/hold + clock→Q), i.e.
+        // the L4 projection is populated, not a hollow shell.
+        let dff = lib
+            .cells
+            .get("sky130_fd_sc_hd__dfxtp_1")
+            .expect("SKY130 D-flop must be present in the descriptor L4");
+        assert!(
+            !dff.pins.is_empty(),
+            "SKY130 D-flop must carry timing pins from descriptor L4"
+        );
     }
 }

--- a/src/sim/setup.rs
+++ b/src/sim/setup.rs
@@ -79,6 +79,17 @@ pub struct DesignArgs {
     /// to surface a configured bus's pins). Registered through the same
     /// path as `trace_signals`.
     pub extra_observable_signals: Vec<String>,
+    /// Optional `--corner <NAME>` — the ADR 0019 D5 PVT corner to read L4
+    /// timing from in the descriptor-driven no-SDF pre-layout timing path.
+    /// Names a corner in the resolved descriptor's corner set; absent uses the
+    /// descriptor's `default_corner`. Distinct from `timing_corner`, which
+    /// selects a corner in a per-design timing IR (ADR 0002).
+    pub corner: Option<String>,
+    /// `--timed` requested pre-layout timing without an SDF/IR. Triggers the
+    /// no-SDF timing path (ADR 0019 D5) to source L4 from the cell-model-IR
+    /// descriptor even when `--liberty` is absent. When false, that path fires
+    /// only if `--liberty` was passed (legacy opt-in).
+    pub timed: bool,
 }
 
 /// Result of loading a design: everything needed for simulation.
@@ -352,6 +363,9 @@ pub fn load_design(args: &DesignArgs) -> LoadedDesign {
             args.clock_period_ps,
             args.liberty.as_deref(),
             args.timing_corner.as_deref(),
+            args.cell_descriptor.as_deref(),
+            args.bundled_descriptor.as_deref(),
+            args.corner.as_deref(),
             args.sdf_debug,
         );
     } else if let Some(ref sdf_path) = args.sdf {
@@ -370,24 +384,36 @@ pub fn load_design(args: &DesignArgs) -> LoadedDesign {
             args.top_module.as_deref(),
             args.clock_period_ps,
             args.timing_corner.as_deref(),
+            args.cell_descriptor.as_deref(),
+            args.bundled_descriptor.as_deref(),
+            args.corner.as_deref(),
             args.sdf_debug,
         );
     }
 
-    // Load Liberty-only timing if provided and no SDF/IR
-    if args.sdf.is_none() && args.timing_ir.is_none() {
-        if let Some(ref lib_path) = args.liberty {
-            use crate::liberty_parser::TimingLibrary;
-            let lib = TimingLibrary::from_file(lib_path).expect("Failed to load Liberty library");
-            let clock_ps = args.clock_period_ps.unwrap_or(25000);
-            clilog::info!(
-                "Loading Liberty timing: {:?} (clock_period={}ps)",
-                lib_path,
-                clock_ps
-            );
-            script.load_timing(&aig, &netlistdb, &lib, clock_ps);
-            script.inject_timing_to_script();
-        }
+    // Pre-layout (no-SDF, no-IR) timing. ADR 0019 D5: source per-cell-type L4
+    // from the cell-model-IR descriptor (explicit > bundled > netlist-prefix
+    // auto-select), with `--liberty` as an explicit `.lib` override and AIGPDK
+    // as the default — one implementation via `resolve_timing_library`. The
+    // trigger stays opt-in so functional runs pay no timing cost: fire when
+    // `--liberty` was passed (legacy) or `--timed` requested it (the D5 case —
+    // timing from the embedded descriptor with no `--liberty`).
+    if args.sdf.is_none() && args.timing_ir.is_none() && (args.liberty.is_some() || args.timed) {
+        let lib = crate::liberty_parser::resolve_timing_library(
+            netlistdb.celltypes.iter().map(|s| s.as_str()),
+            args.cell_descriptor.as_deref(),
+            args.bundled_descriptor.as_deref(),
+            args.corner.as_deref(),
+            args.liberty.as_deref(),
+        );
+        let clock_ps = args.clock_period_ps.unwrap_or(25000);
+        clilog::info!(
+            "Loading pre-layout timing '{}' (clock_period={}ps)",
+            lib.name,
+            clock_ps
+        );
+        script.load_timing(&aig, &netlistdb, &lib, clock_ps);
+        script.inject_timing_to_script();
     }
 
     // Print script hash
@@ -423,6 +449,9 @@ pub fn load_sdf_via_opensta_to_ir(
     top_module: Option<&str>,
     clock_period_ps: Option<u64>,
     corner_name: Option<&str>,
+    cell_descriptor: Option<&Path>,
+    bundled_descriptor: Option<&str>,
+    l4_corner: Option<&str>,
     debug: bool,
 ) {
     let liberty_path = liberty_path.unwrap_or_else(|| {
@@ -482,7 +511,18 @@ pub fn load_sdf_via_opensta_to_ir(
     let ir_file = crate::sim::timing_ir_loader::TimingIrFile::from_bytes(ir_buf)
         .unwrap_or_else(|e| panic!("opensta-to-ir produced invalid IR: {e}"));
 
-    let liberty_fallback = crate::liberty_parser::TimingLibrary::from_file(liberty_path).ok();
+    // ADR 0019 D5: the per-cell-type fallback for instances the SDF/IR does not
+    // annotate comes from the cell-model-IR descriptor's L4 (explicit > bundled
+    // > netlist-prefix auto-select), with the (OpenSTA-required) `--liberty` as
+    // the override. The per-instance IR remains PRIMARY (ADR 0002); this only
+    // fills cells absent from it.
+    let liberty_fallback = Some(crate::liberty_parser::resolve_timing_library(
+        netlistdb.celltypes.iter().map(|s| s.as_str()),
+        cell_descriptor,
+        bundled_descriptor,
+        l4_corner,
+        Some(liberty_path),
+    ));
 
     let ir = ir_file.view();
     let corner_index = crate::flatten::resolve_corner_index(&ir, corner_name)
@@ -503,6 +543,7 @@ pub fn load_sdf_via_opensta_to_ir(
 ///
 /// Mirrors `load_sdf` but consumes the IR via `TimingIrFile`. Optionally
 /// uses a Liberty library as fallback for cells absent from the IR.
+#[allow(clippy::too_many_arguments)]
 pub fn load_timing_ir(
     script: &mut FlattenedScriptV1,
     aig: &AIG,
@@ -511,6 +552,9 @@ pub fn load_timing_ir(
     clock_period_ps: Option<u64>,
     liberty_fallback_path: Option<&Path>,
     corner_name: Option<&str>,
+    cell_descriptor: Option<&Path>,
+    bundled_descriptor: Option<&str>,
+    l4_corner: Option<&str>,
     debug: bool,
 ) {
     let clock_ps = clock_period_ps.unwrap_or(25000);
@@ -528,15 +572,16 @@ pub fn load_timing_ir(
         }
     };
 
-    let liberty_fallback = liberty_fallback_path.and_then(|p| {
-        match crate::liberty_parser::TimingLibrary::from_file(p) {
-            Ok(lib) => Some(lib),
-            Err(e) => {
-                clilog::warn!("Liberty fallback unavailable: {}", e);
-                None
-            }
-        }
-    });
+    // ADR 0019 D5: cells absent from the timing IR fall back to the cell-model-
+    // IR descriptor's L4 (explicit > bundled > netlist-prefix auto-select), with
+    // `--liberty` as the override. The per-instance IR stays PRIMARY (ADR 0002).
+    let liberty_fallback = Some(crate::liberty_parser::resolve_timing_library(
+        netlistdb.celltypes.iter().map(|s| s.as_str()),
+        cell_descriptor,
+        bundled_descriptor,
+        l4_corner,
+        liberty_fallback_path,
+    ));
 
     let ir = ir_file.view();
     let corner_index = crate::flatten::resolve_corner_index(&ir, corner_name)


### PR DESCRIPTION
Finishes ADR 0019 D5: the descriptor already **carried** L4 timing and `sim --timed` static timing already consumed it — this retires the remaining runtime `TimingLibrary::from_file` `.lib` parses so **all** runtime timing comes from the (embedded, auto-selected) descriptor.

## What changed
- **New shared helper `resolve_timing_library`** (`src/liberty_parser.rs`) — one implementation of the D5 precedence: descriptor L4 (explicit `--cell-descriptor` > `--bundled-descriptor` > **netlist-prefix auto-select**) → `--liberty` explicit override → AIGPDK default.
- **Routed every runtime timing consumer through it:**
  - `src/sim/setup.rs` no-SDF pre-layout path — **now fires on `--timed` even with no `--liberty`** (the primary D5 gap: L4 matters most in the no-SDF path). Functional runs (no `--timed`/`--liberty`) still skip timing entirely.
  - `load_sdf` / `load_timing_ir` `liberty_fallback` — per-cell fallback for instances the SDF/timing-IR doesn't annotate now comes from the descriptor. **The per-instance SDF/timing-IR stays PRIMARY (ADR 0002).**
  - `run_timing_analysis` (refactored onto the helper), `dump-paths`, and the standalone `timing_analysis` dev tool.
- The only remaining `TimingLibrary::from_file` is *inside* the helper — the `--liberty` explicit-override tier.

## Verified
- GF180 `jtag_minimal` 9t MD5 `d87c9f75…` unchanged (functional untouched)
- SKY130 `mcu_soc` flash cosim == golden; AIGPDK `COSIM_SCOPE=all` 7/7 == goldens
- `inv_chain_pnr --timed` with **no `--liberty`** now auto-selects the sky130 descriptor and logs "L4 timing from cell-model-IR descriptor" — the D5 win
- `cargo test --lib` 318 (incl. a new auto-select timing test); clippy `--lib` 0 errors; builds clean (no-feature + `--features metal`); lockstep 0.2.4

Note: for GF180 the descriptor L4 is *more faithful* than the old `--liberty` path (honours `time_unit:1ns`; surfaces negedge clk→Q) per the C2.4 finding. No committed timing golden shifted (`inv_chain_pnr` validates JSON shape, uses `--timing-ir` primary with no `--liberty`).