### PR TITLE
feat(cosim): device-timestamp GPU/CPU perf report + --cosim-perf-json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1286,11 +1286,29 @@ jobs:
         timeout-minutes: 30
         run: |
           set -o pipefail
+          # --cosim-perf-json emits a per-edge timing breakdown incl.
+          # ground-truth GPU-execution time from Metal device timestamps
+          # (GPUStartTime/GPUEndTime). Report-only — surfaced in the step
+          # summary below; no perf gate. See docs/cosim-perf-report.md.
           target/release/jacquard cosim \
             tests/mcu_soc/data/6_final.v \
             --config tests/mcu_soc/sim_config.json --top-module top \
             --max-clock-edges 500000 \
+            --cosim-perf-json cosim_perf.json \
             2>&1 | tee cosim_output.txt
+
+      - name: Report cosim timing (Metal, mcu_soc)
+        if: always()
+        run: |
+          # Report-only: log the device-timestamp timing breakdown to the job
+          # summary. Never fails the job (no regression gate — see
+          # docs/cosim-perf-report.md for the rationale and follow-up gating).
+          {
+            echo "## Cosim perf — mcu_soc (Metal, 500K edges)"
+            echo '```json'
+            cat cosim_perf.json 2>/dev/null || echo '{ "error": "no perf report produced" }'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verify UART boot output
         run: |

--- a/docs/cosim-perf-report.md
+++ b/docs/cosim-perf-report.md
@@ -1,0 +1,95 @@
+# Cosim Perf Report (`--cosim-perf-json`)
+
+## Overview
+
+`jacquard cosim` reports a per-edge timing breakdown of the co-simulation
+loop, including **ground-truth GPU-execution time from device
+timestamps** — free of the instrumentation overhead that a full GPU
+trace (Metal System Trace / nsys) imposes on a workload of thousands of
+tiny dispatches per batch.
+
+The breakdown always prints in the human-readable profiling summary at
+the end of a run. Passing `--cosim-perf-json <PATH>` additionally writes
+a flat JSON record for CI to log and track.
+
+## The measurement
+
+The cosim loop batches edges into GPU command buffers (`BATCH_SIZE`
+edges each). Per batch, the CPU: builds the command buffer (*encode*),
+commits it, then waits for the GPU to finish (*spin*), then drains ring
+buffers (*VCD/UART*). The existing summary times these CPU phases with
+`Instant` deltas. This report adds the **GPU-side** truth:
+
+- **Metal**: `MTLCommandBuffer.GPUStartTime`/`GPUEndTime` — host-clock
+  timestamps the driver records for free; `GPUEndTime − GPUStartTime` is
+  the batch's GPU-execution wall. Read after `waitUntilCompleted` (the
+  driver posts the timestamps only at full completion).
+- **CUDA / HIP**: `cudaEvent` / `hipEvent` elapsed time — *follow-up*
+  (the trait seam exists; the impls land in a later PR validated on the
+  GPU CI runner).
+- **CPU backend**: none — `gpu_*` fields are `0` / `gpu_exec_recorded:
+  false`.
+
+The seam is one `CosimBackend` trait method,
+`last_batch_gpu_seconds() -> Option<f64>`, called by the orchestration
+after each batch's `wait()`. The generic loop owns the CPU timing and
+report assembly; each backend supplies only its GPU clock.
+
+## Human summary
+
+```
+=== Profiling Breakdown ===
+  Batch encode + commit             7.6μs/tick   10.3%
+  GPU wait (spin)                  66.3μs/tick   89.3%
+  ...
+  TOTAL (instrumented)             74.2μs/tick  100.0%
+  GPU exec (device ts)             65.8μs/tick   88.7%  (GPU-busy share of wall)
+```
+
+`GPU exec` is a *separate* measure from the CPU categories — it overlaps
+the `GPU wait (spin)` line (the CPU wall spent waiting *is* the GPU
+execution). Its `%` is the GPU-busy share of the instrumented wall.
+
+## JSON schema (report-only)
+
+```json
+{
+  "backend": "metal",
+  "edges": 500000,
+  "wall_seconds": 40.1,
+  "total_us_per_edge": 74.24,
+  "gpu_exec_us_per_edge": 65.85,
+  "gpu_util_pct": 88.7,
+  "gpu_exec_recorded": true,
+  "cpu_encode_us_per_edge": 7.56,
+  "gpu_wait_spin_us_per_edge": 66.31,
+  "drain_us_per_edge": 0.001,
+  "output_vcd_us_per_edge": 0.36,
+  "batches": 550,
+  "mean_batch": 909.1
+}
+```
+
+This is a report format, not a stable contract — it may gain fields.
+
+## CI
+
+The `mcu-soc-metal` job runs the mcu_soc cosim with `--cosim-perf-json`
+and posts the JSON to the GitHub step summary (**report-only** — no
+perf gate). This builds a timing history before we commit to a
+regression threshold: GPU/thermal noise on shared runners needs a
+measured noise floor first, and a premature gate would flake. Adding a
+gate (fail if `total_us_per_edge` regresses beyond a tuned threshold vs
+a committed baseline) is the natural follow-up once the history exists,
+alongside the CUDA/HIP `last_batch_gpu_seconds` impls so every tested
+architecture reports.
+
+## Why not just use a GPU trace?
+
+Metal System Trace / nsys instrument every Metal/CUDA call. For a batch
+of ~2048 tiny dispatches that overhead is large and *systematically
+distorts* the picture — it inflated an early measurement to make the GPU
+look ~88% idle when device timestamps show it ~88% **busy**. Command-buffer
+timestamps cost nothing and are the trustworthy signal for steady-state
+throughput; reserve full traces for one-off per-dispatch investigation
+(see `docs/gpu-capture.md`).

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -482,6 +482,13 @@ struct CosimArgs {
     #[clap(long = "bus-trace-csv", value_name = "PATH")]
     bus_trace_csv: Option<PathBuf>,
 
+    /// Write a machine-readable JSON cosim perf report to <PATH>: per-edge
+    /// timing breakdown including ground-truth GPU-execution time from device
+    /// timestamps (Metal `GPUStartTime`/`GPUEndTime`). Report-only; consumed by
+    /// the CI timing step. The same numbers print in the profiling breakdown.
+    #[clap(long = "cosim-perf-json", value_name = "PATH")]
+    cosim_perf_json: Option<PathBuf>,
+
     /// Force the behavioral-RTL synthesis path (ADR 0021), overriding
     /// auto-detection. Requires a `--features synth` build.
     #[clap(long, conflicts_with = "netlist")]
@@ -2330,6 +2337,7 @@ fn cmd_cosim(args: CosimArgs) {
             jtag_hold_cycles: args.jtag_hold_cycles,
             run_params: args.run_params.clone(),
             bus_trace_csv: args.bus_trace_csv.clone(),
+            cosim_perf_json: args.cosim_perf_json.clone(),
         };
 
         // Backend selection (priority metal > cuda > hip > cpu, mirroring the

--- a/src/sim/cosim/cuda.rs
+++ b/src/sim/cosim/cuda.rs
@@ -669,6 +669,12 @@ impl CosimBackend for CudaBackend {
     fn wait(&self, _token: u64) {
         // run_edges synchronizes at end-of-batch; nothing left to await.
     }
+
+    fn backend_name(&self) -> &'static str {
+        "cuda"
+    }
+    // last_batch_gpu_seconds: default None for now; CUDA-event timing is a
+    // follow-up (cudaEventElapsedTime around the batch), validated on nvidia1.
 }
 
 /// Public CUDA-backend cosim entry point (Stage B). Drives the same agnostic

