### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@ the public contracts in `docs/release-process.md` follow stricter rules).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-07
+
 ### Added
 
+- **Behavioral-RTL on-ramp (ADR 0021).** `jacquard sim` and `jacquard cosim`
+  now accept **behavioral Verilog / SystemVerilog directly** — synthesis is
+  transparent and cached, run through an embedded YoWASP Yosys (with the
+  `yosys-slang` SystemVerilog frontend) via Rust + `wasmtime`. Built into
+  release binaries via the `synth` feature; `--yosys-wasm <PATH>` overrides
+  the bundled wasm. See `docs/accepted-rtl.md`.
 - **Cell-model IR descriptors (ADR 0019).** Standard-cell libraries are now
   consumed as generated JSON descriptors — pin directions, combinational AIG,
   sequential roles, and timing — produced from Liberty by the
@@ -21,6 +29,27 @@ the public contracts in `docs/release-process.md` follow stricter rules).
   cells** — no vendored-PDK read at simulation time — and the `PdkVariant`
   enum, per-PDK stdcell classifiers, and `build.rs` pin-table generation are
   retired. See `docs/adding-a-pdk.md`.
+- **Plural QSPI memory + writable PSRAM (ADR 0013).** The SPI-flash peripheral
+  went plural: **`qspi_memory: Vec<QspiMemoryConfig>`** with N independent
+  instances (the legacy `flash` key folds into instance 0), N-instance GPU
+  kernels on **Metal + CUDA + HIP** with independent backing stores, and an
+  opt-in **writable QSPI-PSRAM (RAM) mode** (APS6404L-class: enter-QPI /
+  quad-write / quad-read). Enables post-PnR cosim of chips whose main RAM is
+  external QSPI PSRAM. Unset options ⇒ byte-identical to the read-only flash.
+- **GPU frame capture (Metal).** `JACQUARD_GPU_CAPTURE=<path>` (with
+  `METAL_CAPTURE_ENABLED=1`) brackets an `MTLCaptureManager` scope around a
+  bounded window of cosim batches and writes an Xcode `.gputrace` for
+  per-dispatch GPU analysis. `JACQUARD_GPU_CAPTURE_SKIP` / `_BATCHES` select
+  the window. See `docs/gpu-capture.md`. (#174)
+- **Cosim perf report.** `jacquard cosim` reports a per-edge CPU/GPU timing
+  breakdown including **ground-truth GPU-execution time from device
+  timestamps** (Metal `GPUStartTime`/`GPUEndTime`) — free of the distortion a
+  full GPU trace imposes on thousands of tiny dispatches per batch.
+  `--cosim-perf-json <PATH>` emits it as JSON for CI. See
+  `docs/cosim-perf-report.md`. (#175)
+- **RTL-source provenance.** `sverilogparse` now captures `(* src *)`
+  attributes and carries them through the netlist and AIG; `jacquard xsources`
+  reports the RTL source location of each design X-source.
 - **TNS / THS timing metrics** in `--timing-summary` and `--timing-report`.
   Alongside the existing worst-single-slack WNS/WHS, the report now carries
   Total Negative Slack and Total Hold Slack — the sum of every negative
@@ -28,6 +57,13 @@ the public contracts in `docs/release-process.md` follow stricter rules).
   `stats.total_hold_slack_ps`). Additive JSON-schema change, bumped to
   `1.2.0` (older reports still parse via `#[serde(default)]`). Salvaged from
   the timing logic in #17. (#9)
+- **`JACQUARD_VENDOR_DIR`** environment override for the vendored-PDK root.
+
+### Changed
+
+- **`jacquard build` folded into `sim`/`cosim`.** The standalone `build`
+  subcommand is removed; behavioral RTL is synthesized transparently by
+  `sim`/`cosim` (see the on-ramp entry above).
 
 ## [0.2.4] - 2026-06-26
 
@@ -424,7 +460,8 @@ runners land (ADR 0018).
   CUDA / HIP detect violations on the GPU but don't currently route
   them; the JSON / text outputs only fire on Metal today.
 
-[Unreleased]: https://github.com/gpu-eda/Jacquard/compare/v0.2.4...HEAD
+[Unreleased]: https://github.com/gpu-eda/Jacquard/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/gpu-eda/Jacquard/compare/v0.2.4...v0.3.0
 [0.2.4]: https://github.com/gpu-eda/Jacquard/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/gpu-eda/Jacquard/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/gpu-eda/Jacquard/compare/v0.2.1...v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,11 +404,11 @@ dependencies = [
 
 [[package]]
 name = "cell-decomp"
