### PR TITLE
feat(cosim): plural qspi_memory peripheral — config + CpuBackend (Stage A of #159 base)

### DIFF
--- a/src/sim/cosim/metal.rs
+++ b/src/sim/cosim/metal.rs
@@ -960,6 +960,19 @@ impl MetalBackend {
         state_size: usize,
         gpio_map: &GpioMapping,
     ) -> (metal::Buffer, metal::Buffer, metal::Buffer, metal::Buffer) {
+        // Stage A: the GPU flash kernels are single-instance. The plural CPU
+        // path steps every `qspi_memory` entry; the GPU N-instance kernels are
+        // Stage B. Guard N>1 here (the GPU build path) so N=1 stays byte-
+        // identical and N>1 fails clearly rather than silently dropping memories.
+        let qspi = config.effective_qspi_memory();
+        assert!(
+            qspi.len() <= 1,
+            "multiple QSPI memories ({}) on the GPU backend requires stage B; \
+             use the CPU backend (build without a GPU feature / `--backend cpu`)",
+            qspi.len()
+        );
+        let primary = qspi.first();
+
         // FlashState (shared, persistent across ticks)
         let flash_state_buffer = device.new_buffer(
             std::mem::size_of::<FlashState>() as u64,
@@ -996,12 +1009,10 @@ impl MetalBackend {
         );
         unsafe {
             let p = &mut *(flash_din_params_buffer.contents() as *mut FlashDinParams);
-            p.has_flash = if config.flash.is_some() { 1 } else { 0 };
+            p.has_flash = if primary.is_some() { 1 } else { 0 };
             p.xmask_state_offset = script.xprop_state_offset;
             for i in 0..4 {
-                p.d_in_pos[i] = config
-                    .flash
-                    .as_ref()
+                p.d_in_pos[i] = primary
                     .and_then(|f| gpio_map.input_bits.get(&(f.d0_gpio + i)).copied())
                     .unwrap_or(0xFFFFFFFF);
             }
@@ -1015,20 +1026,14 @@ impl MetalBackend {
         unsafe {
             let p = &mut *(flash_model_params_buffer.contents() as *mut FlashModelParams);
             p.state_size = state_size as u32;
-            p.clk_out_pos = config
-                .flash
-                .as_ref()
+            p.clk_out_pos = primary
                 .and_then(|f| gpio_map.output_bits.get(&f.clk_gpio).copied())
                 .unwrap_or(0);
-            p.csn_out_pos = config
-                .flash
-                .as_ref()
+            p.csn_out_pos = primary
                 .and_then(|f| gpio_map.output_bits.get(&f.csn_gpio).copied())
                 .unwrap_or(0);
             for i in 0..4 {
-                p.d_out_pos[i] = config
-                    .flash
-                    .as_ref()
+                p.d_out_pos[i] = primary
                     .and_then(|f| gpio_map.output_bits.get(&(f.d0_gpio + i)).copied())
                     .unwrap_or(0xFFFFFFFF);
             }
@@ -1059,9 +1064,10 @@ impl MetalBackend {
             );
         }
         // Load firmware into flash data buffer
-        if let Some(ref flash_cfg) = config.flash {
+        if let Some(fw_path) = primary.and_then(|f| f.firmware.as_ref()) {
             use std::io::Read;
-            let firmware_path = std::path::Path::new(&flash_cfg.firmware);
+            let flash_cfg = primary.expect("primary present when firmware present");
+            let firmware_path = std::path::Path::new(fw_path);
             let mut file =
                 std::fs::File::open(firmware_path).expect("Failed to open firmware file");
             let mut data = Vec::new();

--- a/src/sim/cosim/mod.rs
+++ b/src/sim/cosim/mod.rs
@@ -1128,6 +1128,17 @@ pub(crate) fn build_flash_buffers_dev(
     ulib::UVec<u8>,
     ulib::UVec<u8>,
 ) {
+    // Stage A: GPU flash kernels are single-instance (Stage B is N-instance).
+    // Guard N>1 in the GPU build path; the plural CPU backend handles N>1.
+    let qspi = config.effective_qspi_memory();
+    assert!(
+        qspi.len() <= 1,
+        "multiple QSPI memories ({}) on the GPU backend requires stage B; \
+         use the CPU backend (build without a GPU feature / `--backend cpu`)",
+        qspi.len()
+    );
+    let primary = qspi.first();
+
     // FlashState (shared, persistent across edges) — mirror build_flash_buffers.
     let mut fs: FlashState = unsafe { std::mem::zeroed() };
     fs.data_width = 1; // SPI single-bit mode
@@ -1140,13 +1151,11 @@ pub(crate) fn build_flash_buffers_dev(
     // FlashDinParams (constant).
     let mut din = FlashDinParams {
         d_in_pos: [0xFFFFFFFF; 4],
-        has_flash: if config.flash.is_some() { 1 } else { 0 },
+        has_flash: if primary.is_some() { 1 } else { 0 },
         xmask_state_offset: script.xprop_state_offset,
     };
     for (i, slot) in din.d_in_pos.iter_mut().enumerate() {
-        *slot = config
-            .flash
-            .as_ref()
+        *slot = primary
             .and_then(|f| gpio_map.input_bits.get(&(f.d0_gpio + i)).copied())
             .unwrap_or(0xFFFFFFFF);
     }
@@ -1155,23 +1164,17 @@ pub(crate) fn build_flash_buffers_dev(
     // FlashModelParams (constant).
     let mut model = FlashModelParams {
         state_size: state_size as u32,
-        clk_out_pos: config
-            .flash
-            .as_ref()
+        clk_out_pos: primary
             .and_then(|f| gpio_map.output_bits.get(&f.clk_gpio).copied())
             .unwrap_or(0),
-        csn_out_pos: config
-            .flash
-            .as_ref()
+        csn_out_pos: primary
             .and_then(|f| gpio_map.output_bits.get(&f.csn_gpio).copied())
             .unwrap_or(0),
         d_out_pos: [0xFFFFFFFF; 4],
         flash_data_size: FLASH_DATA_SIZE as u32,
     };
     for (i, slot) in model.d_out_pos.iter_mut().enumerate() {
-        *slot = config
-            .flash
-            .as_ref()
+        *slot = primary
             .and_then(|f| gpio_map.output_bits.get(&(f.d0_gpio + i)).copied())
             .unwrap_or(0xFFFFFFFF);
     }
@@ -1179,9 +1182,10 @@ pub(crate) fn build_flash_buffers_dev(
 
     // Flash firmware buffer (16 MiB) — 0xFF (erased) then firmware overlaid.
     let mut firmware = vec![0xFFu8; FLASH_DATA_SIZE];
-    if let Some(ref flash_cfg) = config.flash {
+    if let Some(fw_path) = primary.and_then(|f| f.firmware.as_ref()) {
         use std::io::Read;
-        let firmware_path = std::path::Path::new(&flash_cfg.firmware);
+        let flash_cfg = primary.expect("primary present when firmware present");
+        let firmware_path = std::path::Path::new(fw_path);
         let mut file = std::fs::File::open(firmware_path).expect("Failed to open firmware file");
         let mut data = Vec::new();
         file.read_to_end(&mut data)
@@ -2040,29 +2044,30 @@ fn run_cosim_generic<B: CosimBackend>(
     // (FlashModelParams / FlashDinParams). Recompute them here as
     // backend-agnostic locals so the cosim loop's flash diagnostics don't
     // read the GPU param buffers. Bit-identical to the buffer init formulas.
-    let flash_clk_out_pos: u32 = config
-        .flash
+    // These backend-agnostic locals feed the cosim loop's flash *diagnostics*
+    // (verbose logging + the `--check-with-cpu` inline reference, both
+    // single-instance). They describe the primary (instance 0) QSPI memory; the
+    // plural per-instance stepping lives inside `CpuBackend::run_edges`.
+    let qspi_primary = config.effective_qspi_memory().into_iter().next();
+    let flash_clk_out_pos: u32 = qspi_primary
         .as_ref()
         .and_then(|f| gpio_map.output_bits.get(&f.clk_gpio).copied())
         .unwrap_or(0);
-    let flash_csn_out_pos: u32 = config
-        .flash
+    let flash_csn_out_pos: u32 = qspi_primary
         .as_ref()
         .and_then(|f| gpio_map.output_bits.get(&f.csn_gpio).copied())
         .unwrap_or(0);
-    let flash_has: bool = config.flash.is_some();
+    let flash_has: bool = qspi_primary.is_some();
     let mut flash_d_in_pos: [u32; 4] = [0xFFFFFFFF; 4];
     for (i, slot) in flash_d_in_pos.iter_mut().enumerate() {
-        *slot = config
-            .flash
+        *slot = qspi_primary
             .as_ref()
             .and_then(|f| gpio_map.input_bits.get(&(f.d0_gpio + i)).copied())
             .unwrap_or(0xFFFFFFFF);
     }
     let mut flash_d_out_pos: [u32; 4] = [0xFFFFFFFF; 4];
     for (i, slot) in flash_d_out_pos.iter_mut().enumerate() {
-        *slot = config
-            .flash
+        *slot = qspi_primary
             .as_ref()
             .and_then(|f| gpio_map.output_bits.get(&(f.d0_gpio + i)).copied())
             .unwrap_or(0xFFFFFFFF);
@@ -2084,7 +2089,7 @@ fn run_cosim_generic<B: CosimBackend>(
         gpio_map.input_bits.keys().collect::<Vec<_>>()
     );
 
-    if let Some(ref flash_cfg) = config.flash {
+    if let Some(ref flash_cfg) = qspi_primary {
         for i in 0..4 {
             let gpio = flash_cfg.d0_gpio + i;
             if gpio_map.input_bits.contains_key(&gpio) {
@@ -2128,22 +2133,22 @@ fn run_cosim_generic<B: CosimBackend>(
 
     // ── Initialize peripheral models (CPU-side, kept for --check-with-cpu) ──
 
-    let _flash: Option<CppSpiFlash> = if let Some(ref flash_cfg) = config.flash {
-        let mut fl = CppSpiFlash::new(16 * 1024 * 1024);
+    let _flash: Option<CppSpiFlash> = qspi_primary.as_ref().map(|flash_cfg| {
+        let mut fl = CppSpiFlash::new(flash_cfg.backing_size_bytes());
         fl.set_verbose(opts.flash_verbose);
-        let firmware_path = std::path::Path::new(&flash_cfg.firmware);
-        match fl.load_firmware(firmware_path, flash_cfg.firmware_offset) {
-            Ok(size) => clilog::info!(
-                "Loaded {} bytes firmware at offset 0x{:X}",
-                size,
-                flash_cfg.firmware_offset
-            ),
-            Err(e) => panic!("Failed to load firmware: {}", e),
+        if let Some(ref fw) = flash_cfg.firmware {
+            let firmware_path = std::path::Path::new(fw);
+            match fl.load_firmware(firmware_path, flash_cfg.firmware_offset) {
+                Ok(size) => clilog::info!(
+                    "Loaded {} bytes firmware at offset 0x{:X}",
+                    size,
+                    flash_cfg.firmware_offset
+                ),
+                Err(e) => panic!("Failed to load firmware: {}", e),
+            }
         }
-        Some(fl)
-    } else {
-        None
-    };
+        fl
+    });
 
     // CLI --clock-period overrides config file clock_period_ps; default 1000ps (1GHz) if neither set
     let clock_period_ps = opts.clock_period.or(config.clock_period_ps).unwrap_or(1000);
@@ -2735,9 +2740,10 @@ fn run_cosim_generic<B: CosimBackend>(
             }
         }
 
-        // Set flash D_IN defaults (high = no data) — initial state before GPU
-        // flash takes over.
-        if let Some(ref flash_cfg) = config.flash {
+        // Set flash D_IN defaults (high = no data) — initial state before the
+        // backend flash model takes over. Applied per QSPI instance so every
+        // memory's MISO lanes start idle-high (plural CPU backend).
+        for flash_cfg in config.effective_qspi_memory() {
             set_flash_din(
                 &mut states[..state_size],
                 &gpio_map,
@@ -4292,6 +4298,33 @@ impl CpuUartDecoderState {
     }
 }
 
+/// One CPU-side QSPI-memory oracle instance (Stage A plurality).
+///
+/// The single-flash path was a flat set of `flash_*` fields on `CpuBackend`;
+/// making QSPI memory plural (`Vec<QspiMemoryConfig>`) means each configured
+/// instance gets its own `CppSpiFlash` model (its own backing buffer), its own
+/// resolved pin positions, and its own per-edge decode state. `run_edges` steps
+/// every instance independently, routing each one's pins in isolation, so two
+/// memories with different firmware read back independent data.
+struct CpuFlashInstance {
+    /// `CppSpiFlash` model with this instance's own backing buffer. `UnsafeCell`
+    /// because `CppSpiFlash::step` is `&mut` but `run_edges` is `&self`
+    /// (dispatch is sequential).
+    model: UnsafeCell<CppSpiFlash>,
+    /// Pin positions resolved in `new` (mirror `build_flash_buffers`):
+    /// clk/csn/d_out are OUTPUT-slot bit positions, d_in are INPUT-slot (MISO).
+    clk_out_pos: u32,
+    csn_out_pos: u32,
+    d_out_pos: [u32; 4],
+    d_in_pos: [u32; 4],
+    /// Current MISO nibble injected by `apply_flash_din` (mirrors `FlashState.d_i`).
+    d_i: UnsafeCell<u8>,
+    /// Delayed (previous-edge) output csn / d_out for the setup-delay dual-step
+    /// (mirror `FlashState.prev_csn` / `prev_d_out`).
+    prev_csn: UnsafeCell<u32>,
+    prev_d_out: UnsafeCell<u8>,
+}
+
 struct CpuBackend {
     /// Full design state `[input_state | output_state]`, `2 × state_size` words.
     state: UnsafeCell<Vec<u32>>,
@@ -4350,24 +4383,13 @@ struct CpuBackend {
     /// Captured raw beats awaiting drain (mirrors the GPU `BusTraceEntry` ring;
     /// `drain_bus_beats` empties it). Interior-mutable for the per-edge FSM.
     bus_beats: UnsafeCell<Vec<crate::sim::models::bus_trace::RawBeat>>,
-    // ── SPI-flash CPU oracle (Stage C) ──────────────────────────────────────
-    /// `CppSpiFlash` model (`Some` when `config.flash` is set), stepped per edge
-    /// in `run_edges` with the GPU's dual-step + delayed-CSN convention so its
-    /// `d_i` matches `gpu_flash_model_step` byte-for-byte. `UnsafeCell` because
-    /// `CppSpiFlash::step` is `&mut` but `run_edges` is `&self` (sequential).
-    flash: Option<UnsafeCell<CppSpiFlash>>,
-    /// Flash GPIO positions resolved in `new` (mirror `build_flash_buffers`):
-    /// clk/csn/d_out are OUTPUT-slot bit positions, d_in are INPUT-slot (MISO).
-    flash_clk_out_pos: u32,
-    flash_csn_out_pos: u32,
-    flash_d_out_pos: [u32; 4],
-    flash_d_in_pos: [u32; 4],
-    /// Current MISO nibble injected by `apply_flash_din` (mirrors `FlashState.d_i`).
-    flash_d_i: UnsafeCell<u8>,
-    /// Delayed (previous-edge) output csn / d_out for the setup-delay dual-step
-    /// (mirror `FlashState.prev_csn` / `prev_d_out`).
-    flash_prev_csn: UnsafeCell<u32>,
-    flash_prev_d_out: UnsafeCell<u8>,
+    // ── QSPI-memory CPU oracle (Stage A: plural) ────────────────────────────
+    /// One `CppSpiFlash` oracle per configured QSPI memory
+    /// (`config.effective_qspi_memory()`), each stepped per edge in `run_edges`
+    /// with the GPU's dual-step + delayed-CSN convention so instance 0's `d_i`
+    /// matches `gpu_flash_model_step` byte-for-byte. Empty when no memory is
+    /// configured; length 1 preserves the single-flash behaviour byte-for-byte.
+    flashes: Vec<CpuFlashInstance>,
 }
 
 impl CpuBackend {
@@ -4506,48 +4528,72 @@ impl CosimBackend for CpuBackend {
         let (bus_positions, bus_lanes) =
             build_bus_trace(aig, netlistdb, script, config.effective_bus_traces());
 
-        // SPI-flash CPU oracle (Stage C): build CppSpiFlash + resolve GPIO
-        // positions exactly as MetalBackend::build_flash_buffers. The flash MISO
-        // (d_i) starts 0x0F (idle high) — matching the GPU FlashState init and
-        // the patched CppSpiFlash p_d_i default — so the oracle is byte-identical
-        // through reset and the command/address phases.
-        let flash = config.flash.as_ref().map(|flash_cfg| {
-            let mut fl = CppSpiFlash::new(16 * 1024 * 1024);
-            let firmware_path = std::path::Path::new(&flash_cfg.firmware);
-            match fl.load_firmware(firmware_path, flash_cfg.firmware_offset) {
-                Ok(size) => clilog::info!(
-                    "CpuBackend flash: loaded {} bytes firmware at offset 0x{:X}",
-                    size,
-                    flash_cfg.firmware_offset
-                ),
-                Err(e) => panic!("CpuBackend flash: failed to load firmware: {}", e),
-            }
-            UnsafeCell::new(fl)
-        });
-        let flash_clk_out_pos = config
-            .flash
-            .as_ref()
-            .and_then(|f| gpio_map.output_bits.get(&f.clk_gpio).copied())
-            .unwrap_or(0);
-        let flash_csn_out_pos = config
-            .flash
-            .as_ref()
-            .and_then(|f| gpio_map.output_bits.get(&f.csn_gpio).copied())
-            .unwrap_or(0);
-        let mut flash_d_out_pos = [0xFFFFFFFFu32; 4];
-        let mut flash_d_in_pos = [0xFFFFFFFFu32; 4];
-        for i in 0..4 {
-            flash_d_out_pos[i] = config
-                .flash
-                .as_ref()
-                .and_then(|f| gpio_map.output_bits.get(&(f.d0_gpio + i)).copied())
-                .unwrap_or(0xFFFFFFFF);
-            flash_d_in_pos[i] = config
-                .flash
-                .as_ref()
-                .and_then(|f| gpio_map.input_bits.get(&(f.d0_gpio + i)).copied())
-                .unwrap_or(0xFFFFFFFF);
-        }
+        // QSPI-memory CPU oracle (Stage A: plural). Build one CppSpiFlash per
+        // configured memory + resolve each one's GPIO positions exactly as
+        // MetalBackend::build_flash_buffers does for the single instance. Each
+        // instance's MISO (d_i) starts 0x0F (idle high) — matching the GPU
+        // FlashState init and the patched CppSpiFlash p_d_i default — so
+        // instance 0 stays byte-identical to the single-flash GPU path through
+        // reset and the command/address phases. Instances >0 are independent
+        // oracles with their own backing buffers and pins.
+        let flashes: Vec<CpuFlashInstance> = config
+            .effective_qspi_memory()
+            .iter()
+            .enumerate()
+            .map(|(idx, flash_cfg)| {
+                let mut fl = CppSpiFlash::new(flash_cfg.backing_size_bytes());
+                if let Some(ref fw) = flash_cfg.firmware {
+                    let firmware_path = std::path::Path::new(fw);
+                    match fl.load_firmware(firmware_path, flash_cfg.firmware_offset) {
+                        Ok(size) => clilog::info!(
+                            "CpuBackend qspi_memory[{}]: loaded {} bytes firmware at offset 0x{:X}",
+                            idx,
+                            size,
+                            flash_cfg.firmware_offset
+                        ),
+                        Err(e) => {
+                            panic!("CpuBackend qspi_memory[{idx}]: failed to load firmware: {e}")
+                        }
+                    }
+                }
+                let clk_out_pos = gpio_map
+                    .output_bits
+                    .get(&flash_cfg.clk_gpio)
+                    .copied()
+                    .unwrap_or(0);
+                let csn_out_pos = gpio_map
+                    .output_bits
+                    .get(&flash_cfg.csn_gpio)
+                    .copied()
+                    .unwrap_or(0);
+                let mut d_out_pos = [0xFFFFFFFFu32; 4];
+                let mut d_in_pos = [0xFFFFFFFFu32; 4];
+                for i in 0..4 {
+                    d_out_pos[i] = gpio_map
+                        .output_bits
+                        .get(&(flash_cfg.d0_gpio + i))
+                        .copied()
+                        .unwrap_or(0xFFFFFFFF);
+                    d_in_pos[i] = gpio_map
+                        .input_bits
+                        .get(&(flash_cfg.d0_gpio + i))
+                        .copied()
+                        .unwrap_or(0xFFFFFFFF);
+                }
+                CpuFlashInstance {
+                    model: UnsafeCell::new(fl),
+                    clk_out_pos,
+                    csn_out_pos,
+                    d_out_pos,
+                    d_in_pos,
+                    // Idle MISO high (mirror GPU FlashState.d_i / patched CppSpiFlash).
+                    d_i: UnsafeCell::new(0x0F),
+                    // CSN starts high (deselected); d_out starts low (mirror FlashState).
+                    prev_csn: UnsafeCell::new(1),
+                    prev_d_out: UnsafeCell::new(0),
+                }
+            })
+            .collect();
 
         let backend = CpuBackend {
             state: UnsafeCell::new(state),
@@ -4575,16 +4621,7 @@ impl CosimBackend for CpuBackend {
             bus_prev_gate: UnsafeCell::new(0),
             bus_current_tick: UnsafeCell::new(0),
             bus_beats: UnsafeCell::new(Vec::new()),
-            flash,
-            flash_clk_out_pos,
-            flash_csn_out_pos,
-            flash_d_out_pos,
-            flash_d_in_pos,
-            // Idle MISO high (mirror GPU FlashState.d_i / patched CppSpiFlash).
-            flash_d_i: UnsafeCell::new(0x0F),
-            // CSN starts high (deselected); d_out starts low (mirror FlashState).
-            flash_prev_csn: UnsafeCell::new(1),
-            flash_prev_d_out: UnsafeCell::new(0),
+            flashes,
         };
         (backend, bus_lanes)
     }
@@ -4650,17 +4687,26 @@ impl CosimBackend for CpuBackend {
     }
 
     fn flash_d_i(&self) -> u8 {
-        // Current MISO nibble from the CppSpiFlash oracle (Stage C); 0x0F idle
-        // when no flash is configured.
+        // Current MISO nibble from the primary (instance 0) CppSpiFlash oracle;
+        // 0x0F idle when no memory is configured. Single-instance diagnostic
+        // used by `--check-with-cpu` (which requires N<=1).
         // SAFETY: sequential dispatch — no concurrent borrow of the cell.
-        unsafe { *self.flash_d_i.get() }
+        self.flashes
+            .first()
+            .map(|f| unsafe { *f.d_i.get() })
+            .unwrap_or(0x0F)
     }
 
     fn flash_debug_snapshot(&self) -> FlashDebug {
-        // CPU flash oracle (Stage C): report the live MISO + reset flag; the
-        // remaining FSM internals live inside CppSpiFlash (not mirrored here).
+        // CPU flash oracle: report the primary instance's live MISO + reset
+        // flag; the remaining FSM internals live inside CppSpiFlash (not
+        // mirrored here).
         FlashDebug {
-            d_i: unsafe { *self.flash_d_i.get() },
+            d_i: self
+                .flashes
+                .first()
+                .map(|f| unsafe { *f.d_i.get() })
+                .unwrap_or(0x0F),
             data_width: 0,
             prev_csn: 0,
             in_reset: self.flash_in_reset as u32,
@@ -4739,13 +4785,14 @@ impl CosimBackend for CpuBackend {
                 }
             }
             // ── CPU apply_flash_din (mirror gpu_apply_flash_din, shader:904) ─
-            // Inject the current MISO nibble into the input-state d_in bits
-            // BEFORE simulate, clearing their X-mask (driven ⇒ known, #95 ph3).
-            if self.flash.is_some() {
+            // Inject each memory's current MISO nibble into ITS input-state
+            // d_in bits BEFORE simulate, clearing their X-mask (driven ⇒ known,
+            // #95 ph3). Every QSPI instance drives its own lanes independently.
+            for inst in &self.flashes {
                 // SAFETY: sequential dispatch — no concurrent borrow.
-                let d_i = unsafe { *self.flash_d_i.get() };
+                let d_i = unsafe { *inst.d_i.get() };
                 for i in 0..4usize {
-                    let pos = self.flash_d_in_pos[i];
+                    let pos = inst.d_in_pos[i];
                     if pos == 0xFFFFFFFF {
                         continue;
                     }
@@ -4802,11 +4849,13 @@ impl CosimBackend for CpuBackend {
             }
 
             // ── CPU flash_model_step (mirror gpu_flash_model_step, shader:943) ─
-            // Read clk/csn/d_out from the OUTPUT slot, then dual-step CppSpiFlash
-            // with delayed CSN (setup-delay model) to compute the next MISO d_i.
-            // Runs after simulate (output fresh) on every edge, mirroring the
-            // Metal `encode_flash_model_step` cadence (before io_step / UART).
-            if let Some(flash_cell) = self.flash.as_ref() {
+            // For EACH memory: read its clk/csn/d_out from the OUTPUT slot, then
+            // dual-step ITS CppSpiFlash with delayed CSN (setup-delay model) to
+            // compute the next MISO d_i. Runs after simulate (output fresh) on
+            // every edge, mirroring the Metal `encode_flash_model_step` cadence
+            // (before io_step / UART). Each instance keeps its own delayed
+            // csn/d_out so the memories advance fully independently.
+            for inst in &self.flashes {
                 let read_out = |pos: u32| -> u32 {
                     if pos == 0xFFFFFFFF {
                         0
@@ -4814,16 +4863,16 @@ impl CosimBackend for CpuBackend {
                         (state[state_size + (pos >> 5) as usize] >> (pos & 31)) & 1
                     }
                 };
-                let clk = read_out(self.flash_clk_out_pos);
-                let csn = read_out(self.flash_csn_out_pos);
+                let clk = read_out(inst.clk_out_pos);
+                let csn = read_out(inst.csn_out_pos);
                 let mut d_out = 0u8;
                 for i in 0..4usize {
-                    d_out |= (read_out(self.flash_d_out_pos[i]) as u8) << i;
+                    d_out |= (read_out(inst.d_out_pos[i]) as u8) << i;
                 }
                 // SAFETY: sequential dispatch — these cells are only touched here.
-                let d_i_cell = unsafe { &mut *self.flash_d_i.get() };
-                let prev_csn = unsafe { &mut *self.flash_prev_csn.get() };
-                let prev_d_out = unsafe { &mut *self.flash_prev_d_out.get() };
+                let d_i_cell = unsafe { &mut *inst.d_i.get() };
+                let prev_csn = unsafe { &mut *inst.prev_csn.get() };
+                let prev_d_out = unsafe { &mut *inst.prev_d_out.get() };
                 if self.flash_in_reset {
                     // Reset branch (shader:974): force MISO high, update the
                     // delayed values, do NOT step the model.
@@ -4831,7 +4880,7 @@ impl CosimBackend for CpuBackend {
                     *prev_csn = csn;
                     *prev_d_out = d_out;
                 } else {
-                    let fl = unsafe { &mut *flash_cell.get() };
+                    let fl = unsafe { &mut *inst.model.get() };
                     // Dual-step with delayed CSN (matches the GPU setup-delay
                     // model): step 1 = delayed csn + delayed d_out, step 2 =
                     // delayed csn + current d_out. CppSpiFlash::step does one

--- a/src/sim/x_sources.rs
+++ b/src/sim/x_sources.rs
@@ -174,7 +174,7 @@ fn driven_gpios_and_ports(config: &TestbenchConfig) -> (HashSet<usize>, HashSet<
     for name in config.constant_ports.keys() {
         ports.insert(name.clone());
     }
-    if let Some(flash) = &config.flash {
+    for flash in config.effective_qspi_memory() {
         gpios.extend([flash.clk_gpio, flash.csn_gpio]);
         // `set_flash_din` drives 4 data lanes (d0..d0+3) for dual/quad SPI.
         gpios.extend((0..4).map(|i| flash.d0_gpio + i));

--- a/src/testbench.rs
+++ b/src/testbench.rs
@@ -199,7 +199,16 @@ pub struct TestbenchConfig {
     pub num_cycles: usize,
     /// Clock period in picoseconds (e.g. 40000 for 25MHz). Used for UART baud rate calculation.
     pub clock_period_ps: Option<u64>,
-    pub flash: Option<FlashConfig>,
+    /// Legacy singular QSPI flash peripheral. Superseded by [`Self::qspi_memory`]
+    /// (ADR 0013 plural-peripheral convention). Kept so existing
+    /// `sim_config.json` files with a single `"flash": { … }` object still parse;
+    /// folded into `effective_qspi_memory()` as a 1-element vec.
+    #[serde(default)]
+    pub flash: Option<QspiMemoryConfig>,
+    /// Plural QSPI memory peripherals (flash / PSRAM). Each entry owns its own
+    /// pins and backing store. See ADR 0013 and `effective_qspi_memory()`.
+    #[serde(default)]
+    pub qspi_memory: Vec<QspiMemoryConfig>,
     pub uart: Option<UartConfig>,
     #[serde(default)]
     pub uarts: Vec<UartConfig>,
@@ -284,6 +293,20 @@ impl TestbenchConfig {
         out
     }
 
+    /// Return the effective QSPI memory configurations (ADR 0013).
+    ///
+    /// Merges the legacy singular `flash` (prepended, so it is instance 0) with
+    /// the plural `qspi_memory` list, mirroring `effective_uarts()`. This is the
+    /// single surface every backend consumes: the CPU backend steps every entry
+    /// independently; the GPU backends (Stage A) require `len() <= 1`.
+    pub fn effective_qspi_memory(&self) -> Vec<QspiMemoryConfig> {
+        let mut out = self.qspi_memory.clone();
+        if let Some(ref f) = self.flash {
+            out.insert(0, f.clone());
+        }
+        out
+    }
+
     /// Return the configured bus traces (ADR 0013).
     ///
     /// There is no legacy singular form — `bus_traces` is new — so this
@@ -324,14 +347,75 @@ pub struct PortMapping {
     pub outputs: HashMap<String, String>,
 }
 
+/// Configuration for a single QSPI memory peripheral (flash or PSRAM).
+///
+/// Formerly `FlashConfig` / the singular `flash` key. Renamed to reflect that
+/// the peripheral is a QSPI *memory* (read-only flash today; writable PSRAM is
+/// PR #159) and made plural via [`TestbenchConfig::qspi_memory`] (ADR 0013's
+/// plural-peripheral convention). Each instance owns its own pins and backing
+/// store, so a design can wire two independent memories.
+///
+/// Back-compat: the legacy `"flash": { … }` object still deserialises into this
+/// struct (via [`TestbenchConfig::flash`]) and is folded into
+/// `effective_qspi_memory()` as a 1-element vec. All the RAM-mode fields default
+/// to the original read-only SPI-flash behaviour, so a legacy config behaves
+/// byte-identically.
 #[derive(Debug, Clone, Deserialize)]
-pub struct FlashConfig {
+pub struct QspiMemoryConfig {
+    /// Optional human-readable name for logs/diagnostics.
+    #[serde(default)]
+    pub name: Option<String>,
     pub clk_gpio: usize,
     pub csn_gpio: usize,
     pub d0_gpio: usize,
-    pub firmware: String,
+    /// Firmware/preload image. Optional: a writable PSRAM may start from a
+    /// zeroed store, so a config without firmware is valid.
+    #[serde(default)]
+    pub firmware: Option<String>,
+    /// Byte offset in the backing store at which `firmware` is loaded.
+    #[serde(default)]
     pub firmware_offset: usize,
+    /// Backing-store size in bytes. Defaults to the historical 16 MiB flash
+    /// buffer when unset (see [`QspiMemoryConfig::backing_size_bytes`]).
+    #[serde(default)]
+    pub size_bytes: Option<usize>,
+
+    // ── QSPI PSRAM (RAM-mode) extensions — inert in Stage A ──────────────────
+    // Carried here so PR #159 (writable QSPI PSRAM) can rebase onto this plural
+    // surface without re-touching the config schema. Stage A is flash/read-only,
+    // so these are parsed but not yet acted upon; all default to the read-only
+    // SPI-flash behaviour (`writable = false`).
+    /// Treat the peripheral as a writable APS6404L-class QSPI PSRAM.
+    #[serde(default)]
+    pub writable: bool,
+    /// Command byte that latches QPI mode (e.g. `0x35`). Only honoured when
+    /// `writable`.
+    #[serde(default)]
+    pub enter_qpi_cmd: Option<u8>,
+    /// Command byte that quad-writes the backing store (e.g. `0x38`). Only
+    /// honoured when `writable`.
+    #[serde(default)]
+    pub quad_write_cmd: Option<u8>,
+    /// Dummy SCK cycles after the address of a QPI read. Defaults to the flash
+    /// value when unset.
+    #[serde(default)]
+    pub read_dummy_cycles: Option<u32>,
 }
+
+/// Historical default backing-store size (16 MiB) for a QSPI memory whose
+/// `size_bytes` is unset. Matches the flash buffer the GPU kernels allocate.
+pub const DEFAULT_QSPI_SIZE_BYTES: usize = 16 * 1024 * 1024;
+
+impl QspiMemoryConfig {
+    /// Backing-store size in bytes: the configured `size_bytes` or the
+    /// historical 16 MiB flash default.
+    pub fn backing_size_bytes(&self) -> usize {
+        self.size_bytes.unwrap_or(DEFAULT_QSPI_SIZE_BYTES)
+    }
+}
+
+/// Backwards-compatible alias: the config type used to be `FlashConfig`.
+pub type FlashConfig = QspiMemoryConfig;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct UartConfig {

--- a/src/testbench.rs
+++ b/src/testbench.rs
@@ -816,4 +816,92 @@ mod tests {
         assert_eq!(uarts[0].name.as_deref(), Some("legacy"));
         assert_eq!(uarts[1].name.as_deref(), Some("new"));
     }
+
+    // ── QSPI memory plurality + legacy `flash` back-compat (ADR 0013) ─────────
+
+    fn qspi_mem(name: Option<&str>, csn_gpio: usize) -> QspiMemoryConfig {
+        let name_field = name
+            .map(|n| format!(r#""name": "{n}","#))
+            .unwrap_or_default();
+        serde_json::from_str(&format!(
+            r#"{{ {name_field} "clk_gpio": 0, "csn_gpio": {csn_gpio}, "d0_gpio": 2 }}"#
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn effective_qspi_memory_empty_when_neither_set() {
+        let cfg = minimal_config();
+        assert!(cfg.effective_qspi_memory().is_empty());
+    }
+
+    #[test]
+    fn effective_qspi_memory_from_legacy_flash() {
+        let mut cfg = minimal_config();
+        cfg.flash = Some(qspi_mem(None, 7));
+        let mems = cfg.effective_qspi_memory();
+        assert_eq!(mems.len(), 1);
+        assert_eq!(mems[0].csn_gpio, 7);
+    }
+
+    #[test]
+    fn effective_qspi_memory_from_plural() {
+        let mut cfg = minimal_config();
+        cfg.qspi_memory = vec![qspi_mem(Some("rom"), 3), qspi_mem(Some("psram"), 6)];
+        let mems = cfg.effective_qspi_memory();
+        assert_eq!(mems.len(), 2);
+        assert_eq!(mems[0].name.as_deref(), Some("rom"));
+        assert_eq!(mems[1].name.as_deref(), Some("psram"));
+        // Independent pins → independent peripherals.
+        assert_ne!(mems[0].csn_gpio, mems[1].csn_gpio);
+    }
+
+    #[test]
+    fn effective_qspi_memory_merges_legacy_flash_prepended() {
+        let mut cfg = minimal_config();
+        cfg.flash = Some(qspi_mem(Some("legacy"), 3));
+        cfg.qspi_memory = vec![qspi_mem(Some("new"), 6)];
+        let mems = cfg.effective_qspi_memory();
+        assert_eq!(mems.len(), 2);
+        assert_eq!(mems[0].name.as_deref(), Some("legacy"));
+        assert_eq!(mems[1].name.as_deref(), Some("new"));
+    }
+
+    #[test]
+    fn legacy_flash_key_deserializes_and_folds() {
+        // An existing sim_config.json using the singular `"flash"` key must
+        // still parse and behave as one QSPI memory (byte-compat).
+        let cfg: TestbenchConfig = serde_json::from_str(
+            r#"{
+                "clock_gpio": 0, "reset_gpio": 1, "reset_active_high": true,
+                "reset_cycles": 10, "num_cycles": 100,
+                "flash": { "clk_gpio": 2, "csn_gpio": 3, "d0_gpio": 4 }
+            }"#,
+        )
+        .unwrap();
+        let mems = cfg.effective_qspi_memory();
+        assert_eq!(mems.len(), 1);
+        assert_eq!(mems[0].clk_gpio, 2);
+        assert_eq!(mems[0].csn_gpio, 3);
+        assert_eq!(mems[0].d0_gpio, 4);
+    }
+
+    #[test]
+    fn plural_qspi_memory_key_parses_distinct_instances() {
+        let cfg: TestbenchConfig = serde_json::from_str(
+            r#"{
+                "clock_gpio": 0, "reset_gpio": 1, "reset_active_high": true,
+                "reset_cycles": 10, "num_cycles": 100,
+                "qspi_memory": [
+                    { "clk_gpio": 2, "csn_gpio": 3, "d0_gpio": 4 },
+                    { "clk_gpio": 5, "csn_gpio": 6, "d0_gpio": 7 }
+                ]
+            }"#,
+        )
+        .unwrap();
+        let mems = cfg.effective_qspi_memory();
+        assert_eq!(mems.len(), 2);
+        assert_ne!(mems[0].csn_gpio, mems[1].csn_gpio);
+        assert_ne!(mems[0].d0_gpio, mems[1].d0_gpio);
+    }
 }


### PR DESCRIPTION
First stage of making the QSPI memory cosim peripheral **plural** (`Vec<QspiMemory>`), the base PR #159 (writable QSPI PSRAM) will rebase onto. Turns the single-instance `flash` peripheral into a plural `qspi_memory` list so a design can wire **multiple independent memories** (e.g. two flashes with different ROMs, or flash + PSRAM) — mirroring the already-plural UART/bus-trace peripherals (ADR 0013).

## Stage A scope (config + CPU oracle; GPU is Stage B)
- **`flash: Option<FlashConfig>` → `qspi_memory: Vec<QspiMemoryConfig>`.** Rename reflects that the peripheral is a QSPI *memory* (writable PSRAM is #159). Config forward-declares the RAM-mode fields so #159's rebase is clean.
- **Back-compat (required):** a legacy `"flash": { … }` object still parses and folds into instance 0 via `effective_qspi_memory()` (mirroring `effective_uarts()`). Existing sim_configs (`mcu_soc`, `timing_test`) are unchanged.
- **CpuBackend oracle** steps every instance with its own backing buffer + delayed CSN/d_out state — memories advance fully independently.
- **GPU path guarded:** N=1 is byte-identical to today; N>1 returns a clear error ("requires stage B"). GPU N-instance is the next PR.

## Verified
- mcu_soc flash + all 7 cosim fixtures == committed goldens on **both CpuBackend and Metal** (single-instance byte-identical)
- 323 lib tests (+6: legacy-`flash` back-compat + 2-element `qspi_memory` plurality parse tests)
- clippy `--lib` 0 errors; builds clean (no-feature + `--features metal`); lockstep 0.2.4

## Follow-ups (this refactor's roadmap)
- **Stage B:** GPU N-instance kernels (Metal + CUDA/HIP), modeled on the bus-trace `BusTraceParamsAll { n_buses; buses[MAX] }` pattern + a concatenated backing-store buffer with per-instance offsets (the on-chip-SRAM pattern).
- **Stage C:** rebase #159 (PSRAM = a writable `qspi_memory` instance) onto the plural base.
- **Stage D:** end-to-end multi-instance test proving independent backing stores.