### PR TITLE
ci: docs-only gate misread mdBook theme/ and book.toml as code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,15 +47,25 @@ jobs:
         id: filter
         with:
           # `every`: a changed file counts toward `code` only if it matches
-          # ALL patterns — i.e. it is NOT under docs/ AND NOT a markdown file.
-          # `code` is then true iff at least one such non-docs file changed.
+          # ALL patterns — i.e. it is not documentation by any of the measures
+          # below. `code` is then true iff at least one such file changed.
           # (The default `some` quantifier OR-combines patterns, so a `'**'`
           # catch-all would match every file and `code` would always be true.)
+          #
+          # This is a denylist of doc paths, not an allowlist of code paths, and
+          # deliberately so: a doc path missing here only wastes CI, whereas a
+          # code path missing from an allowlist would *silently skip the tests*.
+          # The cost is that documentation living outside docs/ has to be listed
+          # — mdBook's theme/ and book.toml are inputs to the `docs` job alone,
+          # so a change to either must not drag in the GPU builds. Add to this
+          # list when documentation grows a new home outside docs/.
           predicate-quantifier: 'every'
           filters: |
             code:
               - '!docs/**'
               - '!**/*.md'
+              - '!theme/**'
+              - '!book.toml'
 
   # Run library unit tests on Linux (no GPU required)
   test:


### PR DESCRIPTION
You spotted this on #200: a logo — six files, none of them code — ran **CUDA Build, Metal Build, Unit Tests, Benchmarks and CVC Reference**. It's a real bug.

## Cause
The `code` filter excludes `docs/**` and `**/*.md`, and with `predicate-quantifier: every` a file counts as code only if it's **neither**. mdBook inputs that live *outside* `docs/` satisfy both negations:

| file | `!docs/**` | `!**/*.md` | verdict |
|---|---|---|---|
| `theme/favicon.svg` | ✅ | ✅ | **code = true** |
| `book.toml` | ✅ | ✅ | **code = true** |

`book.toml` has had this latent since the gate landed. `theme/` only started existing in #200 (created for the favicon), which is what surfaced it.

## Fix
Add both to the denylist.

**Safe:** the `docs` job has no `needs: [changes]` and no `if:` — it runs unconditionally — so theme/`book.toml` changes still build *and deploy* the site. Only the GPU jobs stop firing.

**Kept as a denylist of doc paths, not an allowlist of code paths**, deliberately: a doc path missing from a denylist only wastes CI, whereas a code path missing from an allowlist would **silently skip the tests**. Wrong-but-safe beats wrong-and-quiet. The comment now records that, plus the instruction to extend the list when docs grow a new home outside `docs/`.

## Verified
Simulated the `every` + negation semantics against representative paths — the part that's easy to get subtly wrong:
- excluded: `theme/favicon.svg`, `book.toml`, `docs/assets/*.svg`, `docs/README.md`, `README.md`, `CHANGELOG.md`
- still code: `src/aig.rs`, `csrc/kernel_v1.metal`, `Cargo.toml`, `crates/timing-ir/src/lib.rs`, `tests/apb_trace/sim.json`, `.github/workflows/ci.yml`

Note this PR can't demonstrate the fix on itself — it edits `ci.yml`, which *is* code, so it'll correctly run everything. The next docs-only change is the real proof.