### PR TITLE
ci(release): auto-bump Homebrew tap (+ prerelease channel)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: macos-runner-1
     env:
       GH_TOKEN: ${{ github.token }}
+    # Expose the version/mode decision so the tap-bump job can gate on it.
+    outputs:
+      is_release: ${{ steps.meta.outputs.is_release }}
+      is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -187,3 +191,76 @@ jobs:
           path: |
             ${{ steps.package.outputs.tarball }}
             ${{ steps.package.outputs.sha }}
+
+  # Auto-bump the Homebrew formula in the tap so `brew install` tracks releases
+  # without a manual edit (the tap had been drifting — stale at 0.2.3). Final
+  # releases push to the production tap; prereleases push to a separate
+  # prerelease tap so RCs are `brew install`-able for staging without polluting
+  # the stable channel. See docs/release-process.md § Homebrew.
+  #
+  # Requires (org-admin one-time setup):
+  #   - secrets.HOMEBREW_TAP_TOKEN — a fine-grained PAT / App token with
+  #     `contents: write` on both tap repos below.
+  #   - the gpu-eda/homebrew-tap-prerelease repo (for the RC channel).
+  bump-tap:
+    name: Bump Homebrew tap
+    needs: release-metal
+    # Real tags only (skip workflow_dispatch dry-runs).
+    if: needs.release-metal.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the formula template
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Generate the bumped formula from the published asset
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          ver="${TAG#v}"
+          base="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          tarball="jacquard-${ver}-macos-arm64-metal.tar.gz"
+          # Read the sha256 the release job published alongside the tarball.
+          # Retry on transient errors too — a just-published release asset can
+          # 404 briefly while GitHub propagates the download URL.
+          sha="$(curl -fsSL --retry 6 --retry-delay 5 --retry-all-errors "${base}/${tarball}.sha256" | awk '{print $1}')"
+          test -n "${sha}"
+          # Rewrite the source-of-truth template's url/version/sha256 from the
+          # actual asset (identical mechanism to validate-install.yml).
+          sed -e "s|url \".*\"|url \"${base}/${tarball}\"|" \
+              -e "s|version \".*\"|version \"${ver}\"|" \
+              -e "s|sha256 \".*\"|sha256 \"${sha}\"|" \
+              packaging/homebrew/jacquard.rb > /tmp/jacquard.rb
+          echo "--- generated formula ---"; cat /tmp/jacquard.rb
+      - name: Push to the tap (production or prerelease channel)
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ github.ref_name }}
+          IS_PRERELEASE: ${{ needs.release-metal.outputs.is_prerelease }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TAP_TOKEN:-}" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN is not set — provision it to enable tap auto-bump." >&2
+            exit 1
+          fi
+          if [ "${IS_PRERELEASE}" = "true" ]; then
+            tap_repo="gpu-eda/homebrew-tap-prerelease"
+          else
+            tap_repo="gpu-eda/homebrew-tap"
+          fi
+          git clone --depth 1 \
+            "https://x-access-token:${TAP_TOKEN}@github.com/${tap_repo}.git" tap
+          mkdir -p tap/Formula
+          cp /tmp/jacquard.rb tap/Formula/jacquard.rb
+          cd tap
+          git config user.name "jacquard-release-bot"
+          git config user.email "noreply@github.com"
+          git add Formula/jacquard.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date for ${TAG}; nothing to push."
+            exit 0
+          fi
+          git commit -m "jacquard ${TAG#v}"
+          git push
+          echo "Pushed jacquard ${TAG#v} to ${tap_repo}."

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,6 +26,13 @@ The cleanest path on a Mac. Requires an Apple Silicon machine with a
 Metal GPU. The Homebrew formula is built with `--features synth`, so
 behavioral RTL input works out of the box — see [Accepted RTL surface](accepted-rtl.md).
 
