### PR TITLE
feat(cosim): live signal/video streaming tap

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -80,3 +80,4 @@
   - [RTL-source provenance](plans/rtl-source-provenance.md)
 - [Spike — OpenTimer on SKY130](spikes/opentimer-sky130.md)
 - [Spike — reaching AMD laptops](spikes/amd-laptop-backend.md)
+- [Spike — Live video streaming tap for cosim](spikes/video-streaming-tap.md)

--- a/docs/spikes/video-streaming-tap.md
+++ b/docs/spikes/video-streaming-tap.md
@@ -1,0 +1,102 @@
+# Spike — Live video streaming tap for cosim
+
+**Status:** Proposed. Design validated against the C64 tapeout netlist; prototype not yet built.
+
+**Date:** 2026-07-07
+
+## Goal
+
+Let a separate process read a bundle of chip output pins in near-real-time and render them live — the first use being a debug video view of the C64's 4-bit `colorIndex` + `hsync`/`vsync` pads. The tap is observe-only: it samples design outputs and streams them out a socket. It never drives design inputs, so it stays out of the cycle-accurate reactive path.
+
+This came out of a wider question about a "generic GPIO model" for cosim. The two concrete C64 cases split cleanly: video (this spike) is pure output observation, while the CIA1 keyboard/joystick GPIO is the bidirectional tri-state case and is tracked separately (see "Relationship to the GPIO work" below).
+
+## Why not QEMU virtio/vhost
+
+The original idea was to reuse QEMU's virtio-gpio + vhost-user backend. Rejected for this use, for the record so it isn't re-litigated:
+
+- virtio-gpio and vhost-user are untimed and asynchronous ("set line 5 high, eventually"). Cosim is cycle-accurate per clock edge. A live raster needs per-pixel samples in order, which the virtio model throws away.
+- virtio-gpio is a logical line-command protocol (get/set value, direction, IRQ). Video out is a wire-level bit bundle sampled at pixel rate. The impedance mismatch is high.
+- vhost-user carries real weight (shared-memory negotiation, virtqueue rings, feature negotiation) to expose a semantically poor interface.
+
+virtio-gpio remains the right tool for a different goal — running unmodified guest software against the RTL's GPIO under QEMU — but that is not what a debug video view needs.
+
+## Architecture
+
+The hard part is already solved. When any VCD output is active, cosim enables a device-resident per-edge snapshot ring (`vcd_ring_dev`), blits one full `[input_state | output_state]` snapshot per edge on the GPU, and reads the ring back D2H after each batch. That gives correct per-tick values without forcing `batch=1`. The tap reuses this ring; it adds no GPU code.
+
+A tap is a second sink alongside the output-VCD writer in the per-edge drain loop. For each edge in the batch it extracts the bundle's bits from the snapshot's `output_state`, and (subject to the trigger below) packs one sample and appends it to a per-batch buffer. After the edge loop, the buffer is written to the socket in one non-blocking `write`.
+
+Transport is a UNIX-domain socket. Cosim listens; the renderer connects and disconnects freely. If no client is attached, or the socket would block, cosim drops the batch's samples. Stalling the simulation on a slow renderer is the wrong tradeoff for a debug tool.
+
+Because the tap drives nothing, it does not set `is_active()` and does not force single-edge batches. Throughput is unaffected; end-to-end latency is one batch (`BATCH_SIZE = 1024` scheduler edges by default). Lower latency is a smaller batch, at throughput cost — a knob, not a redesign.
+
+### Wire format
+
+One byte per sample for the video bundle: `[ vsync<<5 | hsync<<4 | colorIndex[3:0] ]`. The stream is contiguous per-tick samples; the renderer reframes from `hsync`/`vsync` edges, so no timestamps are needed in the common case. Each batch write is optionally prefixed with a `u64` tick base so the renderer can resync after a drop. Given drop-on-backpressure, the resync prefix is worth having.
+
+The format generalises: a bundle is an ordered list of signal names plus a socket path, packed LSB-first into as many bytes as the bit count needs. Video is the first consumer; the same sink can later stream CIA ports, a bus address, or anything into Surfer or another live viewer.
+
+## Trigger: sampling at the right rate
+
+`colorIndex` only changes at the ~8 MHz dot rate, so sampling every scheduler edge oversamples and floods the socket with duplicate bytes. A trigger controls when a sample is emitted. Three modes, one field:
+
+- `strobe: "<net>"` — emit on the rising edge of a design net (a pixel clock-enable). The design itself says when a pixel is ready, so this is correct regardless of clock topology. Recommended.
+- `clock: "<name>", divider: N` — emit every Nth edge of a named scheduler clock domain. Correct under multiple clock domains because it is domain-relative.
+- `every: N` — emit every Nth scheduler edge. Simplest; correct when there is a single master clock.
+
+Default is `every: 1`.
+
+The multi-clock subtlety that makes this worth writing down: a scheduler "edge" is one entry in the interleaved `MultiClockScheduler` schedule, and consecutive edges can belong to different domains. So "every Nth edge" drifts against any one clock the moment there is more than one domain. Both `strobe` and `clock`/`divider` avoid this by binding to something the scheduler tracks per edge. The drain loop already reads exactly this — `scheduler.schedule[sched_idx].domain_edges[di]` tells it which domains fired at each edge (see the jitter code at `mod.rs:3445-3461`). Strobe mode goes one better: it binds to a net the design toggles, so tick topology never enters the reasoning.
+
+## C64 grounding (verified against the netlist)
+
+The C64 core is a single-master-clock design with clock enables, MiSTer style. `clk32` (32 MHz, top-level `clk_PAD`) is the only clock. `enablePixel` is a one-cycle strobe generated in a `rising_edge(clk32)` process, asserted on eight evenly spaced sysCycle states — every 4th `clk32` cycle, so a regular 8 MHz dot strobe (`rtl/c64_system.vhd:224-240`). The multi-clock worry does not apply here; both `strobe` and `every: 4` would work, and `strobe` needs no tuning.
+
+Names survive the LibreLane flow in escaped, lowercased, hierarchical form. Confirmed present in the post-PnR netlist (`librelane/runs/.../chip_top.pnl.v`):
+
+| Purpose | Net in post-PnR netlist | Source |
+|---|---|---|
+| Pixel strobe (trigger) | `\i_chip_core.c64_u.enablepixel` | `c64_system.vhd:110,228-238` |
+| colorIndex[3:0] pad value | `\bidir_CORE2PAD[1..4]` | `chip_core.sv` pad map |
+| hsync pad value | `\bidir_CORE2PAD[5]` | `chip_core.sv:63` `PAD_VIC_HSYNC=5` |
+| vsync pad value | `\bidir_CORE2PAD[6]` | `chip_core.sv:64` `PAD_VIC_VSYNC=6` |
+| per-pad output-enable (Case 2) | `\bidir_CORE2PAD_OE[n]` | pad ring |
+
+`\bidir_CORE2PAD[n]` is the core-driven side of bidir pad `n`, which is what we want for the design's output value. The `--trace-signals` multi-candidate resolver (`src/sim/trace_signals.rs:320` `resolve_to_state_pos`) is built for escaped/flattened/hierarchical names, so passing `enablePixel` or the full hierarchical path should resolve; confirm each with `netlist-graph search` before wiring.
+
+Resulting config for the C64 video tap:
+
+```jsonc
+{
+  "name": "video",
+  "socket": "/tmp/c64-video.sock",
+  "trigger": { "strobe": "enablePixel" },
+  "signals": ["colorIndex[3]", "colorIndex[2]", "colorIndex[1]", "colorIndex[0]",
+              "hsync", "vsync"]
+}
+```
+
+The renderer is a separate process (Python + an SDL-ish surface, or a small Rust app). It reads the byte stream, frames the raster from `hsync`/`vsync` edges, applies the C64 16-colour palette (`fpga64_rgbcolor.vhd` exists in the RTL as the reference LUT but is not instantiated on-die), and blits live. All video semantics live in the renderer; cosim only forwards bits.
+
+## The Jacquard hook
+
+Everything is host-side in `src/sim/cosim/mod.rs`:
+
+- Per-edge drain loop: `mod.rs:3414-3532`. `backend.vcd_snapshot(edge_in_batch)` returns `[input_state | output_state]`; a bit is `(output_state[pos>>5] >> (pos&31)) & 1`. The tap slots in beside the output-VCD writer at `mod.rs:3438`.
+- Output-VCD state / signal→position mapping is built at `mod.rs:2958-2991` via `vcd_io::setup_cosim_output_vcd` → `OutputVCDMapping.out2vcd`. The tap's bundle resolution mirrors this, using `trace_signals::resolve_to_state_pos`.
+- The snapshot ring is gated by `vcd_enabled` (`mod.rs:2998`) / `enable_vcd_ring` on the `CosimBackend` trait. The tap must ensure the ring is enabled even when no output VCD path is set.
+
+Config surface: extend `TestbenchConfig` (`src/testbench.rs`) with a `video_taps` / `signal_streams` vector, following the plural-peripheral convention (ADR 0013). A CLI `--video-stream` shorthand is optional sugar.
+
+Rough size: about 40 lines of Rust for the sink plus config plumbing, and about 60 lines for a minimal renderer.
+
+## Open questions and next steps
+
+1. Prototype the sink at `mod.rs:3438` plus a minimal renderer, wired to the C64 config above. This is the actual spike execution; the design above is validated but unbuilt.
+2. Confirm `colorIndex` bit order at the pad — whether `\bidir_CORE2PAD[1]` is `colorIndex[0]` or `[3]` — against the `out_drive` assignment in `chip_core.sv`. Cheap to check; wrong order just permutes the palette.
+3. Backpressure policy: drop whole batches vs a bounded ring with newest-wins. Start with drop-whole-batch; revisit if the picture tears badly.
+4. Whether to land the generic "signal-bundle stream" surface now or start video-specific and generalise once a second consumer appears. Leaning generic, since the CIA case will want it.
+
+## Relationship to the GPIO work
+
+This spike is Case 1 (output observation) of the broader generic-GPIO investigation. Case 2 — the CIA1 PA/PB keyboard-matrix and joystick GPIO — is the bidirectional tri-state case and is separate work: it drives inputs reactively, needs `is_active()`/`batch=1`, and needs open-drain + pull-up wired-AND resolution. This spike incidentally found the net Case 2 will need: per-pad output-enable is `\bidir_CORE2PAD_OE[n]` at the synthesized top, which answers "how is the CIA tri-state `$oe` expressed" for the `GpioMapping` plumbing when that work starts.

