### PR TITLE
fix(release): portable sed in the notes doc-link rewrite (BSD/macOS)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,12 +150,15 @@ jobs:
           fi
           # Version-pin doc links: rewrite `docs/foo.md` refs to the mdBook page
           # published for THIS release (docs-version job deploys to gh-pages
-          # /<tag>/). Produces a clickable [docs/foo.md](…/<tag>/foo.html). \x60
-          # is a backtick (kept out of the raw shell to avoid interpolation).
+          # /<tag>/). Produces a clickable [docs/foo.md](…/<tag>/foo.html).
+          # Portable across GNU + BSD (macOS runner) sed: no `-i` (BSD needs a
+          # suffix arg) — write to a temp file; `bt` is a literal backtick from
+          # printf, kept out of the raw shell to avoid command substitution.
           if [ -s notes.md ]; then
-            sed -i -E \
-              "s#\x60docs/([A-Za-z0-9/_-]+)\.md\x60#[docs/\1.md](https://gpu-eda.github.io/Jacquard/${TAG}/\1.html)#g" \
-              notes.md
+            bt=$(printf '\140')
+            sed -E \
+              "s#${bt}docs/([A-Za-z0-9/_-]+)\.md${bt}#[docs/\1.md](https://gpu-eda.github.io/Jacquard/${TAG}/\1.html)#g" \
+              notes.md > notes.md.tmp && mv notes.md.tmp notes.md
           fi
           if [ ! -s notes.md ]; then
             echo "no matching CHANGELOG section; using auto-generated notes" >&2


### PR DESCRIPTION
**v0.3.0-rc.4's release failed** on the "Extract release notes" step → publish + tap-bump skipped (the docs deployed because that job is independent). Cause: the doc-link `sed` from #187 used `sed -i -E`, a GNU-ism — the macOS runner's **BSD sed** needs a backup-suffix arg after `-i`, so it errored and `set -e` failed the step. My earlier test used a pipe, not `-i`, so it slipped through.

Fix: portable across GNU + BSD — no `-i` (temp file + `mv`), and the backtick via `printf '\140'` not `\x60`. **Verified on local BSD sed (macOS = same as the runner):** exit 0, rewrites `docs/foo.md` → the versioned link, subpaths preserved.

After merge I'll re-tag `v0.3.0-rc.4` at the fixed commit to re-run the release (build/package already proven; the docs are already at `/v0.3.0-rc.4/` and all four links 200).