### PR TITLE
fix(flatten): translate staged endpoint before indexing aig.srams (#186)

### DIFF
--- a/scripts/ci/cosim_cpu_check.sh
+++ b/scripts/ci/cosim_cpu_check.sh
@@ -129,6 +129,17 @@ if [ "$SCOPE" = all ]; then
         --output-vcd "$OUT/multi_mem.vcd" || true
     check multi_mem "$OUT/multi_mem.vcd" tests/multi_mem_cosim/expected/multi_mem_cosim.vcd
 
+    # multi_mem_split: the same design and the same golden, but level-split so
+    # the AIG stages. Staging renumbers the endpoint space, and the SRAM
+    # storage-offset walk used to read that staged index against the original
+    # AIG's `srams` — fine while staging was the identity, out of range (panic)
+    # or silently wrong (bad offset) once a design with SRAMs is split (#186).
+    # Splitting must not change behaviour, so this diffs the non-split golden.
+    run multi_mem_split "$BIN" cosim tests/multi_mem_cosim/multi_mem_dut_synth.gv \
+        --config tests/multi_mem_cosim/sim_config.json --top-module multi_mem_dut \
+        --level-split 10 --output-vcd "$OUT/multi_mem_split.vcd" || true
+    check multi_mem_split "$OUT/multi_mem_split.vcd" tests/multi_mem_cosim/expected/multi_mem_cosim.vcd
+
     # vcd_axes: the output and stimulus VCDs are written from one run off the
     # same edge_tick and are read together, so they must share a time axis.
     # Both files have to come from a single invocation for the comparison to

--- a/src/flatten.rs
+++ b/src/flatten.rs
@@ -1254,17 +1254,23 @@ fn build_flattened_script_v1(
                 // Map each RAMBlock endpoint in this partition to its
                 // backing-storage offset. cellid comes from indexing
                 // `aig.srams` at the endpoint's position within the
-                // SRAM range. Mirror the per-partition `cur_sram_id`
-                // walk that `init_writeout_perms` does later (see the
-                // RAMBlock arm at the `for &endpt_i in &part.endpoints`
-                // loop) — same iteration order, same offset arithmetic.
+                // SRAM range, so `endpt_i` — an index into *this stage's*
+                // endpoint space — must be translated back to the original
+                // AIG's before the subtraction. The two coincide only when
+                // staging is the identity; a level-split design otherwise
+                // indexes `aig.srams` out of range and panics (#186).
                 if flattening_parts[part_id].num_srams > 0 {
                     let part_sram_start = flattening_parts[part_id].sram_start;
                     let mut cur_sram_id: u32 = 0;
                     for &endpt_i in &init_parts[part_id].endpoints {
                         if let EndpointGroup::RAMBlock(_) = staged.get_endpoint_group(aig, endpt_i)
                         {
-                            let sram_pos = endpt_i - aig_po_len - aig_dff_len;
+                            // Never `None`: a staged IO pin resolves to
+                            // `StagedIOPin`, not `RAMBlock`.
+                            let aig_endpt = staged
+                                .to_aig_endpoint(endpt_i)
+                                .expect("RAMBlock endpoint is not a staged IO pin");
+                            let sram_pos = aig_endpt - aig_po_len - aig_dff_len;
                             let cellid = *aig.srams.get_index(sram_pos).unwrap().0;
                             let offset =
                                 part_sram_start + cur_sram_id * (1 << AIGPDK_SRAM_ADDR_WIDTH);

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -40,6 +40,23 @@ impl StagedAIG {
         }
     }
 
+    /// Translate a staged endpoint index into the original AIG's
+    /// endpoint-group index, the mapping [`Self::get_endpoint_group`]
+    /// applies before it defers to the raw AIG.
+    ///
+    /// `None` for a staged IO pin, which fulfils no original endpoint.
+    ///
+    /// Callers that need to index an AIG-side collection (`aig.srams`,
+    /// `aig.dffs`, …) from a staged endpoint must go through this. A staged
+    /// index only coincides with the AIG's when staging is the identity
+    /// (`from_full_aig` with no level split), so arithmetic that skips the
+    /// translation appears to work until a design is split (#186).
+    pub fn to_aig_endpoint(&self, endpt_id: usize) -> Option<usize> {
+        endpt_id
+            .checked_sub(self.primary_output_pins.len())
+            .map(|i| self.endpoints[i])
+    }
+
     /// build a staged AIG that consists of all levels.
     pub fn from_full_aig(aig: &AIG) -> Self {
         StagedAIG {


### PR DESCRIPTION
Closes #186.

> **Stacked on #193** (`feat/derived-clock-divider`). Base retargets to `main`
> automatically once that merges. The diff here is the single `flatten`/`staging`
> commit; #193's commits show only until it lands.

The second of the two blockers keeping the C64 out of `jacquard cosim`.

## The bug is staging, not cell-library macros

The issue supposed this was specific to cell-library-declared SRAM macros. It
isn't. `multi_mem` — an existing fixture using **AIGPDK-native SRAM** — panics
identically:

```
$ jacquard cosim tests/multi_mem_cosim/multi_mem_dut_synth.gv \
    --config tests/multi_mem_cosim/sim_config.json \
    --top-module multi_mem_dut --level-split 10

thread 'main' panicked at src/flatten.rs:1268:73:
called `Option::unwrap()` on a `None` value
```

The trigger is **level-splitting a design that has SRAMs**. The C64 hits it for
being big enough to stage, not for its cell library. That also means the C64
netlist isn't needed to reproduce or verify.

## Cause

The SRAM storage-offset walk read `endpt_i`, an index into the *current stage's*
endpoint space, against the *original AIG's* `primary_outputs` / `dffs` lengths:

```rust
let sram_pos = endpt_i - aig_po_len - aig_dff_len;
let cellid = *aig.srams.get_index(sram_pos).unwrap().0;
```

Those index spaces coincide only when staging is the identity (`from_full_aig`,
no level split), which is why every SRAM fixture passed: none of them stage.
Split, and the index either lands out of range and panics, or lands *in* range
and silently records the wrong backing-storage offset. The silent case is the
worse one.

`StagedAIG::get_endpoint_group` already owns this staged→AIG mapping, and the
walk had reimplemented the arithmetic and drifted out of sync. Rather than
duplicate it a third time, this exposes the mapping as `to_aig_endpoint` and
calls it, so there's one definition.

(The comment above the walk pointed at `init_writeout_perms` for the "same offset
arithmetic". No such function exists any more, which is a fair hint at how the
duplicate drifted. Comment corrected.)

## Test

The regression test reuses the `multi_mem` fixture **and its existing golden**,
level-split. Splitting must not change behaviour, so no new golden is needed and
the assertion is exactly the invariant that broke.

Verified it has teeth: with the fix stashed out, `multi_mem_split` fails.

| Check | Result |
| --- | --- |
| `multi_mem_split` with fix | pass, byte-identical to non-split golden |
| `multi_mem_split` with fix stashed | fails (panics, no output) |
| Golden suite, CpuBackend | 15/15 pass |
| `cargo test --lib` | 339 pass |

The DUT's own `all_match` self-check asserts under level-split, which exercises
the offsets rather than just the absence of a crash: it reads a distinct byte
from each of three flashes and both SRAMs.

Co-developed-by: Claude Code v2.1.209 (claude-opus-4-8[1m])