### PR TITLE
chore: v0.3.0-rc.3 (staging)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,11 +404,11 @@ dependencies = [
 
 [[package]]
 name = "cell-decomp"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 
 [[package]]
 name = "cell-model-ir"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "clap",
  "serde",
@@ -1487,7 +1487,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jacquard-sim"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "anyhow",
  "block",
@@ -1579,14 +1579,14 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "liberty-parse"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "liberty-to-cellir"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "cell-decomp",
  "cell-model-ir",
@@ -1844,7 +1844,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opensta-to-ir"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "clap",
  "flatbuffers",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "timing-ir"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 dependencies = [
  "clap",
  "flatbuffers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 # `jacquard` name, so the binary users run, the release asset, and every
 # `use jacquard::…` in the source are unchanged.
 name = "jacquard-sim"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 description = "GPU-accelerated RTL logic simulator with vector-driven setup/hold timing analysis. Maps gate-level netlists to a virtual manycore Boolean processor and runs them on Metal / CUDA / HIP."
 repository = "https://github.com/gpu-eda/Jacquard"

--- a/crates/cell-decomp/Cargo.toml
+++ b/crates/cell-decomp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cell-decomp"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 description = "PDK-neutral behavioral Verilog parsing and AIG decomposition primitives shared by jacquard core and the Liberty->IR converter. See docs/adr/0019-cell-model-ir.md."
 license = "Apache-2.0"

--- a/crates/cell-model-ir/Cargo.toml
+++ b/crates/cell-model-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cell-model-ir"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 description = "Jacquard cell-model IR: a generated, JSON-first, per-cell-type library descriptor (pin directions, combinational AIG, sequential/classification, timing). See docs/adr/0019-cell-model-ir.md."
 license = "Apache-2.0"

--- a/crates/liberty-parse/Cargo.toml
+++ b/crates/liberty-parse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liberty-parse"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 description = "Generic Liberty (.lib) tokenizer + group/attribute parser. The single Liberty front-end in Jacquard: jacquard's TimingLibrary and the (future) Liberty->cell-model-ir converter both consume this. See docs/adr/0019-cell-model-ir.md (D6)."
 license = "Apache-2.0"

--- a/crates/liberty-to-cellir/Cargo.toml
+++ b/crates/liberty-to-cellir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liberty-to-cellir"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 description = "Build/CI-time tool that generates a cell-model-IR descriptor from a Liberty library (ADR 0019, D6). Lives outside the root cargo package; `cargo test` from the repo root does NOT run its tests — use `cargo test --manifest-path crates/liberty-to-cellir/Cargo.toml`. Not depended on by jacquard core."
 license = "Apache-2.0"

--- a/crates/opensta-to-ir/Cargo.toml
+++ b/crates/opensta-to-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opensta-to-ir"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 description = "Preprocessing tool that drives OpenSTA and emits Jacquard timing IR. Lives outside the root cargo workspace; `cargo test --lib` from the repo root does NOT run its tests — use `cd crates/opensta-to-ir && cargo test` locally, or rely on the dedicated `opensta-to-ir-tests` CI job. See docs/plans/ws2-opensta-to-ir.md and docs/adr/0006-sdf-preprocessing-model.md."
 license = "Apache-2.0"

--- a/crates/timing-ir/Cargo.toml
+++ b/crates/timing-ir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timing-ir"
-version = "0.3.0-rc.2"
+version = "0.3.0-rc.3"
 edition = "2021"
 description = "Jacquard timing intermediate representation (IR) for SDF-equivalent annotations. See docs/adr/0002-timing-ir.md."
 license = "Apache-2.0"


### PR DESCRIPTION
Next release candidate for **v0.3.0** — bumps the seven crates `0.3.0-rc.2 → 0.3.0-rc.3` (CHANGELOG stays under `[Unreleased]`, per the RC-first rule; main == the rc tag).

Cut to validate, end-to-end:
- **#180 notes automation** — the rc.3 release body should auto-populate from CHANGELOG `[Unreleased]` (no manual `gh release edit` this time).
- **`bump-tap`** — pushes the formula to `gpu-eda/homebrew-tap-prerelease` again for `0.3.0-rc.3`.

Merge → tag `v0.3.0-rc.3` → verify both.