--- a/docs/spikes/video-streaming-tap.md
+++ b/docs/spikes/video-streaming-tap.md
@@ -90,9 +90,18 @@ Config surface: extend `TestbenchConfig` (`src/testbench.rs`) with a `video_taps
 
 Rough size: about 40 lines of Rust for the sink plus config plumbing, and about 60 lines for a minimal renderer.
 
+## Spike artifacts
+
+The tap is implemented in-tree (`src/sim/cosim/signal_stream.rs`, config in
+`src/testbench.rs`). The C64-specific renderer and config fragment live under
+`video-streaming-tap/` next to this doc — a `uv`-runnable pygame renderer and
+the `signal_streams` block to merge into the C64 `cocotb/sim_config.json`. They
+are C64-specific and will move to the c64-tapeout project; they sit here so the
+spike runs end-to-end. See `video-streaming-tap/README.md`.
+
 ## Open questions and next steps
 
-1. Prototype the sink at `mod.rs:3438` plus a minimal renderer, wired to the C64 config above. This is the actual spike execution; the design above is validated but unbuilt.
+1. Run it end-to-end: a real cosim run streaming to the renderer, confirming the C64 net names resolve. The tap and renderer exist; this is the remaining validation.
 2. Confirm `colorIndex` bit order at the pad — whether `\bidir_CORE2PAD[1]` is `colorIndex[0]` or `[3]` — against the `out_drive` assignment in `chip_core.sv`. Cheap to check; wrong order just permutes the palette.
 3. Backpressure policy: drop whole batches vs a bounded ring with newest-wins. Start with drop-whole-batch; revisit if the picture tears badly.
 4. Whether to land the generic "signal-bundle stream" surface now or start video-specific and generalise once a second consumer appears. Leaning generic, since the CIA case will want it.

--- a/docs/spikes/video-streaming-tap/README.md
+++ b/docs/spikes/video-streaming-tap/README.md
@@ -1,0 +1,58 @@
+# C64 video streaming tap — spike renderer
+
+Spike artifacts for the cosim signal-streaming tap (see
+`../video-streaming-tap.md`). These are C64-specific and will move to the
+c64-tapeout project once the tap lands; they live here for now so the spike is
+runnable end-to-end.
+
+- `c64_video_renderer.py` — a live renderer (pygame, `uv`-runnable) that reads
+  the tap's UNIX-socket stream and displays the raster.
+- `example-signal-streams.json` — the config fragment to merge into the C64
+  `cocotb/sim_config.json`.
+
+## Run it
+
+1. Add the `signal_streams` block from `example-signal-streams.json` to the C64
+   `cocotb/sim_config.json`.
+
+2. Start cosim (it binds the socket and listens):
+
+   ```bash
+   make jacquard-cosim        # in the c64-tapeout repo
+   # or directly:
+   jacquard cosim --config cocotb/sim_config.json <netlist> --top-module chip_top ...
+   ```
+
+3. In another terminal, start the renderer:
+
+   ```bash
+   uv run docs/spikes/video-streaming-tap/c64_video_renderer.py --socket /tmp/c64-video.sock
+   ```
+
+The renderer waits for cosim to listen, connects, and updates the window as
+samples stream in (one byte per pixel, framed on hsync/vsync). It auto-reconnects
+if cosim drops the client under backpressure.
+
+## Net names (verified against the post-PnR netlist)
+
+The config uses the escaped hierarchical names that survive LibreLane synthesis:
+
+| Role | Net |
+|------|-----|
+| Pixel strobe (trigger) | `\i_chip_core.c64_u.enablepixel` |
+| colorIndex[3:0] | `\bidir_CORE2PAD[1..4]` |
+| hsync | `\bidir_CORE2PAD[5]` |
+| vsync | `\bidir_CORE2PAD[6]` |
+
+The `--trace-signals` multi-candidate resolver also accepts the plain RTL name
+`enablePixel`; the explicit hierarchical form is the safe default. Confirm each
+resolves with `netlist-graph search <netlist> <name>` before a run.
+
+## Open question: colorIndex bit order
+
+The renderer assumes `signals` order `colorIndex[3], colorIndex[2],
+colorIndex[1], colorIndex[0], hsync, vsync`. If the picture's colours look
+permuted, `\bidir_CORE2PAD[1..4]` maps to colorIndex bits in the opposite
+order — check the `out_drive` assignment in `chip_core.sv` and swap the
+`colorIndex[..]` entries in the config (or adjust `decode_sample` in the
+renderer). Wrong order only permutes the palette; it doesn't break framing.

--- a/docs/spikes/video-streaming-tap/README.md
+++ b/docs/spikes/video-streaming-tap/README.md
@@ -1,4 +1,4 @@
-# C64 video streaming tap — spike renderer
+# C64 video streaming tap — spike renderer + runbook
 
 Spike artifacts for the cosim signal-streaming tap (see
 `../video-streaming-tap.md`). These are C64-specific and will move to the
@@ -10,32 +10,113 @@ runnable end-to-end.
 - `example-signal-streams.json` — the config fragment to merge into the C64
   `cocotb/sim_config.json`.
 
-## Run it
+The feature itself lives in Jacquard on branch `feat/cosim-signal-stream-tap`
+(`src/sim/cosim/signal_stream.rs`, config in `src/testbench.rs`, wiring in
+`src/sim/cosim/mod.rs`). PR: gpu-eda/Jacquard#182.
 
-1. Add the `signal_streams` block from `example-signal-streams.json` to the C64
-   `cocotb/sim_config.json`.
+## Automated unit tests (already green)
 
-2. Start cosim (it binds the socket and listens):
+These cover the trigger/packing logic and the config serde contract:
 
-   ```bash
-   make jacquard-cosim        # in the c64-tapeout repo
-   # or directly:
-   jacquard cosim --config cocotb/sim_config.json <netlist> --top-module chip_top ...
-   ```
+```bash
+cd /Users/roberttaylor/Code/Jacquard
+cargo test --features metal --lib signal_stream
+cargo test --features metal --lib testbench::tests::signal_stream
+```
 
-3. In another terminal, start the renderer:
+There is no automated end-to-end test yet — the raster render is validated
+manually with the runbook below. That's the remaining spike-execution step.
 
-   ```bash
-   uv run docs/spikes/video-streaming-tap/c64_video_renderer.py --socket /tmp/c64-video.sock
-   ```
+## End-to-end runbook
 
-The renderer waits for cosim to listen, connects, and updates the window as
-samples stream in (one byte per pixel, framed on hsync/vsync). It auto-reconnects
-if cosim drops the client under backpressure.
+Reference checkouts (same machine):
+`/Users/roberttaylor/Code/Jacquard` and
+`/Users/roberttaylor/Code/Retro/c64-tapeout`.
+
+### 1. Build the feature branch of Jacquard
+
+```bash
+cd /Users/roberttaylor/Code/Jacquard          # branch: feat/cosim-signal-stream-tap
+cargo build -r --features metal --bin jacquard
+# → target/release/jacquard
+```
+
+### 2. Confirm the net names resolve (the known risk)
+
+The video pad + strobe names come from the post-PnR netlist and must resolve
+against it. Check before running cosim:
+
+```bash
+cd /Users/roberttaylor/Code/Jacquard
+NL=/Users/roberttaylor/Code/Retro/c64-tapeout/final/pnl/chip_top.pnl.v   # or newest librelane/runs/*/…/chip_top.pnl.v
+uv run netlist-graph search "$NL" "enablepixel"
+uv run netlist-graph search "$NL" "bidir_CORE2PAD"
+```
+
+Expect `enablepixel` as `\i_chip_core.c64_u.enablepixel`. If the escaped
+`\`-prefixed form doesn't resolve at cosim time, fall back to the plain RTL
+name `enablePixel` in the config — the multi-candidate resolver accepts it.
+This is the resolver-form open question from the spike.
+
+### 3. Add the video tap to the C64 config
+
+Merge the `signal_streams` array from `example-signal-streams.json` into
+`/Users/roberttaylor/Code/Retro/c64-tapeout/cocotb/sim_config.json` as a
+top-level key (alongside `clocks`, `qspi_memory`, …). Socket defaults to
+`/tmp/c64-video.sock`.
+
+### 4. Run cosim (binds the socket and listens)
+
+Via the existing make target, pointed at the feature-branch binary:
+
+```bash
+cd /Users/roberttaylor/Code/Retro/c64-tapeout
+make jacquard-cosim JACQUARD_BIN=/Users/roberttaylor/Code/Jacquard/target/release/jacquard
+```
+
+or the equivalent direct call:
+
+```bash
+/Users/roberttaylor/Code/Jacquard/target/release/jacquard cosim \
+    --config cocotb/sim_config.json \
+    final/pnl/chip_top.pnl.v \
+    --top-module chip_top \
+    --cell-library tools/jacquard_cell_lib/ocd_sram_shim.v \
+    --max-clock-edges 5000000
+```
+
+Watch for `signal-stream 'video': listening on /tmp/c64-video.sock (6 signals)`.
+`… did not resolve; tap disabled` means a name failed — go back to step 2.
+
+### 5. Start the renderer (separate terminal)
+
+```bash
+cd /Users/roberttaylor/Code/Jacquard
+uv run docs/spikes/video-streaming-tap/c64_video_renderer.py --socket /tmp/c64-video.sock
+```
+
+It waits for cosim, connects, and updates the window as samples arrive. First
+frame takes a moment — a PAL frame is ~640k `clk32` edges, so
+`--max-clock-edges 5000000` gives roughly 8 frames.
+
+## Troubleshooting
+
+- **Scrambled / permuted colours** → `colorIndex` bit order. Reverse the
+  `\bidir_CORE2PAD[1..4]` entries in the config, or check the `out_drive[]`
+  assignment in `chip_core.sv` for the true mapping. Framing (sync) is
+  unaffected. See the open question below.
+- **Window stays black** → cosim isn't reaching the video logic yet, or sync
+  polarity is inverted. Sanity-check with `--trace-signals` on `hsync` to a VCD
+  and confirm it toggles (sim-smoke saw `hsync=62`, so it should).
+- **`tap disabled` in the log** → a net name didn't resolve; use step 2 to find
+  the exact string, or try the plain `enablePixel` / bare pad names.
+- **Renderer prints "cosim disconnected" repeatedly** → backpressure drops under
+  a slow display; harmless, it reconnects. Lower `--max-clock-edges` for a
+  gentler run.
 
 ## Net names (verified against the post-PnR netlist)
 
-The config uses the escaped hierarchical names that survive LibreLane synthesis:
+Escaped hierarchical names that survive LibreLane synthesis:
 
 | Role | Net |
 |------|-----|
@@ -44,15 +125,14 @@ The config uses the escaped hierarchical names that survive LibreLane synthesis:
 | hsync | `\bidir_CORE2PAD[5]` |
 | vsync | `\bidir_CORE2PAD[6]` |
 
-The `--trace-signals` multi-candidate resolver also accepts the plain RTL name
-`enablePixel`; the explicit hierarchical form is the safe default. Confirm each
-resolves with `netlist-graph search <netlist> <name>` before a run.
+Confirm each resolves with `netlist-graph search <netlist> <name>` before a run.
 
 ## Open question: colorIndex bit order
 
 The renderer assumes `signals` order `colorIndex[3], colorIndex[2],