+To try a **release candidate** before it ships, install from the prerelease
+tap instead (it tracks the latest `-rc` tag):
+
+```sh
+brew install gpu-eda/tap-prerelease/jacquard
+```
+
 ### cargo binstall — prebuilt binary, no toolchain build
 
 ```sh

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -73,6 +73,25 @@ For maintainers cutting a release:
    section for that version. No artefacts attached unless someone has
    asked for them.
 
+## Homebrew tap (automated)
+
+The Homebrew formula is **auto-bumped by `release.yml`** — no manual step
+(this closes the drift that had left the tap stale at 0.2.3). On every
+release tag the `bump-tap` job rewrites `packaging/homebrew/jacquard.rb`'s
+`url`/`version`/`sha256` from the just-published tarball + `.sha256` and
+pushes `Formula/jacquard.rb` to the tap:
+
+- **final release** → `gpu-eda/homebrew-tap` (`brew install gpu-eda/tap/jacquard`);
+- **prerelease (RC)** → `gpu-eda/homebrew-tap-prerelease`
+  (`brew install gpu-eda/tap-prerelease/jacquard`), so RCs are
+  `brew install`-able for staging without touching the stable channel.
+
+`packaging/homebrew/jacquard.rb` is the **template** — edit it only to change
+the formula's *structure* (deps, install, test); its version pin is a
+placeholder the job overwrites. Requires the one-time org setup:
+`secrets.HOMEBREW_TAP_TOKEN` (a token with `contents: write` on both tap
+repos) and the `gpu-eda/homebrew-tap-prerelease` repo.
+
 ## Staging validation (release candidates)
 
 Optional but recommended before a user-facing release: prove the

--- a/packaging/homebrew/jacquard.rb
+++ b/packaging/homebrew/jacquard.rb
@@ -2,15 +2,15 @@
 
 # Homebrew formula for Jacquard (macOS / Metal prebuilt binary).
 #
-# This is the SOURCE OF TRUTH for the formula; it is copied/PR'd into the
-# `gpu-eda/homebrew-tap` repo as `Formula/jacquard.rb` (see
-# packaging/README.md). Apple Silicon + Metal only — the simulator needs a
-# Metal GPU.
+# This is the SOURCE-OF-TRUTH TEMPLATE for the formula. Apple Silicon + Metal
+# only — the simulator needs a Metal GPU.
 #
-# Per release, bump `url` (both version occurrences), `version`, and
-# `sha256` to the `jacquard-<version>-macos-arm64-metal.tar.gz` asset. The
-# release workflow emits the `.sha256` alongside the tarball; bump by hand,
-# with `brew bump-formula-pr`, or via a future release-CI step.
+# The `url`/`version`/`sha256` below are placeholders: on every release tag,
+# the `bump-tap` job in `.github/workflows/release.yml` rewrites them from the
+# published tarball + `.sha256` and pushes the result to the tap —
+# `gpu-eda/homebrew-tap` for final releases, `gpu-eda/homebrew-tap-prerelease`
+# for RCs. So this file need not be bumped by hand; edit it only to change the
+# formula *structure* (deps, install steps, test), not the version pin.
 class Jacquard < Formula
   desc "GPU-accelerated RTL logic simulator (Metal backend)"
   homepage "https://github.com/gpu-eda/Jacquard"


### PR DESCRIPTION
## Problem
The Homebrew formula is bumped **by hand** — a step with no home in `docs/release-process.md`, so it got skipped. The tap is **stale at v0.2.3**, two releases behind main (0.3.0). `brew install gpu-eda/tap/jacquard` serves 0.2.3 today.

## Fix
`release.yml` gains a **`bump-tap`** job. On every real release tag it rewrites `packaging/homebrew/jacquard.rb`'s `url`/`version`/`sha256` from the just-published tarball + `.sha256` (identical mechanism to `validate-install.yml`) and pushes `Formula/jacquard.rb` to the tap, routed by channel:

| Channel | Tap | Install |
|---|---|---|
| Final release | `gpu-eda/homebrew-tap` | `brew install gpu-eda/tap/jacquard` |
| Prerelease (RC) | `gpu-eda/homebrew-tap-prerelease` | `brew install gpu-eda/tap-prerelease/jacquard` |

So RCs become `brew install`-able for staging (answering "a jacquard-prerelease tap") **without** polluting the stable channel — the separate-tap beta pattern, so no formula-name/binary conflicts.

`packaging/homebrew/jacquard.rb` becomes the **template** (its version pin is a placeholder the job overwrites); `release-process.md` documents the automation and `installation.md` adds the prerelease-tap install line.

## ⚠️ One-time org setup required (I can't do these — org-admin actions)
The job **fails loudly** until both exist:
1. **`HOMEBREW_TAP_TOKEN`** secret — a fine-grained PAT / GitHub App token with `contents: write` on `gpu-eda/homebrew-tap` **and** `gpu-eda/homebrew-tap-prerelease`.
2. The **`gpu-eda/homebrew-tap-prerelease`** repo (can be empty; the job creates `Formula/jacquard.rb`).

## Notes
- Gated on `is_release == 'true'` — `workflow_dispatch` dry-runs skip it.
- Idempotent: no-ops if the formula is already current for the tag.
- Applies to **future** tags; the already-cut `v0.3.0-rc.1` predates this and won't back-fill (use the manual `brew install --formula` path meanwhile).
- Validated: `actionlint` clean (bar the pre-existing SC2129 in the `meta` step), formula `ruby -c` OK.