### PR TITLE
docs: README still said the RTL on-ramp was planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ cargo run -r --features metal --bin jacquard -- sim design.gv input.vcd output.v
 
 Partitioning (mapping the design to GPU blocks) happens automatically at startup.
 
+`sim` replays a **static** VCD, which is enough when the stimulus doesn't depend
+on what the design does. When it does, `jacquard cosim` runs peripheral models —
+SPI flash / QSPI PSRAM, UART, JTAG (with an interactive `--jtag-server`), and
+Wishbone / APB3 bus tracing — as GPU kernels alongside the design, so inputs can
+react to outputs cycle by cycle.
+
 **See [Getting Started](https://gpu-eda.github.io/Jacquard/getting-started.html)** to run bundled
 designs in seconds, or the [Synthesis Flow](https://gpu-eda.github.io/Jacquard/synthesis-flow.html)
 for synthesis preparation, VCD scope handling, and running your own RTL.
@@ -114,32 +120,32 @@ mdbook serve   # opens at http://localhost:3000
 
 ## Input
 
-Jacquard is a gate-level **emulator**: the input to `sim` / `cosim` is a
-**synthesized gate-level Verilog netlist** (structural Verilog mapped to
-`aigpdk` / SKY130 / GF180MCU cells).
+Point it at behavioral Verilog or SystemVerilog and it runs:
 
-**Behavioral RTL is the intended design input — through a synthesis step.** Bring
-your RTL, synthesize it to a gate-level netlist (Yosys or a commercial tool;
-synthesis *quality* sets Jacquard's speed, so it's a deliberate step), then
-simulate. The full flow — memory mapping + logic synthesis to `aigpdk.lib` — is
-in the [Synthesis Flow](https://gpu-eda.github.io/Jacquard/synthesis-flow.html)
-guide.
+```sh
+jacquard sim design.v input.vcd output.vcd 1
+```
 
-- **Feed it:** a synthesized netlist (`design.gv`), or your RTL after synthesis.
-- **Don't feed it raw behavioral RTL** (`always`/`if`/`case`/`reg`/params) — the
-  synthesizer elaborates those away first.
-- Full supported netlist syntax + SystemVerilog/SVA status:
-  [Input netlist language](https://gpu-eda.github.io/Jacquard/input-netlist.html).
+Synthesis happens on the way in, transparently and cached, through an embedded
+Yosys engine. It needs the `synth` feature — on in release and Homebrew binaries,
+`--features metal,synth` if you're building yourself — and a `yosys.wasm`. See
+**[Accepted RTL Surface](https://gpu-eda.github.io/Jacquard/accepted-rtl.html)**
+for the supported language subset and how to supply the wasm.
 
-> An integrated `jacquard build design.v` on-ramp (Yosys embedded via YoWASP, no
-> manual synthesis) is planned — [ADR 0021](https://gpu-eda.github.io/Jacquard/adr/0021-behavioral-rtl-support.html) / [#162](https://github.com/gpu-eda/Jacquard/issues/162).
+A **pre-synthesized gate-level netlist** (`design.gv`, mapped to `aigpdk` /
+SKY130 / GF180MCU cells) works too, and it's the faster path: synthesis quality
+sets Jacquard's speed, so a design you'll run many times is worth synthesizing
+deliberately. The full flow — memory mapping plus logic synthesis to
+`aigpdk.lib` — is in
+[Synthesis Flow](https://gpu-eda.github.io/Jacquard/synthesis-flow.html). A
+binary built without `synth` still simulates netlists, and says so clearly if
+handed RTL.
+
+Netlist syntax and SystemVerilog/SVA status:
+[Input netlist language](https://gpu-eda.github.io/Jacquard/input-netlist.html).
 
 ## Limitations
 
-- `jacquard sim` takes a static VCD input waveform. For reactive testbenches,
-  `jacquard cosim` runs peripheral models (SPI flash, UART, JTAG — including an
-  interactive `--jtag-server` — and Wishbone / APB3 bus tracing) as GPU kernels
-  alongside the design, so inputs can depend on design outputs cycle-by-cycle.
 - **Edge-triggered flip-flops only in the logic** — a raw `LATCH` cell in the
   gate-level netlist is rejected (async set/reset on flip-flops is fine; async
   reset is *not* the restriction). The two common structured latch uses are


### PR DESCRIPTION
You flagged the first Limitations bullet as "not really a limitation" — correct, and pulling that thread found something worse next door.

## The Input section contradicts v0.3.0
It still said:

> **Don't feed it raw behavioral RTL** (`always`/`if`/`case`/`reg`/params)
>
> An integrated `jacquard build design.v` on-ramp … is **planned**

That's the headline feature of the release we shipped last week, described as unavailable. And `jacquard build` doesn't exist — folded into `sim`/`cosim` in the same release (confirmed against the CLI: `Sim`, `Cosim`, `DumpPaths`, `Xsources`, no `Build`). Anyone reading the README would conclude Jacquard can't do the main thing it now does.

Rewritten around what's true: pass RTL, it runs, synthesis is transparent and cached — with the `synth`-feature and `yosys.wasm` caveats pointed at `accepted-rtl.md` rather than glossed. The pre-synthesized netlist stays, as what it now actually is: the *faster* path, since synthesis quality sets the speed.

## The Limitations bullet
It described cosim's reactive peripheral models — a capability, not a limit. It reads oddly because it's an answer to *"my stimulus depends on the design's outputs"*, which is a Usage question, so it moves next to the `sim` examples.

What's left under Limitations is the two things that genuinely are limits: no latches, and clock gates must be `CKLNQD`.