### PR TITLE
docs: publish gpu-capture + cosim-perf-report (were orphaned)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,8 @@
 - [Timing Model Extensions](timing-model-extensions.md)
 - [Signal Tracing](signal-tracing.md)
 - [Bus Transaction Tracing](bus-tracing.md)
+- [Cosim Perf Report](cosim-perf-report.md)
+- [GPU Frame Capture](gpu-capture.md)
 - [Selective X-Propagation](selective-x-propagation.md)
 - [Debugging X Values](x-debugging.md)
 - [Interactive JTAG Debug](jtag-debug.md)


### PR DESCRIPTION
`docs/gpu-capture.md` (#174) and `docs/cosim-perf-report.md` (#175) were added as files but **never registered in `SUMMARY.md`**, so mdBook never rendered them — `gpu-eda.github.io/Jacquard/gpu-capture.html` currently **404s**.

The CHANGELOG references both, so the version-pinned release-note links from #187 (`ci/versioned-docs`) would point at 404s. This registers both pages (under the tracing/observability group) so they render and the links resolve.

**Why the doc-link checker missed it:** it validates links *within* the rendered book against `SUMMARY.md`; nothing inside the book linked to these pages (they're referenced only from code comments + CHANGELOG), so an orphaned-but-on-disk page slipped through. Verified locally: `mdbook build` now emits `cosim-perf-report.html` + `gpu-capture.html`, and neither page has outbound `.md` links.

Should land before cutting the next RC, so its notes' `…/<tag>/gpu-capture.html` links work.