-colorIndex[1], colorIndex[0], hsync, vsync`. If the picture's colours look
-permuted, `\bidir_CORE2PAD[1..4]` maps to colorIndex bits in the opposite
-order — check the `out_drive` assignment in `chip_core.sv` and swap the
-`colorIndex[..]` entries in the config (or adjust `decode_sample` in the
-renderer). Wrong order only permutes the palette; it doesn't break framing.
+colorIndex[1], colorIndex[0], hsync, vsync`, and the config maps those to
+`\bidir_CORE2PAD[4,3,2,1,5,6]` in that order. If the picture's colours look
+permuted, `\bidir_CORE2PAD[1..4]` maps to colorIndex bits the other way —
+check the `out_drive` assignment in `chip_core.sv` and reverse the four
+`colorIndex` entries in the config (or adjust `decode_sample` in the renderer).
+Wrong order only permutes the palette; it doesn't break framing.

--- a/docs/spikes/video-streaming-tap/README.md
+++ b/docs/spikes/video-streaming-tap/README.md
@@ -12,7 +12,7 @@ runnable end-to-end.
 
 The feature itself lives in Jacquard on branch `feat/cosim-signal-stream-tap`
 (`src/sim/cosim/signal_stream.rs`, config in `src/testbench.rs`, wiring in
-`src/sim/cosim/mod.rs`). PR: gpu-eda/Jacquard#182.
+`src/sim/cosim/mod.rs`). PR: gpu-eda/Jacquard#184.
 
 ## Automated unit tests (already green)
 

