### PR TITLE
fix(logo): the accent receded on dark; restore the hierarchy

### DIFF
--- a/docs/assets/jacquard-logo-dark.svg
+++ b/docs/assets/jacquard-logo-dark.svg
@@ -6,7 +6,7 @@
        taps in at a junction instead. Madder is reserved for the logic. -->
 
   <!-- warp: verticals, their taps into the gates, and the junctions -->
-  <g stroke="#6B84C4" stroke-width="4" stroke-linecap="round" fill="none">
+  <g stroke="#6076B4" stroke-width="4" stroke-linecap="round" fill="none">
     <line x1="24" y1="10" x2="24" y2="166"/>
     <line x1="62" y1="10" x2="62" y2="166"/>
     <line x1="100" y1="10" x2="100" y2="166"/>
@@ -14,13 +14,13 @@
     <path d="M24 66 H40"/>
     <path d="M62 142 H78"/>
   </g>
-  <g fill="#6B84C4">
+  <g fill="#6076B4">
     <circle cx="24" cy="66" r="3.4"/>
     <circle cx="62" cy="142" r="3.4"/>
   </g>
 
   <!-- weft: the horizontals, where the signal runs -->
-  <g stroke="#A8BCF2" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none">
+  <g stroke="#93A9E4" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none">
     <path d="M10 24 H19 A5 5 0 0 1 29 24 H57 A5 5 0 0 1 67 24 H95 A5 5 0 0 1 105 24 H108"/>
     <path d="M129 24 H133 A5 5 0 0 1 143 24 H166"/>
 
@@ -35,7 +35,7 @@
   </g>
 
   <!-- the logic: the only coloured thing, because it's the only thing that computes -->
-  <g stroke="#D2513C" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none">
+  <g stroke="#EE7359" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none">
     <path d="M108 17 L108 31 L122 24 Z"/>
     <circle cx="125.5" cy="24" r="3.5"/>
     <path d="M40 54 L48 54 A8 8 0 0 1 48 70 L40 70 Z"/>

--- a/theme/favicon.svg
+++ b/theme/favicon.svg
@@ -2,22 +2,40 @@
   <title id="t">Jacquard</title>
   <!-- The unit cell of the full mark (docs/assets/jacquard-logo.svg): one warp,
        one weft, one gate. A hop, a tap, and an AND — the whole grammar at 16px.
-       Inks sit mid-range so the mark holds on a light or a dark tab strip. -->
+
+       A favicon sits on browser chrome, which follows the OS theme, so it takes
+       the same two palettes as the logo rather than one mid-tone compromise:
+       fixed inks left the warp at 3.2:1 on a light strip and the gate at 3.0:1
+       on a dark one — worst-case on both, and the gate is the whole point of the
+       mark. Browsers without prefers-color-scheme for SVG icons get the light
+       rules, which are legible on either. -->
+  <style>
+    .warp { stroke: #7191CE; }
+    .warp-fill { fill: #7191CE; }
+    .weft { stroke: #3A559A; }
+    .gate { stroke: #9C2A1E; }
+    @media (prefers-color-scheme: dark) {
+      .warp { stroke: #6076B4; }
+      .warp-fill { fill: #6076B4; }
+      .weft { stroke: #93A9E4; }
+      .gate { stroke: #EE7359; }
+    }
+  </style>
 
   <!-- warp + its tap + the junction -->
-  <g stroke="#7191CE" stroke-width="3.4" stroke-linecap="round" fill="none">
+  <g class="warp" stroke-width="3.4" stroke-linecap="round" fill="none">
     <line x1="14" y1="4" x2="14" y2="44"/>
     <path d="M14 28 H22"/>
   </g>
-  <circle cx="14" cy="28" r="3" fill="#7191CE"/>
+  <circle class="warp-fill" cx="14" cy="28" r="3"/>
 
   <!-- weft: in over the hop, and out of the gate -->
-  <g stroke="#5A79C0" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" fill="none">
+  <g class="weft" stroke-width="3.4" stroke-linecap="round" stroke-linejoin="round" fill="none">
     <path d="M4 20 H9 A5 5 0 0 1 19 20 H22"/>
     <path d="M38 24 H44"/>
   </g>
 
   <!-- the gate -->
-  <path d="M22 16 L30 16 A8 8 0 0 1 30 32 L22 32 Z"
-        stroke="#C0392B" stroke-width="3.4" stroke-linejoin="round" fill="none"/>
+  <path class="gate" d="M22 16 L30 16 A8 8 0 0 1 30 32 L22 32 Z"
+        stroke-width="3.4" stroke-linejoin="round" fill="none"/>
 </svg>


### PR DESCRIPTION
You spotted this: the logo needs work on black. It's worse than "a bit dark" — **the mark reads backwards there**.

## What's wrong
Measured against GitHub dark (`#0d1117`):

| | before |
|---|---|
| weft | 10.0:1 |
| warp | 5.2:1 |
| **gates** | **4.5:1** ← quietest thing in the mark |

Madder is in this mark for one reason: the gates are the only part that computes, so they get the only colour. Having plain thread out-shout them by **2.2×** inverts exactly that idea. On light it works; on dark the logic recedes and the cloth shouts.

## The fix
Lift the gates, step the weft back:

| | after |
|---|---|
| weft `#93A9E4` | 8.1:1 |
| **gates `#EE7359`** | **6.5:1** |
| warp `#6076B4` | 4.3:1 |

The accent now leads the threads it sits on, the warp stays recessive, and the weft/gates gap closes from 2.2× to 1.25× — close enough that **hue** does the separating, which was always the intent. Red can't match light blue's luminance without turning pink, so parity isn't the goal; not-last is.

**Light variant untouched** — it was already right.

## The favicon had it worse
Fixed mid-tones meant worst-case on *both* grounds: warp **3.2:1** on a light tab strip, gate **3.0:1** on a dark one — the gate being the whole point of the unit mark. A favicon sits on browser chrome, which follows the OS theme, so it now carries the same two palettes and picks via `prefers-color-scheme`. Browsers that don't honour that for SVG icons get the light rules, legible on either.

## Verified
Both SVGs parse, `mdbook build` is clean, and the adaptive favicon survives the build (mdBook content-hashes it, so I checked for the media query in the output rather than trusting the file existing).

Worth your eye on the real thing once deployed — contrast maths gets the hierarchy right but doesn't tell you whether `#EE7359` still reads as *madder* rather than coral.