--- a/src/sim/cosim/hip.rs
+++ b/src/sim/cosim/hip.rs
@@ -674,6 +674,12 @@ impl CosimBackend for HipBackend {
     fn wait(&self, _token: u64) {
         // run_edges synchronizes at end-of-batch; nothing left to await.
     }
+
+    fn backend_name(&self) -> &'static str {
+        "hip"
+    }
+    // last_batch_gpu_seconds: default None for now; HIP-event timing is a
+    // follow-up (hipEventElapsedTime around the batch), validated on nvidia1.
 }
 
 /// Public HIP-backend cosim entry point (Stage B). Drives the same agnostic

--- a/src/sim/cosim/metal.rs
+++ b/src/sim/cosim/metal.rs
@@ -34,6 +34,19 @@ use super::{
     WB_TRACE_CHANNEL_CAP,
 };
 
+/// `(GPUStartTime, GPUEndTime)` of a completed command buffer, in host-clock
+/// seconds — timestamps Metal records for free (no tracing overhead). Valid
+/// only after completion. Shared by the perf report and `profile_kernels`.
+fn cb_gpu_times(cb: &metal::CommandBufferRef) -> (f64, f64) {
+    unsafe {
+        let obj: *mut objc::runtime::Object =
+            &*(cb as *const _ as *const objc::runtime::Object) as *const _ as *mut _;
+        let start: f64 = msg_send![obj, GPUStartTime];
+        let end: f64 = msg_send![obj, GPUEndTime];
+        (start, end)
+    }
+}
+
 // ── Simulation Parameters (must match Metal shader) ──────────────────────────
 
 #[repr(C)]
