### PR TITLE
docs: lead release notes with a user-facing overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,24 @@ the public contracts in `docs/release-process.md` follow stricter rules).
 
 ## [Unreleased]
 
-A substantial feature release: a **behavioral-RTL on-ramp** (synthesize Verilog /
-SystemVerilog directly, no external tools), a complete **cell-model IR** that
-makes the binary self-contained for standard cells and adds SKY130 + IHP SG13G2,
-**plural QSPI memory with a writable PSRAM mode** across Metal / CUDA / HIP, and
-new **GPU frame-capture** + **device-timestamp cosim profiling**. Full detail
-below; docs links point to the version-pinned pages for this release.
+**What this means for you.** This release makes it easier to get a design onto
+the GPU and broadens what you can simulate:
+
+- **Feed it RTL, not just netlists.** `jacquard sim` / `cosim` accept behavioral
+  Verilog / SystemVerilog directly — synthesis runs transparently and cached, so
+  you no longer need to pre-synthesize a gate-level netlist to start simulating.
+- **More PDKs, less setup.** The binary is self-contained for standard cells (no
+  vendored-PDK files at simulation time); SKY130 and IHP SG13G2 are built in, and
+  proprietary libraries work from a `--cell-descriptor` with no Jacquard rebuild.
+- **Simulate SoCs with external memory.** Cosim now models multiple QSPI flash /
+  PSRAM devices — including a **writable QSPI PSRAM as a chip's main RAM** —
+  across Metal, CUDA, and HIP.
+- **See where GPU time goes.** New cosim profiling: ground-truth GPU-vs-CPU
+  per-edge timing from device timestamps (`--cosim-perf-json`), plus Xcode
+  `.gputrace` frame capture for per-dispatch analysis.
+
+Technical detail below; doc links resolve to the version-pinned pages for this
+release.
 
 ### Added
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -100,8 +100,12 @@ Release notes come from the CHANGELOG, and doc links are pinned to the release
 - **Notes body** = the CHANGELOG section for the tag's version. A prerelease
   (`X.Y.Z-rc.N`) has no dated section, so the extractor falls back to
   `[Unreleased]` — RCs ship the same curated draft you'll ship at promotion.
-  So: **write the notes in `[Unreleased]`**, including a one-sentence summary
-  lead-in before `### Added` (it becomes the release intro).
+  So: **write the notes in `[Unreleased]`**.
+- **Lead with a user-facing overview.** Before the technical `### Added` /
+  `### Changed` sections, open with a short *"What this means for you"* block —
+  a few benefit-framed bullets (what a user can now *do*, not just what changed).
+  The technical changelog then gives the detail. This becomes the release intro
+  and is the first thing a reader sees.
 - **Doc links are version-pinned.** The extractor rewrites `` `docs/foo.md` ``
   references into `[docs/foo.md](https://gpu-eda.github.io/Jacquard/<tag>/foo.html)`
   — the mdBook page frozen for *this* release. So keep CHANGELOG doc references


### PR DESCRIPTION
Release notes dived straight into the technical `### Added` list. Add a **"What this means for you"** overview at the top of CHANGELOG `[Unreleased]` — benefit-framed bullets (what a user can now *do*: feed RTL directly, more PDKs with less setup, simulate SoCs with external QSPI PSRAM, profile GPU cosim time) — before the technical detail, and record it as a convention in `release-process.md`. Lands before tagging rc.4 so that cut demonstrates the full notes shape (overview + version-pinned links).