### PR TITLE
fix(ci): validate-install must binstall jacquard-sim, not jacquard

### DIFF
--- a/.github/workflows/validate-install.yml
+++ b/.github/workflows/validate-install.yml
@@ -58,13 +58,19 @@ jobs:
         # quick-install strategies makes a missing/misnamed asset a hard
         # failure instead of a silent source build — which is the whole point.
         #
+        # The *package* is `jacquard-sim` (renamed 2026-07-07 in 3b3938f3); the
+        # binary it installs is still `jacquard`. `--manifest-path` resolves the
+        # name against the checked-out manifest, so this must be the package
+        # name, not the binary name — `jacquard` gives "Failed to load jacquard
+        # from Cargo.toml: Not found".
+        #
         # GITHUB_TOKEN authenticates binstall's GitHub API calls (release
         # lookup): unauthenticated is 60 req/hr/IP and 403s under load, which
         # then times out the fetcher and aborts.
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          cargo binstall jacquard \
+          cargo binstall jacquard-sim \
             --manifest-path Cargo.toml \
             --no-confirm \
             --strategies crate-meta-data \

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -15,9 +15,10 @@ archive root (matching the `cargo-binstall` `bin-dir` in `Cargo.toml`),
 smoke-tests the relocated binary, and creates a **draft** release. Review
 the assets, then publish.
 
-`cargo binstall jacquard` then resolves the macOS/Metal asset (Linux is
+`cargo binstall jacquard-sim` then resolves the macOS/Metal asset (the
+package is `jacquard-sim`; the binary it installs is `jacquard`). Linux is
 not binstall-able — two GPU backends per target triple; use the tarball
-or a container).
+or a container.
 
 ## Homebrew tap (macOS/Metal)
 


### PR DESCRIPTION
Found by cutting **v0.3.0-rc.5** and actually running the staging validation.

## The failure

```
INFO resolve: Resolving package: 'jacquard'
ERROR Fatal error:
  × For crate jacquard: Failed to load jacquard from Cargo.toml: Not found
```

`validate-install.yml` runs `cargo binstall jacquard --manifest-path Cargo.toml`.
The crate was renamed to **`jacquard-sim`** on 2026-07-07 (3b3938f3) — that commit
updated `docs/installation.md` but not this workflow. `--manifest-path` resolves
the name against the checked-out manifest, so it needs the *package* name; the
**binary** is still `jacquard`, which is what made it easy to miss.

## Why it went unnoticed for a week

Staging validation is "optional but recommended", and it hadn't run since
**2026-06-25** — before the rename. rc.1 → rc.4 all skipped it:

| run | date | result |
| --- | --- | --- |
| #6 | 2026-07-15 | **failure** ← rc.5 |
| #5 | 2026-06-25 | success ← last green, pre-rename |

## Users were never affected

`docs/installation.md` has said `cargo binstall --git … jacquard-sim` since the
rename, and explains why (the crate name `jacquard` on crates.io belongs to an
unrelated AT-Protocol client library). Only the **guard** was wrong — arguably
worse than a broken feature, because a broken guard stops guarding silently:
`--disable-strategies compile,quick-install` exists specifically to turn a
missing asset into a hard error, and that protection has been inert since the
rename.

## Changes

- `validate-install.yml`: `jacquard` → `jacquard-sim`, plus a comment on the
  package-vs-binary distinction so the next rename doesn't repeat this.
- `packaging/README.md`: same stale name.

Left alone deliberately: the `cargo install jacquard` line in
`docs/installation.md` (it's explaining the crates.io collision) and the
CHANGELOG reference (history).

## After this lands

Re-dispatch **Validate install (staging)** against `v0.3.0-rc.5` — the workflow
resolves from the default branch, so it picks the fix up without re-cutting the
RC. `brew install` already passed; `cargo binstall` is the only leg outstanding
before promoting to v0.3.0.

Co-developed-by: Claude Code v2.1.209 (claude-opus-4-8[1m])