@@ -168,6 +181,10 @@ struct MetalSimulator {
     batch_index: std::cell::Cell<usize>,
     /// Whether an `MTLCaptureManager` capture is currently open.
     capture_active: std::cell::Cell<bool>,
+    /// Most recently committed batch command buffer, retained so its GPU
+    /// timestamps (`GPUStartTime`/`GPUEndTime`) can be read after completion for
+    /// the perf report. Replaced each batch; one command buffer stays alive.
+    last_cb: std::cell::RefCell<Option<metal::CommandBuffer>>,
 }
 
 impl MetalSimulator {
@@ -268,6 +285,7 @@ impl MetalSimulator {
             gpu_capture,
             batch_index: std::cell::Cell::new(0),
             capture_active: std::cell::Cell::new(false),
+            last_cb: std::cell::RefCell::new(None),
         }
     }
 
@@ -326,6 +344,19 @@ impl MetalSimulator {
                 clilog::info!("GPU capture written → {}", cfg.path);
             }
         }
+    }
+
+    /// GPU-execution wall (seconds) of the last committed batch, from device
+    /// timestamps. `None` before the first batch. The spin-wait only observes
+    /// the shared event; the driver posts `GPUStartTime`/`GPUEndTime` at full
+    /// command-buffer completion, so `wait_until_completed` (which returns
+    /// immediately here — the event already fired) is needed before reading.
+    fn last_batch_gpu_seconds(&self) -> Option<f64> {
+        self.last_cb.borrow().as_ref().map(|cb| {
+            cb.wait_until_completed();
+            let (start, end) = cb_gpu_times(cb);
+            end - start
+        })
     }
 
     /// Dispatch a single stage (standalone, with own command buffer).
