### PR TITLE
docs: add the logo to the README and the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ the public contracts in `docs/release-process.md` follow stricter rules).
 
 ## [Unreleased]
 
+### Documentation
+
+- **A logo.** A 4×4 weave carrying an and-inverter graph: two ANDs and two NOTs,
+  one per row and one per column. Warp threads pass under the weft and hop where
+  they cross, except where one taps a gate's second leg; madder is reserved for
+  the logic, being the only part that computes. It sits at the top of the README
+  and the docs, and its unit cell — one warp, one weft, one gate — is the docs
+  favicon.
+
 ## [0.3.0] - 2026-07-15
 
 The headline change is the RTL on-ramp. `jacquard sim` and `cosim` now take

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/jacquard-logo-dark.svg">
+  <img src="docs/assets/jacquard-logo.svg" alt="Jacquard" width="120" align="right">
+</picture>
+
 # Jacquard
 
 ![CI](https://github.com/gpu-eda/Jacquard/actions/workflows/ci.yml/badge.svg)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/jacquard-logo-dark.svg">
+  <img src="assets/jacquard-logo.svg" alt="" width="104" align="right">
+</picture>
+
 # Jacquard Documentation
 
 Welcome to the documentation for Jacquard, a GPU-accelerated RTL logic simulator.

--- a/docs/assets/jacquard-logo-dark.svg
+++ b/docs/assets/jacquard-logo-dark.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 176 176" role="img" aria-labelledby="t">
+  <title id="t">Jacquard</title>
+  <!-- A 4x4 weave carrying an and-inverter graph: two ANDs and two NOTs, one per
+       row and one per column (a 4-queens solution). Warp threads run under the
+       weft and hop where they cross; where a warp feeds a gate's second leg it
+       taps in at a junction instead. Madder is reserved for the logic. -->
+
+  <!-- warp: verticals, their taps into the gates, and the junctions -->
+  <g stroke="#6B84C4" stroke-width="4" stroke-linecap="round" fill="none">
+    <line x1="24" y1="10" x2="24" y2="166"/>
+    <line x1="62" y1="10" x2="62" y2="166"/>
+    <line x1="100" y1="10" x2="100" y2="166"/>
+    <line x1="138" y1="10" x2="138" y2="166"/>
+    <path d="M24 66 H40"/>
+    <path d="M62 142 H78"/>
+  </g>
+  <g fill="#6B84C4">
+    <circle cx="24" cy="66" r="3.4"/>
+    <circle cx="62" cy="142" r="3.4"/>
+  </g>
+
+  <!-- weft: the horizontals, where the signal runs -->
+  <g stroke="#A8BCF2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M10 24 H19 A5 5 0 0 1 29 24 H57 A5 5 0 0 1 67 24 H95 A5 5 0 0 1 105 24 H108"/>
+    <path d="M129 24 H133 A5 5 0 0 1 143 24 H166"/>
+
+    <path d="M10 62 H19 A5 5 0 0 1 29 62 H32 V58 H40"/>
+    <path d="M56 62 H57 A5 5 0 0 1 67 62 H95 A5 5 0 0 1 105 62 H133 A5 5 0 0 1 143 62 H166"/>
+
+    <path d="M10 100 H19 A5 5 0 0 1 29 100 H57 A5 5 0 0 1 67 100 H95 A5 5 0 0 1 105 100 H133 A5 5 0 0 1 143 100 H144"/>
+    <path d="M164 100 H166"/>
+
+    <path d="M10 138 H19 A5 5 0 0 1 29 138 H57 A5 5 0 0 1 67 138 H70 V134 H78"/>
+    <path d="M94 138 H95 A5 5 0 0 1 105 138 H133 A5 5 0 0 1 143 138 H166"/>
+  </g>
+
+  <!-- the logic: the only coloured thing, because it's the only thing that computes -->
+  <g stroke="#D2513C" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M108 17 L108 31 L122 24 Z"/>
+    <circle cx="125.5" cy="24" r="3.5"/>
+    <path d="M40 54 L48 54 A8 8 0 0 1 48 70 L40 70 Z"/>
+    <path d="M144 93 L144 107 L157 100 Z"/>
+    <circle cx="160.5" cy="100" r="3.5"/>
+    <path d="M78 130 L86 130 A8 8 0 0 1 86 146 L78 146 Z"/>
+  </g>
+</svg>

--- a/docs/assets/jacquard-logo.svg
+++ b/docs/assets/jacquard-logo.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 176 176" role="img" aria-labelledby="t">
+  <title id="t">Jacquard</title>
+  <!-- A 4x4 weave carrying an and-inverter graph: two ANDs and two NOTs, one per
+       row and one per column (a 4-queens solution). Warp threads run under the
+       weft and hop where they cross; where a warp feeds a gate's second leg it
+       taps in at a junction instead. Madder is reserved for the logic. -->
+
+  <!-- warp: verticals, their taps into the gates, and the junctions -->
+  <g stroke="#7191CE" stroke-width="4" stroke-linecap="round" fill="none">
+    <line x1="24" y1="10" x2="24" y2="166"/>
+    <line x1="62" y1="10" x2="62" y2="166"/>
+    <line x1="100" y1="10" x2="100" y2="166"/>
+    <line x1="138" y1="10" x2="138" y2="166"/>
+    <path d="M24 66 H40"/>
+    <path d="M62 142 H78"/>
+  </g>
+  <g fill="#7191CE">
+    <circle cx="24" cy="66" r="3.4"/>
+    <circle cx="62" cy="142" r="3.4"/>
+  </g>
+
+  <!-- weft: the horizontals, where the signal runs -->
+  <g stroke="#3A559A" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M10 24 H19 A5 5 0 0 1 29 24 H57 A5 5 0 0 1 67 24 H95 A5 5 0 0 1 105 24 H108"/>
+    <path d="M129 24 H133 A5 5 0 0 1 143 24 H166"/>
+
+    <path d="M10 62 H19 A5 5 0 0 1 29 62 H32 V58 H40"/>
+    <path d="M56 62 H57 A5 5 0 0 1 67 62 H95 A5 5 0 0 1 105 62 H133 A5 5 0 0 1 143 62 H166"/>
+
+    <path d="M10 100 H19 A5 5 0 0 1 29 100 H57 A5 5 0 0 1 67 100 H95 A5 5 0 0 1 105 100 H133 A5 5 0 0 1 143 100 H144"/>
+    <path d="M164 100 H166"/>
+
+    <path d="M10 138 H19 A5 5 0 0 1 29 138 H57 A5 5 0 0 1 67 138 H70 V134 H78"/>
+    <path d="M94 138 H95 A5 5 0 0 1 105 138 H133 A5 5 0 0 1 143 138 H166"/>
+  </g>
+
+  <!-- the logic: the only coloured thing, because it's the only thing that computes -->
+  <g stroke="#9C2A1E" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M108 17 L108 31 L122 24 Z"/>
+    <circle cx="125.5" cy="24" r="3.5"/>
+    <path d="M40 54 L48 54 A8 8 0 0 1 48 70 L40 70 Z"/>
+    <path d="M144 93 L144 107 L157 100 Z"/>
+    <circle cx="160.5" cy="100" r="3.5"/>
+    <path d="M78 130 L86 130 A8 8 0 0 1 86 146 L78 146 Z"/>
+  </g>
+</svg>

--- a/theme/favicon.svg
+++ b/theme/favicon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" role="img" aria-labelledby="t">
+  <title id="t">Jacquard</title>
+  <!-- The unit cell of the full mark (docs/assets/jacquard-logo.svg): one warp,
+       one weft, one gate. A hop, a tap, and an AND — the whole grammar at 16px.
+       Inks sit mid-range so the mark holds on a light or a dark tab strip. -->
+
+  <!-- warp + its tap + the junction -->
+  <g stroke="#7191CE" stroke-width="3.4" stroke-linecap="round" fill="none">
+    <line x1="14" y1="4" x2="14" y2="44"/>
+    <path d="M14 28 H22"/>
+  </g>
+  <circle cx="14" cy="28" r="3" fill="#7191CE"/>
+
+  <!-- weft: in over the hop, and out of the gate -->
+  <g stroke="#5A79C0" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M4 20 H9 A5 5 0 0 1 19 20 H22"/>
+    <path d="M38 24 H44"/>
+  </g>
+
+  <!-- the gate -->
+  <path d="M22 16 L30 16 A8 8 0 0 1 30 32 L22 32 Z"
+        stroke="#C0392B" stroke-width="3.4" stroke-linejoin="round" fill="none"/>
+</svg>


### PR DESCRIPTION
A logo, built out of the name rather than bolted onto it.

## The mark
A **4×4 weave carrying an and-inverter graph** — two ANDs and two NOTs, nothing else, because nothing else is in an AIG.

- **One gate per row and per column**, on an actual 4-queens solution (rows 1–4 → columns 3, 1, 4, 2). A hand-scatter tends to double up a column or line up on a diagonal, and the eye reads that as a line even when you can't say why.
- **Warp under weft, hopping where they cross** — which is exactly what a schematic already draws when two wires cross without connecting. Weaving and circuits turn out to use the same mark for the same idea.
- **A gate can't sit *at* a crossing** (four arms vs three), so the weft dips to one leg and the column's own warp taps the other. Hence the detail worth keeping: warp 24 is *hopped* at one height and *connects* at another — both weave states on one thread.
- **Madder is reserved for the gates**, the only part that computes. Warp and weft separate on value, not hue, so the accent means exactly one thing.

## The unit
One warp, one weft, one gate — a hop, a tap, and an AND. Not a second mark but the **unit cell** of this one, so the favicon is the same grammar at 16px rather than another thing to recognise. It's now the docs favicon.

## Where it lands
- Top of `README.md` — right next to the sentence it illustrates ("Like a Jacquard loom weaving patterns from punched cards…").
- Top of `docs/README.md`, the book's Introduction.
- `theme/favicon.svg` — overrides mdBook's default.

Light and dark are separate files behind `<picture>`; the inks have to move to hold on either ground.

## Verified, not assumed
- All three SVGs parse as well-formed XML.
- `mdbook build` succeeds, copies `docs/assets/`, and the `theme/` override **does** replace mdBook's default favicon (confirmed by content, not by the file existing — mdBook content-hashes the name).
- `check_doc_links.py` passes; its one note (`spikes/rust-wasmtime-yosys/README.md`) is pre-existing.