### PR TITLE
fix(release): honest RC-window main state + rename crate to jacquard-sim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ the public contracts in `docs/release-process.md` follow stricter rules).
 
 ## [Unreleased]
 
-## [0.3.0] - 2026-07-07
-
 ### Added
 
 - **Behavioral-RTL on-ramp (ADR 0021).** `jacquard sim` and `jacquard cosim`
@@ -460,8 +458,7 @@ runners land (ADR 0018).
   CUDA / HIP detect violations on the GPU but don't currently route
   them; the JSON / text outputs only fire on Metal today.
 
-[Unreleased]: https://github.com/gpu-eda/Jacquard/compare/v0.3.0...HEAD
-[0.3.0]: https://github.com/gpu-eda/Jacquard/compare/v0.2.4...v0.3.0
+[Unreleased]: https://github.com/gpu-eda/Jacquard/compare/v0.2.4...HEAD
 [0.2.4]: https://github.com/gpu-eda/Jacquard/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/gpu-eda/Jacquard/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/gpu-eda/Jacquard/compare/v0.2.1...v0.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,11 +404,11 @@ dependencies = [
 
 [[package]]
 name = "cell-decomp"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 
 [[package]]
 name = "cell-model-ir"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 dependencies = [
  "clap",
  "serde",
@@ -1486,8 +1486,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jacquard"
-version = "0.3.0"
+name = "jacquard-sim"
+version = "0.3.0-rc.2"
 dependencies = [
  "anyhow",
  "block",
@@ -1579,14 +1579,14 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "liberty-parse"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "liberty-to-cellir"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 dependencies = [
  "cell-decomp",
  "cell-model-ir",
@@ -1844,7 +1844,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opensta-to-ir"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 dependencies = [
  "clap",
  "flatbuffers",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "timing-ir"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 dependencies = [
  "clap",
  "flatbuffers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,12 @@
 [package]
-name = "jacquard"
-version = "0.3.0"
+# Registry/package name. Renamed from "jacquard" (which is an unrelated,
+# actively-published crates.io crate — an AT-Protocol client library) so
+# `cargo install` / `cargo binstall` resolve unambiguously and never fall back
+# to building that other project. The library and binary targets below keep the
+# `jacquard` name, so the binary users run, the release asset, and every
+# `use jacquard::…` in the source are unchanged.
+name = "jacquard-sim"
+version = "0.3.0-rc.2"
 edition = "2021"
 description = "GPU-accelerated RTL logic simulator with vector-driven setup/hold timing analysis. Maps gate-level netlists to a virtual manycore Boolean processor and runs them on Metal / CUDA / HIP."
 repository = "https://github.com/gpu-eda/Jacquard"
@@ -92,6 +98,11 @@ optional = true
 [dependencies.block]
 version = "0.1"
 optional = true
+
+[lib]
+# Keep the library crate name `jacquard` (independent of the package name
+# above) so every `use jacquard::…` in src/bin and tests stays untouched.
+name = "jacquard"
 
 [[bin]]
 name = "jacquard"

--- a/crates/cell-decomp/Cargo.toml
+++ b/crates/cell-decomp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cell-decomp"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 edition = "2021"
 description = "PDK-neutral behavioral Verilog parsing and AIG decomposition primitives shared by jacquard core and the Liberty->IR converter. See docs/adr/0019-cell-model-ir.md."
 license = "Apache-2.0"

--- a/crates/cell-model-ir/Cargo.toml
+++ b/crates/cell-model-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cell-model-ir"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 edition = "2021"
 description = "Jacquard cell-model IR: a generated, JSON-first, per-cell-type library descriptor (pin directions, combinational AIG, sequential/classification, timing). See docs/adr/0019-cell-model-ir.md."
 license = "Apache-2.0"

--- a/crates/liberty-parse/Cargo.toml
+++ b/crates/liberty-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liberty-parse"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 edition = "2021"
 description = "Generic Liberty (.lib) tokenizer + group/attribute parser. The single Liberty front-end in Jacquard: jacquard's TimingLibrary and the (future) Liberty->cell-model-ir converter both consume this. See docs/adr/0019-cell-model-ir.md (D6)."
 license = "Apache-2.0"

--- a/crates/liberty-to-cellir/Cargo.toml
+++ b/crates/liberty-to-cellir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liberty-to-cellir"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 edition = "2021"
 description = "Build/CI-time tool that generates a cell-model-IR descriptor from a Liberty library (ADR 0019, D6). Lives outside the root cargo package; `cargo test` from the repo root does NOT run its tests — use `cargo test --manifest-path crates/liberty-to-cellir/Cargo.toml`. Not depended on by jacquard core."
 license = "Apache-2.0"

--- a/crates/opensta-to-ir/Cargo.toml
+++ b/crates/opensta-to-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensta-to-ir"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 edition = "2021"
 description = "Preprocessing tool that drives OpenSTA and emits Jacquard timing IR. Lives outside the root cargo workspace; `cargo test --lib` from the repo root does NOT run its tests — use `cd crates/opensta-to-ir && cargo test` locally, or rely on the dedicated `opensta-to-ir-tests` CI job. See docs/plans/ws2-opensta-to-ir.md and docs/adr/0006-sdf-preprocessing-model.md."
 license = "Apache-2.0"

--- a/crates/timing-ir/Cargo.toml
+++ b/crates/timing-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timing-ir"
-version = "0.3.0"
+version = "0.3.0-rc.2"
 edition = "2021"
 description = "Jacquard timing intermediate representation (IR) for SDF-equivalent annotations. See docs/adr/0002-timing-ir.md."
 license = "Apache-2.0"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,14 +37,24 @@ brew install gpu-eda/tap-prerelease/jacquard
 
 ```sh
 brew install llvm     # runtime dependency — see note below
-cargo binstall --git https://github.com/gpu-eda/Jacquard jacquard
+cargo binstall --git https://github.com/gpu-eda/Jacquard jacquard-sim \
+  --disable-strategies compile,quick-install
 ```
 
-Fetches the release binaries (`jacquard` + `timing_analysis`) on
-**macOS/Metal**. The `--git` form is required: `jacquard` is **not on
-crates.io** (its dependencies are a vendored fork carrying in-flight
-patches), so binstall reads the `[package.metadata.binstall]` pkg-url
-straight from the repo rather than looking the crate up on the registry.
+Installs the `jacquard` binary (+ `timing_analysis`) on **macOS/Metal**. The
+crate is the **`jacquard-sim`** package (the binary it installs is still
+`jacquard`); the `--git` form is required because it's **not on crates.io**
+(its dependencies are a vendored fork carrying in-flight patches), so binstall
+reads the `[package.metadata.binstall]` pkg-url straight from the repo.
+
+> **Why `jacquard-sim`, not `jacquard`.** The package is named `jacquard-sim`
+> because the crate name `jacquard` is taken on crates.io by an **unrelated**
+> project (an AT-Protocol client library) — so `cargo install jacquard` would
+> build *that*, not this. Naming our package `jacquard-sim` makes resolution
+> unambiguous. `--disable-strategies compile,quick-install` is kept as
+> belt-and-suspenders: it turns a missing prebuilt binary into a clean hard
+> error rather than any source-build fallback. (`validate-install.yml` uses the
+> same guard.)
 Linux is **not** binstall-able: there are two GPU backends (CUDA, HIP) for
 one target triple, so it can't be auto-selected — use the release tarball
 for your backend, a container, or build from source.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -99,10 +99,23 @@ Optional but recommended before a user-facing release: prove the
 promoting. There is no "test crates registry", so a **GitHub prerelease**
 is the staging tier for the binary channels.
 
-1. **Cut an RC.** `python3 scripts/bump_version.py <X.Y.Z>-rc.<N>`, commit,
-   tag `v<X.Y.Z>-rc.<N>`, push the tag. `release.yml` detects the SemVer
+> **Sequence matters — do NOT roll main to the final version before the RC
+> validates.** During the RC window `main` **is** the candidate: it stays at
+> `X.Y.Z-rc.N` with the changelog still under `[Unreleased]`. Only the
+> **Promote** step (below) rolls `[Unreleased] → [X.Y.Z]` and bumps to the
+> final `X.Y.Z`. Rolling the release onto `main` first leaves `main`
+> advertising a version that has no release — the version pin and dated
+> changelog claim `X.Y.Z` is shipped while only the RC tag exists, which also
+> breaks `cargo binstall --git` (it reads `main`'s version and fetches a
+> non-existent `vX.Y.Z` tarball). Each new RC is a `main` commit bumped to the
+> next `-rc.N`; `main == the latest RC tag` throughout.
+
+1. **Cut an RC.** On `main` at `X.Y.Z-rc.N` (changelog under `[Unreleased]`),
+   `python3 scripts/bump_version.py <X.Y.Z>-rc.<N>`, commit, tag
+   `v<X.Y.Z>-rc.<N>`, push the tag. `release.yml` detects the SemVer
    pre-release suffix and publishes a GitHub **prerelease** (never shown as
-   "Latest") with the Metal tarball attached.
+   "Latest") with the Metal tarball attached, and `bump-tap` pushes the
+   formula to `gpu-eda/homebrew-tap-prerelease`.
 
 2. **Validate.** Dispatch the **Validate install (staging)** workflow
    (`validate-install.yml`) with that tag. It runs the real install


### PR DESCRIPTION
Pre-`rc.2` release-window hygiene — three related fixes so the RC channel actually works.

## 1. Back main out of the premature 0.3.0 roll
The release PR (#177) rolled the changelog to a dated `[0.3.0]` and bumped to `0.3.0` on **main** *before* the RC validated — so main advertises a version with **no release**, and `cargo binstall --git` (which reads main's version) tries to fetch a non-existent `v0.3.0` tarball.
- Move the `[0.3.0]` entries back under `[Unreleased]`, restore link refs.
- Bump `0.3.0 → 0.3.0-rc.2` — so **main *is* the candidate** (main == the rc tag). `--git` binstall then serves the RC cleanly.

## 2. Document the RC-first rule
`docs/release-process.md` now states: during the RC window main stays at `X.Y.Z-rc.N` under `[Unreleased]`; only **Promote** rolls `[X.Y.Z]` + bumps to the final version. (Prevents the mistake in #1.)

## 3. Rename the crate: `jacquard` → `jacquard-sim`
`jacquard` is taken on crates.io by an **unrelated** project (an AT-Protocol client lib), so `cargo install jacquard` / binstall's compile fallback builds *that*. Renaming the **package** fixes resolution:
```toml
[package] name = "jacquard-sim"   # registry name — unambiguous
[lib]     name = "jacquard"       # kept — every `use jacquard::…` untouched
[[bin]]   name = "jacquard"       # kept — binary, asset, formula all unchanged
```
Blast radius verified minimal: `CARGO_PKG_NAME` is unused, the clap app-name is hardcoded `"jacquard"`, no `build.rs` refs, no `-p jacquard` selectors. `docs/installation.md` updates the binstall command to `jacquard-sim` and keeps `--disable-strategies compile,quick-install` as belt-and-suspenders.

## Testing
- Compiles clean through all 67 `use jacquard::…` refs (the `[lib] name` pin works); the only local build errors are the pre-existing `cell_src` submodule mismatch in `aig.rs`, unrelated — CI builds green with the recorded submodule.
- `bump_version.py --check 0.3.0-rc.2` passes; binary `--version`/`--help` identity unchanged (`jacquard`).

## Next
Merge → cut `v0.3.0-rc.2` (main == tag == rc.2) → `bump-tap` populates `gpu-eda/homebrew-tap-prerelease` → `brew install gpu-eda/tap-prerelease/jacquard` + `cargo binstall … jacquard-sim` both work.