--- a/docs/spikes/video-streaming-tap/c64_video_renderer.py
+++ b/docs/spikes/video-streaming-tap/c64_video_renderer.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pygame-ce>=2.4"]
+# ///
+# SPDX-License-Identifier: Apache-2.0
+"""Live C64 video renderer for the Jacquard cosim signal-streaming tap.
+
+Reads the UNIX-socket byte stream produced by a ``signal_streams`` tap (see
+``docs/spikes/video-streaming-tap.md``) and renders the C64 raster live in a
+window. Spike artifact — intended to move to the c64-tapeout project.
+
+Run cosim with a video tap configured (socket path must match ``--socket``),
+then start this renderer; it connects, frames the raster on hsync/vsync edges,
+applies the C64 palette, and blits. It auto-reconnects if cosim drops the
+client under backpressure.
+
+    uv run c64_video_renderer.py --socket /tmp/c64-video.sock
+
+The bundle signal order MUST match the cosim config. This renderer assumes:
+
+    colorIndex[3], colorIndex[2], colorIndex[1], colorIndex[0], hsync, vsync
+
+packed LSB-first into one byte per sample (bit 0 = colorIndex[3]). If the
+picture's colours are permuted, the pad bit-order differs — see the spike's
+open question about ``bidir_CORE2PAD`` bit order and adjust ``decode_sample``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import struct
+import sys
+import time
+
+import pygame
+
+# fpga64_rgbcolor 16-colour C64 palette (Pepto approximation). Reconcile
+# against fpga64_rgbcolor.vhd for exact on-die values if colours look off.
+PALETTE = [
+    (0x00, 0x00, 0x00), (0xFF, 0xFF, 0xFF), (0x68, 0x37, 0x2B), (0x70, 0xA4, 0xB2),
+    (0x6F, 0x3D, 0x86), (0x58, 0x8D, 0x43), (0x35, 0x28, 0x79), (0xB8, 0xC7, 0x6F),
+    (0x6F, 0x4F, 0x25), (0x43, 0x39, 0x00), (0x9A, 0x67, 0x59), (0x44, 0x44, 0x44),
+    (0x6C, 0x6C, 0x6C), (0x9A, 0xD2, 0x84), (0x6C, 0x5E, 0xB5), (0x95, 0x95, 0x95),
+]
+PAL_BYTES = [bytes(c) for c in PALETTE]
+
+# Generous PAL raster bounds (dot clock ~8 MHz, ~504 dots/line, 312 lines).
+WIDTH = 520
+HEIGHT = 320
+
+# Per-batch frame header: u64 first_tick LE, u32 sample_count LE.
+HEADER = struct.Struct("<QI")
+
+
+def decode_sample(b: int) -> tuple[int, int, int]:
+    """Unpack one sample byte into (colorIndex, hsync, vsync).
+
+    Bit order (LSB-first, config order): bit0=colorIndex[3] .. bit3=colorIndex[0],
+    bit4=hsync, bit5=vsync. So colorIndex = bit3 | bit2<<1 | bit1<<2 | bit0<<3.
+    """
+    color = ((b >> 3) & 1) | ((b >> 2) & 1) << 1 | ((b >> 1) & 1) << 2 | (b & 1) << 3
+    hsync = (b >> 4) & 1
+    vsync = (b >> 5) & 1
+    return color, hsync, vsync
+
+
+class Raster:
+    """Reconstructs frames from the pixel + sync stream into a framebuffer."""
+
+    def __init__(self) -> None:
+        self.fb = bytearray(WIDTH * HEIGHT * 3)
+        self.x = 0
+        self.y = 0
+        self.prev_h = 0
+        self.prev_v = 0
+
+    def push(self, byte: int) -> bool:
+        """Consume one sample. Returns True when a frame completes (vsync)."""
+        color, hsync, vsync = decode_sample(byte)
+        frame_done = False
+
+        # vsync rising → present current frame, restart at top.
+        if vsync and not self.prev_v:
+            frame_done = True
+            self.x = 0
+            self.y = 0
+        # hsync rising → next line.
+        elif hsync and not self.prev_h:
+            self.x = 0
+            self.y += 1
+
+        self.prev_h = hsync
+        self.prev_v = vsync
+
+        if 0 <= self.x < WIDTH and 0 <= self.y < HEIGHT:
+            off = (self.y * WIDTH + self.x) * 3
+            self.fb[off:off + 3] = PAL_BYTES[color]
+        self.x += 1
+        return frame_done
+
+    def surface(self) -> pygame.Surface:
+        return pygame.image.frombuffer(bytes(self.fb), (WIDTH, HEIGHT), "RGB")
+
+    def clear(self) -> None:
+        self.fb[:] = b"\x00" * len(self.fb)
+
+
+def connect(path: str) -> socket.socket:
+    """Block until cosim is listening on the socket, then connect."""
+    while True:
+        try:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.connect(path)
+            s.settimeout(0.1)
+            print(f"connected to {path}", file=sys.stderr)
+            return s
+        except (FileNotFoundError, ConnectionRefusedError):
+            time.sleep(0.25)
+
+
+def run(path: str, bytes_per_sample: int, scale: int) -> None:
+    pygame.init()
+    screen = pygame.display.set_mode((WIDTH * scale, HEIGHT * scale))
+    pygame.display.set_caption("C64 cosim video tap")
+    raster = Raster()
+
+    sock: socket.socket | None = None
+    buf = bytearray()
+
+    def present() -> None:
+        frame = pygame.transform.scale(raster.surface(), (WIDTH * scale, HEIGHT * scale))
+        screen.blit(frame, (0, 0))
+        pygame.display.flip()
+        raster.clear()
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+        if not running:
+            break
+
+        if sock is None:
+            sock = connect(path)
+            buf.clear()
+
+        try:
+            chunk = sock.recv(65536)
+            if not chunk:
+                raise ConnectionResetError
+            buf.extend(chunk)
+        except socket.timeout:
+            continue
+        except (ConnectionResetError, BrokenPipeError, OSError):
+            print("cosim disconnected; reconnecting", file=sys.stderr)
+            sock.close()
+            sock = None
+            continue
+
+        # Parse as many complete frames as the buffer holds.
+        while len(buf) >= HEADER.size:
+            _first_tick, n_samples = HEADER.unpack_from(buf, 0)
+            payload = n_samples * bytes_per_sample
+            if len(buf) < HEADER.size + payload:
+                break
+            start = HEADER.size
+            for i in range(n_samples):
+                # Low byte of each sample carries the video bundle.
+                if raster.push(buf[start + i * bytes_per_sample]):
+                    present()
+            del buf[: HEADER.size + payload]
+
+    pygame.quit()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--socket", default="/tmp/c64-video.sock", help="cosim tap socket path")
+    ap.add_argument(
+        "--bytes-per-sample",
+        type=int,
+        default=1,
+        help="ceil(n_signals / 8); 1 for the 6-signal video bundle",
+    )
+    ap.add_argument("--scale", type=int, default=2, help="integer upscale factor")
+    args = ap.parse_args()
+    run(args.socket, args.bytes_per_sample, args.scale)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/spikes/video-streaming-tap/example-signal-streams.json
+++ b/docs/spikes/video-streaming-tap/example-signal-streams.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Fragment: merge this `signal_streams` array into the C64 cocotb/sim_config.json. Bundle order is colorIndex[3..0], hsync, vsync — packed LSB-first, one byte per pixel. The renderer's decode_sample() assumes this order.",
+  "signal_streams": [
+    {
+      "name": "video",
+      "socket": "/tmp/c64-video.sock",
+      "trigger": { "strobe": "\\i_chip_core.c64_u.enablepixel" },
+      "signals": [
+        "\\bidir_CORE2PAD[4]",
+        "\\bidir_CORE2PAD[3]",
+        "\\bidir_CORE2PAD[2]",
+        "\\bidir_CORE2PAD[1]",
+        "\\bidir_CORE2PAD[5]",
+        "\\bidir_CORE2PAD[6]"
+      ]
+    }
+  ]
+}

--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -2289,11 +2289,20 @@ fn cmd_cosim(args: CosimArgs) {
 
         // Bus-trace pins must be registered as observable before
         // partitioning so they get output-state slots the GPU can read.
-        let bus_trace_signals: Vec<String> = config
+        // Nets that must be observable (output-state slots the GPU can
+        // snapshot) before partitioning: bus-trace pins and signal-stream
+        // tap bundles (plus any strobe net).
+        let mut extra_observable_signals: Vec<String> = config
             .effective_bus_traces()
             .iter()
             .flat_map(jacquard::sim::models::bus_trace::observed_net_names)
             .collect();
+        for tap in config.effective_signal_streams() {
+            extra_observable_signals.extend(tap.signals.iter().cloned());
+            if let jacquard::testbench::StreamTrigger::Strobe(net) = &tap.trigger {
+                extra_observable_signals.push(net.clone());
+            }
+        }
 
         // Derived (on-die divided) clocks (gpu-eda/Jacquard#185): collect the
         // `net` of every `clocks[]` entry that declares one, so the AIG can cut
@@ -2345,7 +2354,7 @@ fn cmd_cosim(args: CosimArgs) {
             cell_descriptor: args.cell_descriptor.clone(),
             bundled_descriptor: args.bundled_descriptor.clone(),
             trace_signals: args.trace_signals.clone(),
-            extra_observable_signals: bus_trace_signals,
+            extra_observable_signals,
             // cosim has no `--corner`/`--timed`; its no-SDF path stays off
             // unless a timing IR is supplied (handled by load_timing_ir, whose
             // descriptor fallback still uses `default_corner`).

--- a/src/sim/cosim/mod.rs
+++ b/src/sim/cosim/mod.rs
@@ -3158,7 +3158,56 @@ fn run_cosim_generic<B: CosimBackend>(
     // When stimulus or output VCD is active, we snapshot output_state after
     // each edge via a GPU blit into a ring buffer. This allows batched dispatch
     // (no batch=1 override) while preserving per-tick VCD accuracy.
-    let vcd_enabled = stimulus_vcd_state.is_some() || output_vcd_state.is_some();
+    // ── Signal-streaming taps (observe-only live socket streams) ───────────
+    //
+    // Each tap samples a bundle of design output nets per triggered edge and
+    // streams packed bytes out a UNIX socket. Reuses the per-edge vcd_snapshot
+    // ring below; drives nothing, so no batch=1 penalty. See
+    // docs/spikes/video-streaming-tap.md.
+    let mut stream_taps: Vec<signal_stream::SignalStreamTap> = Vec::new();
+    for cfg in config.effective_signal_streams() {
+        let resolve = |name: &str| {
+            crate::sim::trace_signals::resolve_to_state_pos(aig, netlistdb, script, name)
+        };
+        let Some(positions) = cfg.signals.iter().map(|s| resolve(s)).collect::<Option<Vec<u32>>>()
+        else {
+            clilog::warn!(
+                "signal-stream `{}`: one or more signals did not resolve; tap disabled",
+                cfg.name
+            );
+            continue;
+        };
+        let strobe_pos = match &cfg.trigger {
+            crate::testbench::StreamTrigger::Strobe(net) => {
+                let Some(p) = resolve(net) else {
+                    clilog::warn!(
+                        "signal-stream `{}`: strobe net `{}` did not resolve; tap disabled",
+                        cfg.name,
+                        net
+                    );
+                    continue;
+                };
+                Some(p)
+            }
+            crate::testbench::StreamTrigger::Every(_) => None,
+        };
+        match signal_stream::SignalStreamTap::new(cfg, positions, strobe_pos) {
+            Ok(tap) => {
+                clilog::info!(
+                    "signal-stream `{}`: listening on {} ({} signals)",
+                    cfg.name,
+                    cfg.socket,
+                    cfg.signals.len()
+                );
+                stream_taps.push(tap);
+            }
+            Err(e) => clilog::warn!("signal-stream `{}`: {}; tap disabled", cfg.name, e),
+        }
+    }
+
+    // Streaming taps also need the per-edge snapshot ring.
+    let vcd_enabled =
+        stimulus_vcd_state.is_some() || output_vcd_state.is_some() || !stream_taps.is_empty();
     if vcd_enabled {
         backend.enable_vcd_ring();
     }
@@ -3590,6 +3639,11 @@ fn run_cosim_generic<B: CosimBackend>(
                 let output_state = &slot_base[state_size..];
                 let edge_tick = tick + edge_in_batch;
 
+                // Signal-stream taps: sample this edge (trigger-gated).
+                for tap in stream_taps.iter_mut() {
+                    tap.on_edge(output_state, edge_tick as u64);
+                }
+
                 // Stimulus VCD
                 let t_stim = std::time::Instant::now();
                 if let Some((ref mut writer, ref mapping, ref mut prev_values)) = stimulus_vcd_state
@@ -3708,6 +3762,11 @@ fn run_cosim_generic<B: CosimBackend>(
                     }
                 }
                 prof_output_vcd += t_timing.elapsed().as_nanos() as u64;
+            }
+
+            // Stream this batch's samples to any connected renderer.
+            for tap in stream_taps.iter_mut() {
+                tap.flush_batch();
             }
         }
 
@@ -5459,6 +5518,8 @@ pub fn run_cosim_cpu(
 ) -> CosimResult {
     run_cosim_generic::<CpuBackend>(design, config, opts, timing_constraints)
 }
+
+mod signal_stream;
 
 #[cfg(feature = "metal")]
 mod metal;

--- a/src/sim/cosim/mod.rs
+++ b/src/sim/cosim/mod.rs
@@ -3169,7 +3169,11 @@ fn run_cosim_generic<B: CosimBackend>(
         let resolve = |name: &str| {
             crate::sim::trace_signals::resolve_to_state_pos(aig, netlistdb, script, name)
         };
-        let Some(positions) = cfg.signals.iter().map(|s| resolve(s)).collect::<Option<Vec<u32>>>()
+        let Some(positions) = cfg
+            .signals
+            .iter()
+            .map(|s| resolve(s))
+            .collect::<Option<Vec<u32>>>()
         else {
             clilog::warn!(
                 "signal-stream `{}`: one or more signals did not resolve; tap disabled",

--- a/src/sim/cosim/signal_stream.rs
+++ b/src/sim/cosim/signal_stream.rs
@@ -1,0 +1,296 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026
+// SPDX-License-Identifier: Apache-2.0
+//! Live signal-streaming tap for cosim (observe-only).
+//!
+//! Samples a configured bundle of design output nets per triggered edge
+//! and streams packed bytes out a UNIX-domain socket to an external
+//! renderer (first use: a live C64 video debug view). Reuses the per-edge
+//! `vcd_snapshot` ring — no GPU code — and never drives design inputs, so
+//! it stays out of the reactive path and imposes no `batch=1` penalty.
+//!
+//! Design: `docs/spikes/video-streaming-tap.md`.
+//!
+//! ## Wire format
+//!
+//! Cosim listens on the socket; a renderer connects. After each GPU batch,
+//! the tap writes one frame per batch that produced samples:
+//!
+//! ```text
+//! [ u64 first_tick LE ][ u32 sample_count LE ][ sample_count × bytes_per_sample payload ]
+//! ```
+//!
+//! Each sample packs the bundle's signals LSB-first in config order
+//! (`signals[0]` → bit 0 of byte 0). `bytes_per_sample = ceil(n_signals / 8)`.
+//! The `first_tick` header lets a renderer resync after a dropped batch.
+//! Backpressure or a gone client drops the batch and the connection; the
+//! renderer is expected to reconnect.
+
+use std::io::Write;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+
+use crate::sim::models::{read_bit, Edge, EdgeDetector};
+use crate::testbench::{SignalStreamConfig, StreamTrigger};
+
+/// Bytes in the per-batch frame header: `u64 first_tick` + `u32 sample_count`.
+const FRAME_HEADER_LEN: usize = 12;
+
+/// When the tap emits a sample.
+enum TriggerState {
+    /// Emit every `n`-th edge seen.
+    Every { n: u32, counter: u32 },
+    /// Emit on the rising edge of the net at `pos` in the output state.
+    Strobe { pos: u32, edge: EdgeDetector },
+}
+
+/// Trigger + packing, split out from the socket so it is unit-testable
+/// without binding a listener.
+struct Sampler {
+    /// Output-state bit positions for each bundle signal, in pack order.
+    positions: Vec<u32>,
+    bytes_per_sample: usize,
+    trigger: TriggerState,
+}
+
+impl Sampler {
+    fn new(positions: Vec<u32>, trigger: TriggerState) -> Self {
+        let bytes_per_sample = positions.len().div_ceil(8).max(1);
+        Self {
+            positions,
+            bytes_per_sample,
+            trigger,
+        }
+    }
+
+    /// Evaluate the trigger for one edge, advancing its state. If it fires,
+    /// append one packed sample (`bytes_per_sample` bytes, LSB-first) to
+    /// `out` and return `true`. `output_state` is the design-output half of
+    /// the per-edge snapshot (same frame as `resolve_to_state_pos`). Packs
+    /// in place — no per-edge allocation in the drain loop's hot path.
+    fn sample_into(&mut self, output_state: &[u32], out: &mut Vec<u8>) -> bool {
+        let fire = match &mut self.trigger {
+            TriggerState::Every { n, counter } => {
+                let f = *counter == 0;
+                *counter = (*counter + 1) % (*n).max(1);
+                f
+            }
+            TriggerState::Strobe { pos, edge } => {
+                matches!(edge.update(read_bit(output_state, *pos) != 0), Edge::Rising)
+            }
+        };
+        if !fire {
+            return false;
+        }
+        let base = out.len();
+        out.resize(base + self.bytes_per_sample, 0);
+        for (i, &pos) in self.positions.iter().enumerate() {
+            if read_bit(output_state, pos) != 0 {
+                out[base + i / 8] |= 1 << (i % 8);
+            }
+        }
+        true
+    }
+}
+
+/// A resolved, ready-to-run streaming tap. Constructed once per
+/// [`SignalStreamConfig`] after its signals resolve to state positions.
+pub struct SignalStreamTap {
+    name: String,
+    socket_path: PathBuf,
+    listener: UnixListener,
+    client: Option<UnixStream>,
+    sampler: Sampler,
+    /// Samples accumulated within the current batch.
+    batch_buf: Vec<u8>,
+    /// Tick of the first sample in `batch_buf`; meaningful only while
+    /// `batch_buf` is non-empty.
+    batch_first_tick: u64,
+}
+
+impl SignalStreamTap {
+    /// Bind the socket and build the tap. `positions` are the resolved
+    /// output-state positions of `cfg.signals` (pack order); `strobe_pos`
+    /// is the resolved position of the strobe net, required iff the trigger
+    /// is [`StreamTrigger::Strobe`]. The caller resolves these (it holds the
+    /// AIG / netlist / script) and skips the tap if any signal is unresolved.
+    pub fn new(
+        cfg: &SignalStreamConfig,
+        positions: Vec<u32>,
+        strobe_pos: Option<u32>,
+    ) -> std::io::Result<Self> {
+        let socket_path = PathBuf::from(&cfg.socket);
+
+        // Remove a stale socket from a previous run so bind() succeeds, but
+        // refuse to clobber a non-socket file the user may have named by
+        // mistake.
+        if let Ok(meta) = std::fs::symlink_metadata(&socket_path) {
+            use std::os::unix::fs::FileTypeExt;
+            if meta.file_type().is_socket() {
+                let _ = std::fs::remove_file(&socket_path);
+            } else {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    format!("path {} exists and is not a socket", cfg.socket),
+                ));
+            }
+        }
+
+        let listener = UnixListener::bind(&socket_path)?;
+        listener.set_nonblocking(true)?;
+
+        let trigger = match &cfg.trigger {
+            StreamTrigger::Every(n) => TriggerState::Every {
+                n: (*n).max(1),
+                counter: 0,
+            },
+            StreamTrigger::Strobe(_) => TriggerState::Strobe {
+                pos: strobe_pos.expect("strobe trigger requires a resolved strobe position"),
+                edge: EdgeDetector::new(false),
+            },
+        };
+
+        Ok(Self {
+            name: cfg.name.clone(),
+            socket_path,
+            listener,
+            client: None,
+            sampler: Sampler::new(positions, trigger),
+            batch_buf: Vec::new(),
+            batch_first_tick: 0,
+        })
+    }
+
+    /// Sample one edge. Appends a packed sample to the batch buffer if the
+    /// trigger fires, stamping the batch's first-sample tick.
+    pub fn on_edge(&mut self, output_state: &[u32], tick: u64) {
+        let was_empty = self.batch_buf.is_empty();
+        if self.sampler.sample_into(output_state, &mut self.batch_buf) && was_empty {
+            self.batch_first_tick = tick;
+        }
+    }
+
+    /// Flush the batch's samples to the connected client. Non-blocking:
+    /// accepts a pending connection, and drops the batch + connection on any
+    /// write error (backpressure or a gone renderer).
+    pub fn flush_batch(&mut self) {
+        if self.client.is_none() {
+            if let Ok((stream, _)) = self.listener.accept() {
+                let _ = stream.set_nonblocking(true);
+                self.client = Some(stream);
+                clilog::info!("signal-stream `{}`: client connected", self.name);
+            }
+        }
+
+        if self.batch_buf.is_empty() {
+            return;
+        }
+
+        if let Some(stream) = self.client.as_mut() {
+            let n_samples = (self.batch_buf.len() / self.sampler.bytes_per_sample) as u32;
+            let mut header = [0u8; FRAME_HEADER_LEN];
+            header[..8].copy_from_slice(&self.batch_first_tick.to_le_bytes());
+            header[8..].copy_from_slice(&n_samples.to_le_bytes());
+            let wrote = stream
+                .write_all(&header)
+                .and_then(|_| stream.write_all(&self.batch_buf));
+            if wrote.is_err() {
+                clilog::debug!("signal-stream `{}`: client write failed, dropping", self.name);
+                self.client = None;
+            }
+        }
+
+        self.batch_buf.clear();
+    }
+}
+
+impl Drop for SignalStreamTap {
+    fn drop(&mut self) {
+        // Best-effort cleanup of the socket file we created.
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a small output state with the given bit positions set.
+    fn state(bits: &[u32]) -> Vec<u32> {
+        let mut s = vec![0u32; 4];
+        for &b in bits {
+            s[(b >> 5) as usize] |= 1 << (b & 31);
+        }
+        s
+    }
+
+    /// Run one edge through the sampler; return the packed sample if it fired.
+    fn fire(s: &mut Sampler, st: &[u32]) -> Option<Vec<u8>> {
+        let mut buf = Vec::new();
+        s.sample_into(st, &mut buf).then_some(buf)
+    }
+
+    #[test]
+    fn every_fires_on_multiples() {
+        let mut s = Sampler::new(vec![0], TriggerState::Every { n: 3, counter: 0 });
+        let st = state(&[0]);
+        // Fires on edge 0, 3, 6, …
+        assert!(fire(&mut s, &st).is_some()); // 0
+        assert!(fire(&mut s, &st).is_none()); // 1
+        assert!(fire(&mut s, &st).is_none()); // 2
+        assert!(fire(&mut s, &st).is_some()); // 3
+    }
+
+    #[test]
+    fn every_one_fires_each_edge() {
+        let mut s = Sampler::new(vec![0], TriggerState::Every { n: 1, counter: 0 });
+        let st = state(&[]);
+        assert!(fire(&mut s, &st).is_some());
+        assert!(fire(&mut s, &st).is_some());
+    }
+
+    #[test]
+    fn strobe_fires_only_on_rising_edge() {
+        // Strobe net at pos 10; sampled net at pos 0.
+        let mut s = Sampler::new(
+            vec![0],
+            TriggerState::Strobe {
+                pos: 10,
+                edge: EdgeDetector::new(false),
+            },
+        );
+        let low = state(&[0]); // strobe=0
+        let high = state(&[0, 10]); // strobe=1
+        assert!(fire(&mut s, &low).is_none()); // 0→0
+        assert!(fire(&mut s, &high).is_some()); // 0→1 rising
+        assert!(fire(&mut s, &high).is_none()); // 1→1 held
+        assert!(fire(&mut s, &low).is_none()); // 1→0 falling
+        assert!(fire(&mut s, &high).is_some()); // 0→1 rising again
+    }
+
+    #[test]
+    fn packs_lsb_first_in_signal_order() {
+        // 6 signals → 1 byte. positions map signal i → some state bit.
+        // signals: [pos2, pos5, pos0, pos1, pos7, pos3]
+        let mut s = Sampler::new(
+            vec![2, 5, 0, 1, 7, 3],
+            TriggerState::Every { n: 1, counter: 0 },
+        );
+        // Drive state bits 2,0,7 high → signals index 0,2,4 high.
+        let sample = fire(&mut s, &state(&[2, 0, 7])).unwrap();
+        assert_eq!(sample.len(), 1);
+        // bits 0,2,4 set → 0b0001_0101 = 0x15
+        assert_eq!(sample[0], 0b0001_0101);
+    }
+
+    #[test]
+    fn packs_multibyte_bundle() {
+        // 10 signals → 2 bytes.
+        let positions: Vec<u32> = (0..10).collect();
+        let mut s = Sampler::new(positions, TriggerState::Every { n: 1, counter: 0 });
+        // Set state bits 0,1,8,9 → signals 0,1,8,9.
+        let sample = fire(&mut s, &state(&[0, 1, 8, 9])).unwrap();
+        assert_eq!(sample.len(), 2);
+        assert_eq!(sample[0], 0b0000_0011); // signals 0,1 in byte 0
+        assert_eq!(sample[1], 0b0000_0011); // signals 8,9 in byte 1
+    }
+}

--- a/src/sim/cosim/signal_stream.rs
+++ b/src/sim/cosim/signal_stream.rs
@@ -194,7 +194,10 @@ impl SignalStreamTap {
                 .write_all(&header)
                 .and_then(|_| stream.write_all(&self.batch_buf));
             if wrote.is_err() {
-                clilog::debug!("signal-stream `{}`: client write failed, dropping", self.name);
+                clilog::debug!(
+                    "signal-stream `{}`: client write failed, dropping",
+                    self.name
+                );
                 self.client = None;
             }
         }

--- a/src/testbench.rs
+++ b/src/testbench.rs
@@ -323,6 +323,11 @@ pub struct TestbenchConfig {
     /// and ADR 0013.
     #[serde(default)]
     pub bus_traces: Vec<BusTraceConfig>,
+    /// Live signal-streaming taps (observe-only). Each samples a bundle of
+    /// design output nets per triggered edge and streams packed bytes out a
+    /// UNIX socket. See `src/sim/cosim/signal_stream.rs`.
+    #[serde(default)]
+    pub signal_streams: Vec<SignalStreamConfig>,
 }
 
 impl TestbenchConfig {
@@ -383,6 +388,12 @@ impl TestbenchConfig {
     /// uniform across peripherals.
     pub fn effective_bus_traces(&self) -> &[BusTraceConfig] {
         &self.bus_traces
+    }
+
+    /// Return the configured signal-streaming taps. No legacy singular form;
+    /// named for symmetry with the other `effective_*` accessors.
+    pub fn effective_signal_streams(&self) -> &[SignalStreamConfig] {
+        &self.signal_streams
     }
 }
 
@@ -587,6 +598,48 @@ fn default_bus_addr_bits() -> usize {
 
 fn default_bus_data_bits() -> usize {
     DEFAULT_BUS_WIDTH
+}
+
+/// A live signal-streaming tap (observe-only). Samples a bundle of design
+/// output nets per triggered edge and streams packed bytes out a
+/// UNIX-domain socket to an external renderer (first use: a live C64 video
+/// debug view). See `src/sim/cosim/signal_stream.rs` and
+/// `docs/spikes/video-streaming-tap.md`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SignalStreamConfig {
+    /// Name, used in logs.
+    pub name: String,
+    /// UNIX-domain socket path. Cosim listens; a renderer connects.
+    pub socket: String,
+    /// Ordered output net names to sample. Packed LSB-first: `signals[0]`
+    /// → bit 0 of byte 0, etc. Bit order in the stream is this list's order.
+    pub signals: Vec<String>,
+    /// When to emit a sample. Defaults to every scheduler edge.
+    #[serde(default)]
+    pub trigger: StreamTrigger,
+}
+
+/// When a [`SignalStreamConfig`] emits a sample. Serialized externally
+/// tagged: `{ "strobe": "enablePixel" }` or `{ "every": 4 }`.
+///
+/// `strobe` gates on the rising edge of a design net (a pixel/clock enable),
+/// which is correct regardless of clock topology. `every` counts scheduler
+/// edges and is simplest for a single-master-clock design. A domain-relative
+/// `clock` + `divider` mode is planned (see the spike) but not yet
+/// implemented.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StreamTrigger {
+    /// Emit on the rising edge of the named design net.
+    Strobe(String),
+    /// Emit every Nth scheduler edge.
+    Every(u32),
+}
+
+impl Default for StreamTrigger {
+    fn default() -> Self {
+        StreamTrigger::Every(1)
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -971,5 +1024,53 @@ mod tests {
         assert_eq!(mems.len(), 2);
         assert_ne!(mems[0].csn_gpio, mems[1].csn_gpio);
         assert_ne!(mems[0].d0_gpio, mems[1].d0_gpio);
+    }
+
+    #[test]
+    fn signal_stream_config_parses_strobe_and_defaults() {
+        // The external contract the C64 video renderer config depends on:
+        // `{ "strobe": "net" }` and a defaulted `{ "every": 1 }`.
+        let cfg: TestbenchConfig = serde_json::from_str(
+            r#"{
+                "clock_gpio": 0, "reset_gpio": 1, "reset_active_high": true,
+                "reset_cycles": 10, "num_cycles": 100,
+                "signal_streams": [
+                    { "name": "video", "socket": "/tmp/v.sock",
+                      "trigger": { "strobe": "enablePixel" },
+                      "signals": ["colorIndex[3]", "hsync", "vsync"] },
+                    { "name": "raw", "socket": "/tmp/r.sock",
+                      "signals": ["a", "b"] }
+                ]
+            }"#,
+        )
+        .unwrap();
+        let streams = cfg.effective_signal_streams();
+        assert_eq!(streams.len(), 2);
+        assert!(matches!(
+            &streams[0].trigger,
+            StreamTrigger::Strobe(net) if net == "enablePixel"
+        ));
+        assert_eq!(streams[0].signals.len(), 3);
+        // Omitted trigger defaults to every-edge.
+        assert!(matches!(streams[1].trigger, StreamTrigger::Every(1)));
+    }
+
+    #[test]
+    fn signal_stream_every_trigger_parses() {
+        let cfg: TestbenchConfig = serde_json::from_str(
+            r#"{
+                "clock_gpio": 0, "reset_gpio": 1, "reset_active_high": true,
+                "reset_cycles": 10, "num_cycles": 100,
+                "signal_streams": [
+                    { "name": "v", "socket": "/tmp/v.sock",
+                      "trigger": { "every": 4 }, "signals": ["x"] }
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            cfg.effective_signal_streams()[0].trigger,
+            StreamTrigger::Every(4)
+        ));
     }
 }


### PR DESCRIPTION
## What

Adds an observe-only **streaming tap** to `jacquard cosim`: sample a configured bundle of chip output pins per-tick and stream them out a UNIX-domain socket to an external process (first use: a live C64 video debug view of `colorIndex[3:0]` + `hsync`/`vsync`).

Design note: [`docs/spikes/video-streaming-tap.md`](docs/spikes/video-streaming-tap.md).

## Why

Cosim can already surface internal nets per-tick via `--trace-signals` (GPU ring buffer), but only to a VCD file. This exposes the same per-tick capture as a live stream so a separate renderer can visualise output pins in near-real-time. The driving case is C64 video: the chip emits a 4-bit palette index + H/V sync, and an external renderer does the palette lookup + display.

QEMU virtio/vhost was considered and rejected for this use (untimed, wrong granularity) — see the spike.

## Approach

- Reuse the existing per-edge `vcd_snapshot` ring; no GPU code.
- Add a socket sink beside the output-VCD writer in the shared drain loop (`run_cosim_generic`, `src/sim/cosim/mod.rs`).
- Observe-only ⇒ no `batch=1` penalty; latency is one batch, drop-on-backpressure.
- Trigger modes: `strobe` (gate on a design net, dissolves multi-clock) / `every: N`.

The generic feature lands here; the C64-specific config + Python renderer live in the c64-tapeout project.

## Wire format

Per batch that produced samples: `[u64 first_tick LE][u32 sample_count LE][sample_count × ceil(n_signals/8) bytes]`, each sample packed LSB-first in config order. The `first_tick` header lets a renderer resync after a dropped batch.

## Status

Draft — feature implemented, built (`--features metal`) and unit-tested; end-to-end render pending (lands with the c64 renderer).

- [x] Design spike
- [x] Config surface (`SignalStreamConfig` + `StreamTrigger` enum) + parse tests
- [x] Socket sink module (`signal_stream.rs`) + trigger/packing unit tests
- [x] Drain-loop wiring + signal resolution (reuses `resolve_to_state_pos` observable path)
- [x] Trigger modes: `strobe` + `every`
- [x] `/simplify` pass (reuse `EdgeDetector`, in-place packing, flatten resolve loop)
- [ ] End-to-end: real cosim run streaming to a renderer (with the c64 config)
- [ ] Follow-up: domain-relative `clock` + `divider` trigger mode
