### PR TITLE
ci(release): prerelease notes fall back to [Unreleased]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,16 +127,28 @@ jobs:
       - name: Extract release notes from CHANGELOG
         if: steps.meta.outputs.is_release == 'true'
         id: notes
+        env:
+          IS_PRERELEASE: ${{ steps.meta.outputs.is_prerelease }}
         run: |
           set -euo pipefail
           ver="${{ steps.meta.outputs.version }}"
-          awk -v ver="$ver" '
-            $0 ~ "^## \\[" ver "\\]" {flag=1; next}
-            flag && /^## \[/ {flag=0}
-            flag {print}
-          ' CHANGELOG.md > notes.md || true
+          extract() {
+            awk -v ver="$1" '
+              $0 ~ "^## \\[" ver "\\]" {flag=1; next}
+              flag && /^## \[/ {flag=0}
+              flag {print}
+            ' CHANGELOG.md
+          }
+          extract "$ver" > notes.md || true
+          # Prereleases (X.Y.Z-rc.N) have no dated [X.Y.Z-rc.N] section — their
+          # entries live under [Unreleased] during the RC window — so fall back
+          # to it, giving RC releases the curated draft notes for review.
+          if [ ! -s notes.md ] && [ "${IS_PRERELEASE}" = "true" ]; then
+            echo "no [$ver] section; prerelease → using [Unreleased] draft notes" >&2
+            extract "Unreleased" > notes.md || true
+          fi
           if [ ! -s notes.md ]; then
-            echo "no [$ver] section in CHANGELOG; using auto-generated notes" >&2
+            echo "no matching CHANGELOG section; using auto-generated notes" >&2
             echo "AUTO=true" >> "$GITHUB_OUTPUT"
           else
             echo "AUTO=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem
RC prereleases show GitHub's auto-generated PR dump as their release body (see [v0.3.0-rc.2](https://github.com/gpu-eda/Jacquard/releases/tag/v0.3.0-rc.2)) instead of our curated notes. The extractor `awk`s for an exact `## [X.Y.Z-rc.N]` CHANGELOG section — which never exists, because during the RC window the entries live under `[Unreleased]`.

## Fix
For **prereleases**, fall back to the `[Unreleased]` section when there's no exact `[X.Y.Z-rc.N]` match. RCs then ship the **curated draft notes** — exactly what you review the release against before promoting. Final releases are unchanged (they still match their dated `[X.Y.Z]` section).

~3-line `awk` refactor (shared `extract()` helper + a prerelease fallback). Validated locally: `[0.3.0-rc.2]` → 0 lines → falls back to `[Unreleased]` (which carries the 0.3.0 highlights). actionlint clean.

## Follow-up
After merge I'll refresh the current `v0.3.0-rc.2` release body with the curated notes (one-off; the workflow handles future RCs automatically).