-version = "0.2.4"
+version = "0.3.0"
 
 [[package]]
 name = "cell-model-ir"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "clap",
  "serde",
@@ -1487,7 +1487,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jacquard"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "block",
@@ -1579,14 +1579,14 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "liberty-parse"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "liberty-to-cellir"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "cell-decomp",
  "cell-model-ir",
@@ -1844,7 +1844,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opensta-to-ir"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "clap",
  "flatbuffers",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "timing-ir"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "clap",
  "flatbuffers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jacquard"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "GPU-accelerated RTL logic simulator with vector-driven setup/hold timing analysis. Maps gate-level netlists to a virtual manycore Boolean processor and runs them on Metal / CUDA / HIP."
 repository = "https://github.com/gpu-eda/Jacquard"

--- a/crates/cell-decomp/Cargo.toml
+++ b/crates/cell-decomp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cell-decomp"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "PDK-neutral behavioral Verilog parsing and AIG decomposition primitives shared by jacquard core and the Liberty->IR converter. See docs/adr/0019-cell-model-ir.md."
 license = "Apache-2.0"

--- a/crates/cell-model-ir/Cargo.toml
+++ b/crates/cell-model-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cell-model-ir"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "Jacquard cell-model IR: a generated, JSON-first, per-cell-type library descriptor (pin directions, combinational AIG, sequential/classification, timing). See docs/adr/0019-cell-model-ir.md."
 license = "Apache-2.0"

--- a/crates/liberty-parse/Cargo.toml
+++ b/crates/liberty-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liberty-parse"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "Generic Liberty (.lib) tokenizer + group/attribute parser. The single Liberty front-end in Jacquard: jacquard's TimingLibrary and the (future) Liberty->cell-model-ir converter both consume this. See docs/adr/0019-cell-model-ir.md (D6)."
 license = "Apache-2.0"

--- a/crates/liberty-to-cellir/Cargo.toml
+++ b/crates/liberty-to-cellir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liberty-to-cellir"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "Build/CI-time tool that generates a cell-model-IR descriptor from a Liberty library (ADR 0019, D6). Lives outside the root cargo package; `cargo test` from the repo root does NOT run its tests — use `cargo test --manifest-path crates/liberty-to-cellir/Cargo.toml`. Not depended on by jacquard core."
 license = "Apache-2.0"

--- a/crates/opensta-to-ir/Cargo.toml
+++ b/crates/opensta-to-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensta-to-ir"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "Preprocessing tool that drives OpenSTA and emits Jacquard timing IR. Lives outside the root cargo workspace; `cargo test --lib` from the repo root does NOT run its tests — use `cd crates/opensta-to-ir && cargo test` locally, or rely on the dedicated `opensta-to-ir-tests` CI job. See docs/plans/ws2-opensta-to-ir.md and docs/adr/0006-sdf-preprocessing-model.md."
 license = "Apache-2.0"

--- a/crates/timing-ir/Cargo.toml
+++ b/crates/timing-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timing-ir"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2021"
 description = "Jacquard timing intermediate representation (IR) for SDF-equivalent annotations. See docs/adr/0002-timing-ir.md."
 license = "Apache-2.0"


### PR DESCRIPTION
Release **v0.3.0** — a substantial feature release since v0.2.4.

## Changes
- Rolls `[Unreleased]` → `[0.3.0]` in `CHANGELOG.md` (+ link refs).
- Bumps all seven Rust crates 0.2.4 → 0.3.0 via `scripts/bump_version.py` (+ `Cargo.lock`).

## Headline features (since v0.2.4)
- **Behavioral-RTL on-ramp (ADR 0021)** — `sim`/`cosim` accept behavioral Verilog/SV directly via embedded YoWASP Yosys (`yosys-slang`) through Rust+wasmtime; `jacquard build` folded in; `--yosys-wasm` override.
- **Plural QSPI memory + writable PSRAM (ADR 0013)** — `qspi_memory: Vec<…>`, N-instance kernels on Metal/CUDA/HIP, opt-in writable RAM mode.
- **GPU frame capture (Metal)** — `JACQUARD_GPU_CAPTURE` → `.gputrace` (#174).
- **Cosim perf report** — device-timestamp GPU/CPU timing + `--cosim-perf-json` (#175).
- **Cell-model IR descriptors (ADR 0019)**, **RTL-source provenance**, **TNS/THS timing metrics**, `JACQUARD_VENDOR_DIR`.

## Post-merge
Once this is merged + green on main, tag `v0.3.0` and create the GitHub release (body = the 0.3.0 CHANGELOG section), per `docs/release-process.md`.