### PR TITLE
docs(ci): register the AMD ROCm runner, correct the release checklist

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -13,3 +13,12 @@ self-hosted-runner:
     - cuda
     - blackwell
     - sm_120
+    # Self-hosted AMD ROCm runner (gfx1036 — RDNA2 integrated GPU), registered
+    # at org level. Targeted as `runs-on: [self-hosted, amd, rocm]`. Until now
+    # nothing referenced it: `HIP Tests (NVIDIA backend)` builds against
+    # hip-runtime-nvidia and runs on tesla4-runner, so HIP had never executed on
+    # AMD hardware — the open "HIP CI on the AMD runner" item in
+    # docs/release-process.md.
+    - amd
+    - rocm
+    - gfx1036

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -176,12 +176,26 @@ These items are tracked in [`docs/plans/post-phase-0-roadmap.md`](plans/post-pha
 - [x] WS-RH.1 (OpenSTA detection + version check) shipped.
 - [x] Metal CI on `macos-runner-1` green (re-enabled in commit `12e98df`,
       2026-05-12).
-- [ ] **CUDA CI** on `nvidia-runner-1` green on main. Currently
-      disabled in `.github/workflows/ci.yml` (`if: ${{ false }}`,
-      ~line 268). Re-enable when hardware lands.
-- [ ] **HIP CI** on the AMD runner green on main. Currently disabled
-      in `.github/workflows/ci.yml` (`if: ${{ false }}`, ~line 357).
-      Re-enable when the AMD runner is online.
+- [x] **CUDA CI** green on main. Runs as the required `CUDA Tests` job on
+      the ephemeral `tesla4-runner`, plus `CUDA Blackwell Tests` (sm_120) on
+      the self-hosted Blackwell runner. (This item used to say the job was
+      disabled via `if: ${{ false }}` and named a `nvidia-runner-1` host;
+      both went stale — no `if: ${{ false }}` remains in `ci.yml`.)
+- [ ] **HIP CI on AMD hardware** green on main. Still open, and *not*
+      satisfied by the passing `HIP Tests (NVIDIA backend)` job: that one
+      builds against `hip-runtime-nvidia` and runs on `tesla4-runner`, so it
+      exercises HIP-over-CUDA, never ROCm.
+      The blocker named here ("re-enable when the AMD runner is online") is
+      **gone** — an AMD ROCm runner is registered at org level and idle
+      (labels `self-hosted, amd, rocm, gfx1036`). A probe on 2026-07-15
+      confirmed it is ready: ROCm 7.2.4, `hipcc` (HIP 7.2.53211),
+      `hipconfig --platform` = `amd`, Rust 1.96.1 preinstalled, and a
+      trivial HIP kernel compiles and runs correctly on the GPU with **no**
+      `HSA_OVERRIDE_GFX_VERSION` needed. Note the device reports **`gfx1030`**
+      (`gfx_target_version 100306`) despite the runner's `gfx1036` label.
+      What remains is the job itself: `hip-build` deliberately targets the
+      NVIDIA platform, so an AMD/ROCm build variant is needed before the
+      cosim goldens can gate on it.
 - [ ] **Prebuilt CUDA/HIP binaries** (ADR 0018 Phase 4), when produced, must
       build with `JACQUARD_CUDA_ARCH=all-major` so the kernel ships portable
       SASS for every major arch (`sm_50`…`sm_120` on CUDA ≥ 12.8, Blackwell


### PR DESCRIPTION
Docs + lint config only; no workflow behaviour changes.

## What prompted this

Checking the pre-release checklist before v0.3.0, I claimed the "HIP CI on the
AMD runner" item was stale because the AMD runner is online. That was wrong, and
worth writing down properly.

The org has a self-hosted AMD ROCm runner online and **idle**, which **no
workflow targets** — actionlint's label registry didn't even list it. Meanwhile
`HIP Tests (NVIDIA backend)` builds `hip-runtime-nvidia` and runs on
`tesla4-runner`: that's HIP-over-CUDA. **HIP has never executed on ROCm in this
repo**, so the checklist item is genuinely unmet, not stale.

## Probe result (2026-07-15)

A throwaway probe job on that runner says it's ready:

| | |
| --- | --- |
| GPU | **`gfx1030`** (`gfx_target_version 100306`) — *not* the `gfx1036` its label claims |
| Host | Ryzen 5 7600, 12 cores, 61 GiB, containerised |
| ROCm | 7.2.4, `hipcc` (HIP 7.2.53211), AMD clang 22 |
| Platform | `hipconfig --platform` → `amd` (genuine ROCm) |
| Rust | 1.96.1 preinstalled |
| HIP kernel | compiles + runs correctly, **no `HSA_OVERRIDE_GFX_VERSION`** |

```
--- native ---
result: 1 2 3 4 5 6 7 8
NATIVE: OK
```

Someone built a proper ROCm CI image; it just never got wired to a job.

## Changes

- **`.github/actionlint.yaml`** — register `amd` / `rocm` / `gfx1036` so a job
  can reference the runner without tripping the label check.
- **`docs/release-process.md`** — correct two drifted checklist items:
  - **CUDA CI** → `[x]`. It claimed the job was disabled via `if: ${{ false }}`
    at ~line 268 on a `nvidia-runner-1` host. No `if: ${{ false }}` remains
    anywhere in `ci.yml`; `CUDA Tests` is a required check on `tesla4-runner`
    and passes, as does `CUDA Blackwell Tests`.
  - **HIP-on-AMD** stays `[ ]`, restated accurately: not satisfied by the
    NVIDIA-backend job, blocker ("when the AMD runner is online") gone, probe
    findings recorded, and the remaining work named — `hip-build` deliberately
    targets the NVIDIA platform, so an AMD/ROCm build variant is needed before
    the cosim goldens can gate on it.

## Not included

The real `HIP Tests (AMD/ROCm)` job — that's a follow-up, deliberately not on
the release path. The probe workflow was temporary and isn't merged.

Co-developed-by: Claude Code v2.1.209 (claude-opus-4-8[1m])