@@ -677,6 +708,10 @@ impl MetalSimulator {
         cb.encode_signal_event(&self.shared_event, batch_done);
         cb.commit();
 
+        // Retain this batch's command buffer so its GPU timestamps can be read
+        // after completion (perf report). One command buffer stays alive.
+        *self.last_cb.borrow_mut() = Some(cb.to_owned());
+
         self.event_counter.set(batch_done);
 
         // Advance the capture batch counter and, once the window has closed,
@@ -727,16 +762,8 @@ impl MetalSimulator {
     ) {
         // Use schedule position 0 for profiling (all patterns have same kernel cost).
         let (ref edge_prep_params_buffer, ref edge_ops_buffer) = schedule_buffers.edge_buffers[0];
-        #[inline]
-        fn gpu_times(cb: &metal::CommandBufferRef) -> (f64, f64) {
-            unsafe {
-                let obj: *mut objc::runtime::Object =
-                    &*(cb as *const _ as *const objc::runtime::Object) as *const _ as *mut _;
-                let start: f64 = msg_send![obj, GPUStartTime];
-                let end: f64 = msg_send![obj, GPUEndTime];
-                (start, end)
-            }
-        }
+        // Per-kernel GPU timing uses the shared `cb_gpu_times` helper.
+        let gpu_times = cb_gpu_times;
 
         println!("\n=== GPU Kernel Profiling ({} edges) ===\n", num_ticks);
 
@@ -2059,6 +2086,14 @@ impl CosimBackend for MetalBackend {
     #[inline]
     fn wait(&self, token: u64) {
         self.sim.spin_wait(token);
+    }
+
+    fn last_batch_gpu_seconds(&self) -> Option<f64> {
+        self.sim.last_batch_gpu_seconds()
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "metal"
     }
 }
 

--- a/src/sim/cosim/mod.rs
+++ b/src/sim/cosim/mod.rs
@@ -65,6 +65,13 @@ pub struct CosimOpts {
     /// Path to write decoded AHB/APB bus transactions as CSV. Requires
     /// at least one `bus_traces` entry in the config. See ADR 0013.
     pub bus_trace_csv: Option<std::path::PathBuf>,
+    /// Path to write a machine-readable JSON cosim perf report (per-edge timing
+    /// breakdown incl. device-timestamp GPU-exec time). Report-only; consumed by
+    /// the CI timing step. `None` → no JSON file is written. (The GPU-exec
+    /// timing itself is always collected so the human summary can show it; its
+    /// cost is negligible — one command-buffer completion read per ~1024-edge
+    /// batch.)
+    pub cosim_perf_json: Option<std::path::PathBuf>,
 }
 
 /// Result of a co-simulation run.
@@ -1939,6 +1946,24 @@ trait CosimBackend {
     /// no-op — a CPU backend has no GPU kernels to profile.
     fn profile_kernels(&self, _num_ticks: usize) {}
 
+    /// GPU-execution wall time, in seconds, of the most recently completed
+    /// batch — measured from device timestamps (Metal: `MTLCommandBuffer`
+    /// `GPUStartTime`/`GPUEndTime`; CUDA/HIP: event elapsed time). Called by the
+    /// orchestration after `wait()`, so the batch is already complete. Returns
+    /// `None` for backends without a GPU clock (the CPU reference backend) or
+    /// when the last batch has no timing recorded yet. This is the ground-truth
+    /// GPU-vs-CPU split, free of the tracing overhead that Metal System Trace /
+    /// nsys impose on a workload of thousands of tiny dispatches per batch.
+    fn last_batch_gpu_seconds(&self) -> Option<f64> {
+        None
+    }
+
+    /// Short backend identifier for perf reports (`"metal"`, `"cuda"`, `"hip"`,
+    /// `"cpu"`).
+    fn backend_name(&self) -> &'static str {
+        "unknown"
+    }
+
     /// Materialise the backend's native per-edge schedule storage *once* from
     /// the backend-agnostic ops description (one `Vec<BitOp>` per scheduler
     /// edge). The orchestration keeps only scalars (`edges_per_period`,
@@ -3181,6 +3206,10 @@ fn run_cosim_generic<B: CosimBackend>(
     let mut prof_drain: u64 = 0;
     let mut prof_stimulus_vcd: u64 = 0;
     let mut prof_output_vcd: u64 = 0;
+    // Ground-truth GPU-execution time (device timestamps), summed over batches.
+    // Distinct from `prof_gpu_wait` (CPU wall spent spinning), which is a CPU
+    // measurement; this is the GPU-side clock and is 0 when the backend has none.
+    let mut prof_gpu_exec_ns: u64 = 0;
     let mut total_batches: u64 = 0;
     // Batch-utilisation telemetry: how often the GPU-only batched fast path
     // (batch>1) is exercised vs. forced single-edge dispatch. Informs the
@@ -3406,6 +3435,12 @@ fn run_cosim_generic<B: CosimBackend>(
         let t_wait = std::time::Instant::now();
         backend.wait(batch_done);
         prof_gpu_wait += t_wait.elapsed().as_nanos() as u64;
+
+        // Ground-truth GPU-execution time from device timestamps (the batch is
+        // complete now). `None` on the CPU backend / until a backend records it.
+        if let Some(gpu_s) = backend.last_batch_gpu_seconds() {
+            prof_gpu_exec_ns += (gpu_s * 1e9) as u64;
+        }
 
         // ── Drain VCD ring buffer (stimulus + timing) ──────────────────────
         if vcd_enabled {
@@ -4009,6 +4044,13 @@ fn run_cosim_generic<B: CosimBackend>(
     // Print profiling results
     let total_ns =
         prof_batch_encode + prof_gpu_wait + prof_drain + prof_stimulus_vcd + prof_output_vcd;
+    // GPU-busy share of the instrumented wall — computed once, used by both the
+    // human summary line and the JSON report.
+    let gpu_util_pct = if total_ns > 0 {
+        100.0 * prof_gpu_exec_ns as f64 / total_ns as f64
+    } else {
+        0.0
+    };
     let print_prof = |name: &str, ns: u64| {
         let us = ns as f64 / 1000.0 / max_edges as f64;
         let pct = if total_ns > 0 {
@@ -4030,6 +4072,17 @@ fn run_cosim_generic<B: CosimBackend>(
         "TOTAL (instrumented)",
         total_ns as f64 / 1000.0 / max_edges as f64
     );
+    // Ground-truth GPU-execution time from device timestamps — a *separate*
+    // measure from the CPU categories above (it overlaps the "GPU wait (spin)"
+    // line, which is the CPU wall spent waiting). The % is GPU-busy share of the
+    // instrumented wall. Absent on the CPU backend.
+    if prof_gpu_exec_ns > 0 {
+        let us = prof_gpu_exec_ns as f64 / 1000.0 / max_edges as f64;
+        println!(
+            "  {:<32} {:>8.1}μs/tick  {:>5.1}%  (GPU-busy share of wall)",
+            "GPU exec (device ts)", us, gpu_util_pct
+        );
+    }
     println!();
     println!("  Total batches:                 {}", total_batches);
     let total_edges = tick.max(1);
@@ -4048,6 +4101,40 @@ fn run_cosim_generic<B: CosimBackend>(
 
     let sim_elapsed = sim_start.elapsed();
     clilog::finish!(timer_sim);
+
+    // ── Machine-readable perf report (--cosim-perf-json, report-only) ────
+    // A flat JSON record of the per-edge timing breakdown for CI to log/track.
+    // `gpu_*` fields are 0 / `gpu_exec_recorded:false` on the CPU backend (no
+    // device clock). Report format, not a stable contract — may gain fields.
+    if let Some(json_path) = opts.cosim_perf_json.as_ref() {
+        let per_edge = |ns: u64| ns as f64 / 1000.0 / max_edges.max(1) as f64;
+        let report = serde_json::json!({
+            "backend": backend.backend_name(),
+            "edges": max_edges,
+            "wall_seconds": sim_elapsed.as_secs_f64(),
+            "total_us_per_edge": per_edge(total_ns),
+            "gpu_exec_us_per_edge": per_edge(prof_gpu_exec_ns),
+            "gpu_util_pct": gpu_util_pct,
+            "gpu_exec_recorded": prof_gpu_exec_ns > 0,
+            "cpu_encode_us_per_edge": per_edge(prof_batch_encode),
+            "gpu_wait_spin_us_per_edge": per_edge(prof_gpu_wait),
+            "drain_us_per_edge": per_edge(prof_drain),
+            "output_vcd_us_per_edge": per_edge(prof_output_vcd),
+            "batches": total_batches,
+            "mean_batch": mean_batch,
+        });
+        match serde_json::to_string_pretty(&report)
+            .map_err(|e| e.to_string())
+            .and_then(|s| std::fs::write(json_path, s).map_err(|e| e.to_string()))
+        {
+            Ok(()) => clilog::info!("cosim perf report → {}", json_path.display()),
+            Err(e) => clilog::warn!(
+                "failed to write cosim perf report to {}: {}",
+                json_path.display(),
+                e
+            ),
+        }
+    }
 
     // ── Bus transaction trace output (ADR 0013) ──────────────────────────
     if !bus_lanes.is_empty() {
@@ -5176,6 +5263,12 @@ impl CosimBackend for CpuBackend {
     fn wait(&self, _token: u64) {
         // Synchronous CPU backend — run_edges already completed.
     }
+
+    fn backend_name(&self) -> &'static str {
+        "cpu"
+    }
+    // last_batch_gpu_seconds: default None — the CPU reference backend has no
+    // GPU clock; the perf report's gpu_* fields stay 0 / gpu_exec_recorded=false.
 }
 
 /// Public CPU-backend cosim entry point (Phase 1 step 5a). Drives the same


### PR DESCRIPTION
## What

A cross-backend cosim **perf-timing report** that measures **ground-truth GPU-execution time from device timestamps** — and surfaces it both in the human profiling summary and (via `--cosim-perf-json`) as a machine-readable JSON record for CI.

## Why

A full GPU trace (Metal System Trace / nsys) instruments every Metal/CUDA call. For a cosim batch of ~2048 tiny dispatches that overhead is large and **systematically distorts** the CPU/GPU picture — in this investigation it made the GPU look ~88% *idle* when command-buffer timestamps show it ~88% **busy**. `MTLCommandBuffer.GPUStartTime`/`GPUEndTime` cost nothing and are the trustworthy signal for steady-state throughput. This lands that measurement as a first-class, low-overhead report so we can track it in CI.

## Design

- **Trait seam** (backend-agnostic): `CosimBackend::last_batch_gpu_seconds() -> Option<f64>` (default `None`) + `backend_name()`, mirroring the existing `profile_kernels` default-hook pattern. The generic loop (`run_cosim_generic`) owns CPU timing + report assembly; each backend supplies only its GPU clock.
- **Metal**: `GPUStartTime`/`GPUEndTime`, read after completion (shared `cb_gpu_times` helper, dedup'd with `profile_kernels`).
- **CUDA/HIP**: trait default (`None`) for now — their `cudaEvent`/`hipEvent` impls are a follow-up validated on the GPU runner. `backend_name()` is still correct today, and `gpu_exec_recorded:false` lets consumers distinguish "no clock" from "measured zero".
- **CPU backend**: `None` (no device clock).

## Output

Human summary gains a line:
```
  GPU exec (device ts)             65.7μs/tick   88.1%  (GPU-busy share of wall)
```
`--cosim-perf-json <PATH>` writes (serde_json):
```json
{ "backend": "metal", "edges": 500000, "gpu_exec_us_per_edge": 65.7,
  "gpu_util_pct": 88.1, "gpu_exec_recorded": true, "total_us_per_edge": 74.5,
  "cpu_encode_us_per_edge": 7.8, "batches": 550, "mean_batch": 909.1, ... }
```
Report format, not a stable contract — may gain fields.

## CI

The `mcu-soc-metal` job runs the mcu_soc cosim with `--cosim-perf-json` and posts the JSON to the step summary — **report-only, no perf gate**. Rationale: build a timing history first; a gate needs a measured noise floor to avoid flaking on shared-runner GPU/thermal noise. Gating (+ CUDA/HIP reporting) is the natural follow-up.

## Testing

- Byte-identical to golden VCDs on **mcu_soc** and **qspi_psram** (the `last_cb` retention doesn't affect simulation).
- Verified on mcu_soc: GPU exec 65.7 µs/edge / 88.1% busy, matching the spin-wait time.
- Builds green for default (CpuBackend) and `--features metal`.

## Notes

- GPU timing is collected **always** (so the human summary shows it), at negligible cost — one command-buffer completion read per ~1024-edge batch (agents quantified ≪0.5% of a seconds-long run).
- Deferred by design (noted in code/docs): a dedicated schema-versioned report module (this is report-only, not a stable contract like the STA `--timing-report`), and a CI composite action (extract when CUDA/HIP add their jobs).

Docs: `docs/cosim-perf-report.md`.