### PR TITLE
feat(cosim/metal): env-gated MTLCaptureManager GPU frame capture

### DIFF
--- a/docs/gpu-capture.md
+++ b/docs/gpu-capture.md
@@ -1,0 +1,99 @@
+# GPU Frame Capture (`.gputrace`)
+
+## Overview
+
+`jacquard cosim` (Metal backend) can emit an Xcode **`.gputrace`** document
+capturing the exact Metal command stream of the GPU simulation — every
+compute dispatch, buffer binding, and blit for a bounded window of edge
+batches. This is the detailed counterpart to a system-level
+`xctrace --template "Metal System Trace"` recording: the system trace shows
+*when* GPU work runs relative to the CPU, while a `.gputrace` shows *what*
+each dispatch does (threadgroup sizes, buffer arguments, per-dispatch
+timing, dependency DAG, and — after an Xcode replay — shader occupancy and
+memory-bandwidth counters).
+
+Capture is **env-gated and zero-overhead when off**: with no
+`JACQUARD_GPU_CAPTURE` set, none of the capture code runs.
+
+## Quick start
+
+```bash
+# Capture one steady-state batch (skip the reset/warm-up batch 0).
+# METAL_CAPTURE_ENABLED=1 is REQUIRED — Metal refuses programmatic
+# .gputrace capture without it.
+METAL_CAPTURE_ENABLED=1 \
+JACQUARD_GPU_CAPTURE=/tmp/cosim.gputrace \
+JACQUARD_GPU_CAPTURE_SKIP=1 \
+  cargo run -r --features metal --bin jacquard -- cosim \
+    tests/qspi_psram/qspi_psram_dut_synth.gv \
+    --config tests/qspi_psram/sim_config.json \
+    --top-module qspi_psram_dut \
+    --max-clock-edges 200 \
+    --output-vcd target/test-out/qspi_psram.vcd
+
+open /tmp/cosim.gputrace   # opens in Xcode's GPU debugger
+```
+
+## Environment variables
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `JACQUARD_GPU_CAPTURE` | *(unset)* | Output path for the `.gputrace` bundle. Setting it enables capture. |
+| `JACQUARD_GPU_CAPTURE_SKIP` | `0` | Batches to run before opening the capture window. Skip the reset/warm-up batches to grab a steady-state one. |
+| `JACQUARD_GPU_CAPTURE_BATCHES` | `1` | Number of consecutive batches to capture. Keep small — each batch is thousands of dispatches. |
+| `METAL_CAPTURE_ENABLED` | *(unset)* | **Required** by Metal for programmatic `.gputrace` capture. Without it, capture is skipped with a warning and the run continues uncaptured. |
+
+## How it works
+
+The Metal backend commits **one command buffer per edge batch**
+(`MetalSimulator::encode_and_commit_gpu_batch`). Each batch encodes, for
+every edge in it, the full per-edge dispatch chain:
+
+```
+state_prep → apply_flash_din → simulate_v1_stage × N → flash_model_step → io_step → VCD blit
+```
+
+Capture brackets an `MTLCaptureManager` scope (destination
+`GpuTraceDocument`, scoped to the simulator's command queue) around the
+window `[SKIP, SKIP + BATCHES)`:
+
+- **Start** — immediately before the first in-window batch's command buffer
+  is created, so the trace opens on a clean batch boundary.
+- **Stop** — after the last in-window batch is committed; that command
+  buffer is waited to completion first so its GPU work is recorded before
+  `stopCapture()` finalizes the document.
+
+A stale bundle at the target path is removed first (Metal refuses to
+overwrite). Any failure (missing `METAL_CAPTURE_ENABLED`, unsupported
+destination) is logged and the simulation continues normally, uncaptured.
+
+## Choosing a batch to capture
+
+Batch 0 is the reset/warm-up batch and is usually small and unrepresentative.
+`JACQUARD_GPU_CAPTURE_SKIP=1` (or higher) captures a steady-state batch.
+The batch size is `BATCH_SIZE` edges (see `src/sim/cosim/mod.rs`), so a
+single captured batch already contains the complete per-edge dispatch stream
+repeated across the batch — enough to profile the kernel without a giant
+multi-batch trace.
+
+## Shader performance counters
+
+The `.gputrace` records the command stream and per-dispatch timing out of
+the box. **Occupancy, bandwidth, and cache-hit counters require an Xcode
+replay with shader profiling enabled**: open the trace in Xcode, press
+**Replay**, and Xcode writes the counter `streamData` back into the bundle.
+Only then do the `profiler_gpu_counters` / `profiler_gpu_scheduling`
+analyses have data to read.
+
+## Relationship to system-level tracing
+
+For CPU↔GPU timeline correlation (where the sim spends wall-clock, GPU duty
+cycle, inter-batch CPU gaps) use a Metal System Trace instead:
+
+```bash
+xctrace record --template "Metal System Trace" --output cosim.trace \
+  --launch -- jacquard cosim ...
+```
+
+That `.trace` answers "is the sim CPU- or GPU-bound?"; the `.gputrace` here
+answers "is each GPU dispatch efficient?". They are complementary.

--- a/src/sim/cosim/metal.rs
+++ b/src/sim/cosim/metal.rs
@@ -15,8 +15,8 @@ use crate::flatten::FlattenedScriptV1;
 use crate::sim::setup::LoadedDesign;
 use crate::testbench::TestbenchConfig;
 use metal::{
-    CommandQueue, ComputePipelineState, Device as MTLDevice, MTLResourceOptions, MTLSize,
-    SharedEvent,
+    CaptureDescriptor, CaptureManager, CommandQueue, ComputePipelineState, Device as MTLDevice,
+    MTLCaptureDestination, MTLResourceOptions, MTLSize, SharedEvent,
 };
 use netlistdb::NetlistDB;
 use ulib::{AsUPtr, Device};
@@ -116,6 +116,29 @@ impl ScheduleBuffers {
     }
 }
 
