### PR TITLE
fix(sim): bad VCD input panicked instead of reporting

### DIFF
--- a/src/bin/jacquard.rs
+++ b/src/bin/jacquard.rs
@@ -702,25 +702,51 @@ fn cmd_sim(args: SimArgs) {
 
     let timing_constraints = setup::build_timing_constraints(&design.script);
 
-    // Parse input VCD
-    let input_vcd = std::fs::File::open(&args.input_vcd).unwrap();
+    // Parse input VCD. These are user-supplied paths and user-authored files, so
+    // failures here are ordinary bad input, not bugs: report them the way the
+    // netlist path above does rather than panicking with a backtrace.
+    let input_vcd = match std::fs::File::open(&args.input_vcd) {
+        Ok(f) => f,
+        Err(e) => {
+            clilog::error!("cannot open input VCD {}: {e}", args.input_vcd);
+            std::process::exit(1);
+        }
+    };
     let mut bufrd = std::io::BufReader::with_capacity(65536, input_vcd);
     let header = {
         let mut vcd_parser = vcd_ng::Parser::new(&mut bufrd);
-        vcd_parser.parse_header().unwrap()
+        match vcd_parser.parse_header() {
+            Ok(h) => h,
+            Err(e) => {
+                clilog::error!(
+                    "cannot parse the header of input VCD {}: {e}",
+                    args.input_vcd
+                );
+                std::process::exit(1);
+            }
+        }
     };
     use std::io::{Seek, SeekFrom};
     let mut vcd_file = bufrd.into_inner();
-    vcd_file.seek(SeekFrom::Start(0)).unwrap();
+    if let Err(e) = vcd_file.seek(SeekFrom::Start(0)) {
+        clilog::error!("cannot rewind input VCD {}: {e}", args.input_vcd);
+        std::process::exit(1);
+    }
     let mut vcdflow = vcd_ng::FastFlow::new(vcd_file, 65536);
 
     // Resolve VCD scope
-    let top_scope = vcd_io::resolve_vcd_scope(
+    let top_scope = match vcd_io::resolve_vcd_scope(
         &header.items[..],
         args.input_vcd_scope.as_deref(),
         &design.netlistdb,
         args.top_module.as_deref(),
-    );
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            clilog::error!("{e:#}");
+            std::process::exit(1);
+        }
+    };
 
     // Match VCD inputs to netlist ports
     let (vcd2inp, _) = vcd_io::match_vcd_inputs(top_scope, &design.netlistdb);

--- a/src/sim/vcd_io.rs
+++ b/src/sim/vcd_io.rs
@@ -247,26 +247,34 @@ pub struct ParsedInputVCD {
 }
 
 /// Resolve the top scope from VCD header, either from user-specified path or auto-detection.
+/// Both failures here are ordinary bad input — a VCD whose scope doesn't match
+/// the design — so they are returned rather than panicked. See
+/// `docs/troubleshooting-vcd.md`, which exists because this is a common mistake.
 pub fn resolve_vcd_scope<'i>(
     header_items: &'i [ScopeItem],
     input_vcd_scope: Option<&str>,
     netlistdb: &NetlistDB,
     top_module: Option<&str>,
-) -> &'i Scope {
+) -> anyhow::Result<&'i Scope> {
     if let Some(scope_path) = input_vcd_scope {
         clilog::info!("Using user-specified VCD scope: {}", scope_path);
-        find_top_scope(header_items, scope_path).expect("Specified top scope not found in VCD.")
+        find_top_scope(header_items, scope_path).ok_or_else(|| {
+            anyhow::anyhow!(
+                "the VCD has no scope '{scope_path}' (given by --input-vcd-scope). \
+                 Check the scope path against the VCD's $scope declarations."
+            )
+        })
     } else {
         let top_module_name = top_module.unwrap_or("top");
         clilog::info!("No VCD scope specified - attempting auto-detection");
 
         match auto_detect_vcd_scope(header_items, netlistdb, top_module_name) {
-            Some((_path, scope)) => scope,
-            None => {
-                panic!(
-                    "Failed to auto-detect VCD scope. Please specify --input-vcd-scope manually."
-                );
-            }
+            Some((_path, scope)) => Ok(scope),
+            None => Err(anyhow::anyhow!(
+                "could not work out which VCD scope holds the inputs of '{top_module_name}'. \
+                 Pass --input-vcd-scope with the scope path to use. \
+                 See docs/troubleshooting-vcd.md."
+            )),
         }
     }
 }


### PR DESCRIPTION
Found by running an sv-test end-to-end on Metal, as you suggested.

## The bug
Three ways to hand `jacquard sim` a bad VCD, three panics-with-backtrace:

```rust
File::open(&args.input_vcd).unwrap()        // missing file
vcd_parser.parse_header().unwrap()          // truncated / not a VCD
panic!("Failed to auto-detect VCD scope…")  // scope doesn't match the design
```

All three are **ordinary bad input, not bugs** — and the netlist path a few lines above already reports exactly this class through `clilog::error!` + `exit(1)`. So it was inconsistent as well as unfriendly.

The scope one matters most: a VCD whose scope doesn't match the design is common enough that **`docs/troubleshooting-vcd.md` exists for it**. It was already printing a helpful message — it just wrapped it in a panic, so users saw `note: run with RUST_BACKTRACE=1` under advice that was already correct.

## The fix
`resolve_vcd_scope` returns `Result` (one caller, trivial ripple), and both its failures now say what to do — which scope was missing, or that `--input-vcd-scope` is the answer.

## Verified
| case | before | after |
|---|---|---|
| missing file | panic (101) | exit 1, `cannot open input VCD …: No such file or directory` |
| truncated VCD | panic (101) | exit 1, `cannot parse the header of input VCD …` |
| scope mismatch | panic (101) | exit 1, `could not work out which VCD scope holds the inputs of 'ok_tb'. Pass --input-vcd-scope…` |
| **matching VCD** | works | **still works** — SystemVerilog `always_ff` through the on-ramp, simulated on Metal, output VCD written |

`cargo test --lib`: 339 passed.

## Two more bugs found on the way, not fixed here
Reporting rather than scope-creeping:

1. **`ABC_NEW` wasm-traps** on `sv-tests/tests/chapter-9/9.2.2.4--always_ff.sv` — an expected-pass test. The SV parses fine (`slang: 0 errors`); the design optimizes to nothing (no ports, constant clock → `OPT_CLEAN` removes the flop) and then `abc_new` — the XAIGER path we adopted in #176 for `(* src *)` provenance — dies with `wasm unreachable`, surfacing as an unreadable wasm backtrace. A control with real ports synthesizes fine, so it's specific to the degenerate design.
2. **`staging.rs:122` asserts** on a design with no endpoints: `assertion failed: !unrealized_endpoint_nodes.is_empty()`. Should be a clean "design has no logic".

Both matter for the sv-tests plan: most sv-tests are **portless compile tests**, so they optimize to empty and would hit these two en masse — not because the SystemVerilog is unsupported.