### PR TITLE
fix(synth): report engine crashes readably instead of a wasm backtrace

### DIFF
--- a/src/synth.rs
+++ b/src/synth.rs
@@ -111,8 +111,16 @@ pub fn synthesize(design: &Path, opts: &SynthOptions) -> Result<PathBuf> {
         std::fs::write(wp.join(&base), &design_bytes)?;
         std::fs::write(wp.join("synth.ys"), &script)?;
 
-        run_yosys_wasm(&wasm_path, &share_dir, wp, &["yosys", "-s", "synth.ys"])
-            .context("running YoWASP Yosys synthesis")?;
+        // `-l`: Yosys tees its log to the file as well as stdout, so a crash can
+        // be reported with the pass that died (see `describe_wasm_trap`). Stdout
+        // is still inherited, so the user's view is unchanged.
+        run_yosys_wasm(
+            &wasm_path,
+            &share_dir,
+            wp,
+            &["yosys", "-l", "synth.log", "-s", "synth.ys"],
+        )
+        .context("running YoWASP Yosys synthesis")?;
 
         let produced = wp.join("gatelevel.gv");
         if !produced.exists() {
@@ -494,9 +502,53 @@ fn run_yosys_wasm(
         Err(e) => match e.downcast_ref::<I32Exit>() {
             Some(exit) if exit.0 == 0 => Ok(()),
             Some(exit) => bail!("Yosys exited with code {}", exit.0),
-            None => Err(e).context("Yosys WASM trap"),
+            // A trap is the engine dying — abort(), a failed assert, or memory
+            // unsafety — not an ordinary error. Yosys reports those itself and
+            // exits non-zero, which lands in the arm above. See gpu-eda/Jacquard#211.
+            None => bail!(describe_wasm_trap(&e, work_dir)),
         },
     }
+}
+
+/// Turn a wasm trap into something a person can act on.
+///
+/// `wasmtime`'s Display for a trap appends the whole wasm backtrace: dozens of
+/// `<wasm function 32210>` frames that are meaningless without the module's
+/// symbols, and which bury the one fact that matters — synthesis crashed, and
+/// where. Keep the trap kind, drop the frames, and name the last pass Yosys
+/// announced (from the `-l` log) so the report points at a culprit.
+fn describe_wasm_trap(e: &anyhow::Error, work_dir: &Path) -> String {
+    // Trap's Display already reads "wasm trap: …", so don't prefix it again.
+    let kind = e
+        .downcast_ref::<wasmtime::Trap>()
+        .map(|t| t.to_string())
+        .unwrap_or_else(|| "wasm trap".to_string());
+
+    let last_pass = std::fs::read_to_string(work_dir.join("synth.log"))
+        .ok()
+        .and_then(|log| {
+            log.lines()
+                .filter(|l| l.contains(". Executing "))
+                .next_back()
+                .map(|l| l.trim().to_string())
+        });
+
+    let mut msg = String::from("the synthesis engine crashed (");
+    msg.push_str(&kind);
+    msg.push(')');
+    match last_pass {
+        Some(pass) => {
+            msg.push_str("\n  it died in: ");
+            msg.push_str(&pass);
+        }
+        None => msg.push_str("\n  (no Yosys log was captured; see the output above)"),
+    }
+    msg.push_str(
+        "\n  A crash is an engine bug rather than a problem with your RTL, though \
+         unusual input can trigger one.\n  Please report it, with the design, at \
+         https://github.com/gpu-eda/Jacquard/issues",
+    );
+    msg
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes the reporting half of #211. Independent of the upstream question there (whether abc's empty-network trap is ours or stock), which is why it's worth doing on its own: **any** future engine crash now names its pass.

## Before
A trap inside `yosys.wasm` gave the user ~27 frames of:
```
25: 0x11ab83a - <unknown>!<wasm function 31558>
26: 0x118af27 - <unknown>!<wasm function 31193>
27:  0x116f4 - <unknown>!<wasm function 27>: wasm trap: wasm `unreachable` instruction executed
```
Meaningless without the module's symbols, and burying the two facts that matter: **synthesis crashed**, and **where**. The trap arm propagated wasmtime's error, whose `Display` appends the entire backtrace.

## After
```
the synthesis engine crashed (wasm trap: wasm `unreachable` instruction executed)
  it died in: 16.5.4. Executing ABC9.
  A crash is an engine bug rather than a problem with your RTL, though unusual
  input can trigger one.
  Please report it, with the design, at https://github.com/gpu-eda/Jacquard/issues
```
**27 wasm frames → 0.**

## How it names the pass
The synthesis run now passes `-l synth.log`. Yosys **tees** to the file as well as stdout, so stdout stays inherited and the user's view is otherwise unchanged; on a trap we read back the last `N. Executing …` line. `probe_help` already used this same mechanism, so it's an established pattern here rather than a new one.

Nice side effect: **it's better triage than I had by hand.** The culprit is `ABC9` — a *sub-pass* — not `abc_new`'s top level. Fed back to robtaylor/origin-shell#1.

## Why the framing is "engine bug, but input can trigger it"
Both halves are true and I didn't want to assert either alone: a synthesis engine crashing is always its bug, but #211's trigger is a portless module, so input clearly reaches it. Telling someone their RTL is at fault would be wrong; telling them it can't be involved would also be wrong.

## Verified
- The #211 repro produces the message above, **0 wasm frames** (was 27).
- A good design still synthesizes and **simulates on Metal**, output VCD written, no panics.
- `-l` doesn't disturb the `read_slang` probe.
- `cargo test --lib` and `--features synth`: **339 passed** each.

Ordinary Yosys errors are untouched — they exit non-zero and already reported cleanly (`ERROR: Module 'no_such_module' not found!`). That's also the evidence that the wasm's missing exception handling *isn't* what turns these into traps, recorded in origin-shell#1.