+// ── GPU frame capture (env-gated, Metal only) ────────────────────────────────
+
+/// Configuration for an optional `MTLCaptureManager` GPU trace, enabled by the
+/// `JACQUARD_GPU_CAPTURE` env var. When set, the simulator brackets a bounded
+/// window of batch command buffers with a Metal capture and writes a
+/// `.gputrace` document for offline analysis (Xcode GPU debugger / the
+/// apple-profiler `profiler_gpu_*` tools). Because the simulation commits one
+/// command buffer per edge-batch, a single captured batch already contains the
+/// full per-edge dispatch stream (state_prep → flash_din → simulate stages →
+/// flash_model → io_step → VCD blit). See `docs/gpu-capture.md`.
+struct GpuCaptureConfig {
+    /// Output path for the `.gputrace` bundle (`JACQUARD_GPU_CAPTURE`).
+    path: String,
+    /// Batches to let run before opening the capture window
+    /// (`JACQUARD_GPU_CAPTURE_SKIP`, default 0). Skipping the reset/warm-up
+    /// batches captures a steady-state batch instead.
+    skip_batches: usize,
+    /// Number of consecutive batches to capture
+    /// (`JACQUARD_GPU_CAPTURE_BATCHES`, default 1). Keep this small — each batch
+    /// is thousands of dispatches.
+    num_batches: usize,
+}
+
 // ── Metal Simulator ──────────────────────────────────────────────────────────
 
 struct MetalSimulator {
@@ -137,6 +160,14 @@ struct MetalSimulator {
     shared_event: SharedEvent,
     /// Monotonic counter for shared event signaling
     event_counter: std::cell::Cell<u64>,
+    /// Optional GPU frame capture (env `JACQUARD_GPU_CAPTURE`); `None` in normal
+    /// runs so there is zero overhead when capture is not requested.
+    gpu_capture: Option<GpuCaptureConfig>,
+    /// Count of batch command buffers committed so far — drives the capture
+    /// window (start at `skip_batches`, stop after `skip + num_batches`).
+    batch_index: std::cell::Cell<usize>,
+    /// Whether an `MTLCaptureManager` capture is currently open.
+    capture_active: std::cell::Cell<bool>,
 }
 
 impl MetalSimulator {
@@ -207,6 +238,22 @@ impl MetalSimulator {
 
         let shared_event = device.new_shared_event();
 
+        // Optional GPU frame capture, gated on `JACQUARD_GPU_CAPTURE=<path>`.
+        // Absent env → `None` → no capture code runs on the hot path.
+        let gpu_capture = std::env::var("JACQUARD_GPU_CAPTURE").ok().map(|path| {
+            let usize_env = |key: &str, default: usize| {
+                std::env::var(key)
+                    .ok()
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .unwrap_or(default)
+            };
+            GpuCaptureConfig {
+                path,
+                skip_batches: usize_env("JACQUARD_GPU_CAPTURE_SKIP", 0),
+                num_batches: usize_env("JACQUARD_GPU_CAPTURE_BATCHES", 1).max(1),
+            }
+        });
+
         Self {
             device,
             command_queue,
@@ -218,6 +265,66 @@ impl MetalSimulator {
             params_buffers,
             shared_event,
             event_counter: std::cell::Cell::new(0),
+            gpu_capture,
+            batch_index: std::cell::Cell::new(0),
+            capture_active: std::cell::Cell::new(false),
+        }
+    }
+
+    /// Open an `MTLCaptureManager` GPU trace scoped to our command queue,
+    /// writing a `.gputrace` document. Metal refuses programmatic
+    /// `GpuTraceDocument` capture unless `METAL_CAPTURE_ENABLED=1` is set in the
+    /// environment, so this is best-effort: on any failure it logs a hint and
+    /// leaves the simulation running normally (uncaptured).
+    fn start_gpu_capture(&self, cfg: &GpuCaptureConfig) {
+        let manager = CaptureManager::shared();
+        if !manager.supports_destination(MTLCaptureDestination::GpuTraceDocument) {
+            clilog::warn!(
+                "JACQUARD_GPU_CAPTURE set but the .gputrace destination is \
+                 unavailable — re-run with METAL_CAPTURE_ENABLED=1. Continuing \
+                 without capture."
+            );
+            return;
+        }
+        // MTLCaptureManager errors out rather than overwriting an existing
+        // document, so clear any stale bundle at the target path first.
+        let path = std::path::Path::new(&cfg.path);
+        if path.exists() {
+            if let Err(e) = std::fs::remove_dir_all(path) {
+                clilog::warn!("Could not remove existing {}: {e}", cfg.path);
+            }
+        }
+
+        let descriptor = CaptureDescriptor::new();
+        descriptor.set_capture_command_queue(&self.command_queue);
+        descriptor.set_destination(MTLCaptureDestination::GpuTraceDocument);
+        descriptor.set_output_url(path);
+
+        match manager.start_capture(&descriptor) {
+            Ok(()) => {
+                self.capture_active.set(true);
+                clilog::info!(
+                    "GPU capture started → {} (skipping {} batch(es), capturing {})",
+                    cfg.path,
+                    cfg.skip_batches,
+                    cfg.num_batches
+                );
+            }
+            Err(e) => clilog::warn!(
+                "GPU capture failed to start ({e}) — ensure METAL_CAPTURE_ENABLED=1 \
+                 is set. Continuing without capture."
+            ),
+        }
+    }
+
+    /// Close an open capture and finalize the `.gputrace` document.
+    fn stop_gpu_capture(&self) {
+        if self.capture_active.get() {
+            CaptureManager::shared().stop_capture();
+            self.capture_active.set(false);
+            if let Some(cfg) = &self.gpu_capture {
+                clilog::info!("GPU capture written → {}", cfg.path);
+            }
         }
     }
 
@@ -484,6 +591,15 @@ impl MetalSimulator {
         arrival_state_offset: u32,
         vcd_ring_buffer: Option<&metal::Buffer>,
     ) -> u64 {
+        // Open the GPU capture window immediately before this batch's command
+        // buffer is created, once the requested number of warm-up batches have
+        // been skipped. No-op unless JACQUARD_GPU_CAPTURE is set.
+        if let Some(cfg) = &self.gpu_capture {
+            if self.batch_index.get() == cfg.skip_batches {
+                self.start_gpu_capture(cfg);
+            }
+        }
+
         let batch_done = self.event_counter.get() + 1;
         let cb = self.command_queue.new_command_buffer();
         let edges_per_period = schedule_buffers.edge_buffers.len();
@@ -562,6 +678,21 @@ impl MetalSimulator {
         cb.commit();
 
         self.event_counter.set(batch_done);
+
+        // Advance the capture batch counter and, once the window has closed,
+        // finalize the trace. Wait for the last captured command buffer so its
+        // GPU work is recorded before stopCapture(); the outer loop's own wait()
+        // on this batch is idempotent. The whole block is skipped when capture
+        // is off, so normal runs never touch this state.
+        if let Some(cfg) = &self.gpu_capture {
+            let next_batch = self.batch_index.get() + 1;
+            self.batch_index.set(next_batch);
+            if self.capture_active.get() && next_batch >= cfg.skip_batches + cfg.num_batches {
+                cb.wait_until_completed();
+                self.stop_gpu_capture();
+            }
+        }
+
         batch_done
     }
 


### PR DESCRIPTION
## What

Adds an opt-in Metal **GPU frame capture** to `jacquard cosim`. Setting `JACQUARD_GPU_CAPTURE=<path>` brackets an `MTLCaptureManager` scope around a bounded window of batch command buffers and writes an Xcode `.gputrace` document — giving per-dispatch GPU analysis (threadgroup sizes, buffer bindings, dependency DAG, and — after an Xcode replay — occupancy / bandwidth counters).

## Why

System-level `xctrace --template "Metal System Trace"` shows *when* GPU work runs vs the CPU, but not *what* each dispatch does. Profiling the simulation kernel (e.g. confirming dispatch efficiency, threadgroup occupancy) needs a real `.gputrace`, which a pure CLI Metal tool can only produce via an in-process `MTLCaptureManager` bracket. This adds that bracket.

Motivating measurement: on a 10k-edge `mcu_soc` cosim the GPU is only **~7% duty-cycle** during the sim phase (79 ms GPU compute across a 1.07 s span), with ~95 ms CPU-only gaps between each 2048-encoder command buffer. A `.gputrace` lets us drill into whether the GPU bursts themselves are efficient.

## Interface

| Env var | Default | Meaning |
|---|---|---|
| `JACQUARD_GPU_CAPTURE=<path>` | *(unset)* | Enable; output `.gputrace` path |
| `JACQUARD_GPU_CAPTURE_SKIP` | `0` | Batches to skip before capturing (grab a steady-state batch, not reset) |
| `JACQUARD_GPU_CAPTURE_BATCHES` | `1` | Batches to capture |
| `METAL_CAPTURE_ENABLED` | *(unset)* | **Required by Metal** for programmatic `.gputrace`; missing → warns and runs uncaptured |

```bash
METAL_CAPTURE_ENABLED=1 JACQUARD_GPU_CAPTURE=/tmp/cosim.gputrace JACQUARD_GPU_CAPTURE_SKIP=1 \
  jacquard cosim design.gv --config sim.json --top-module top --max-clock-edges 200
open /tmp/cosim.gputrace   # Xcode GPU debugger
```

## Design notes

- **Self-contained** to the Metal backend (`src/sim/cosim/metal.rs`); no trait or generic-loop changes. GPU capture is inherently Metal-only (CUDA/HIP use nsys/rocprof), and the bracket points are Metal command-buffer lifecycle events the generic loop doesn't expose.
- **Zero-overhead when off**: gated on an `Option` that is `None` in normal runs; the per-batch counter block is skipped entirely unless capture is configured.
- **Fails soft**: any capture failure (missing `METAL_CAPTURE_ENABLED`, unsupported destination) logs a hint and the simulation continues, uncaptured.
- Clears a stale bundle at the target path first (Metal refuses to overwrite); waits the final captured command buffer before `stopCapture()` so its GPU work is recorded.

## Testing

Verified on `tests/qspi_psram` (skip=1): produces a valid 5.1 MB `.gputrace` with `captured_frames_count == 1` (exactly the one steady-state batch), all pipeline states + buffers snapshotted, sim still `PASSED`. No change to non-capture runs.

## Docs

New `docs/gpu-capture.md` (quick-start, env-var table, relationship to system-level tracing, shader-counter replay note).

## Follow-up

Promote the three knobs to `--gpu-capture[-skip|-batches]` CLI flags to match `--gpu-profile` / `--trace-signals` and the CLAUDE.md env→CLI convention. Kept env-gated here to stay surgical (single-file diff); the platform `METAL_CAPTURE_ENABLED` stays an env var regardless.