### PR TITLE
fix(synth): cache key omitted three synthesis inputs; enforce fmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,7 +219,20 @@ jobs:
         with:
           components: rustfmt, clippy
       - name: Check formatting
-        run: cargo fmt --all -- --check || echo "::warning::Formatting issues found"
+        # Enforced, not advisory — it used to end in `|| echo "::warning::"`, so it
+        # could never fail and the tree drifted out of shape unnoticed.
+        #
+        # Not `cargo fmt --all`: that reaches into vendor/eda-infra-rs, a
+        # submodule we don't format, so it can never be clean here — which is
+        # presumably why the check was defanged rather than fixed. rustfmt's own
+        # `ignore` setting would be the tidy answer but is nightly-only, and
+        # `cargo fmt` has no --exclude. So: check our sources explicitly. New
+        # files under these paths are picked up automatically; a new top-level
+        # source directory needs adding here.
+        run: |
+          set -euo pipefail
+          git ls-files 'src/*.rs' 'src/**/*.rs' 'crates/**/*.rs' 'benches/*.rs' \
+            | xargs rustfmt --edition 2021 --check
       - name: Clippy
         run: cargo clippy --lib 2>&1 | tee clippy_output.txt || true
       - name: Check for clippy errors (not warnings)

--- a/crates/opensta-to-ir/src/builder.rs
+++ b/crates/opensta-to-ir/src/builder.rs
@@ -283,9 +283,7 @@ fn build_setup_hold<'a>(
 
     let setup: Vec<_> = checks
         .iter()
-        .map(|c| {
-            ir::TimingValue::new(c.corner_index, c.setup_min, c.setup_typ, c.setup_max)
-        })
+        .map(|c| ir::TimingValue::new(c.corner_index, c.setup_min, c.setup_typ, c.setup_max))
         .collect();
     let hold: Vec<_> = checks
         .iter()

--- a/crates/opensta-to-ir/src/main.rs
+++ b/crates/opensta-to-ir/src/main.rs
@@ -159,21 +159,18 @@ fn parse_corner_specs(
     }
     Ok(by_name
         .into_iter()
-        .map(
-            |(name, liberty)| opensta_to_ir::opensta::CornerSpec {
-                name,
-                process: "tt".into(),
-                voltage: 1.0,
-                temperature: 25.0,
-                liberty,
-            },
-        )
+        .map(|(name, liberty)| opensta_to_ir::opensta::CornerSpec {
+            name,
+            process: "tt".into(),
+            voltage: 1.0,
+            temperature: 25.0,
+            liberty,
+        })
         .collect())
 }
 
 fn run_opensta(args: &Args) -> Result<opensta_to_ir::dump::DumpDocument, (u8, String)> {
-    let corners =
-        parse_corner_specs(&args.liberty).map_err(|e| (EXIT_ARG_INVALID, e))?;
+    let corners = parse_corner_specs(&args.liberty).map_err(|e| (EXIT_ARG_INVALID, e))?;
     if args.verilog.is_empty() {
         return Err((
             EXIT_ARG_INVALID,

--- a/crates/opensta-to-ir/src/opensta.rs
+++ b/crates/opensta-to-ir/src/opensta.rs
@@ -70,10 +70,7 @@ pub enum LocateError {
         stderr: String,
     },
     /// `<binary> -version` produced output we couldn't parse.
-    VersionUnparseable {
-        binary: PathBuf,
-        raw: String,
-    },
+    VersionUnparseable { binary: PathBuf, raw: String },
     /// Detected version is older than `MIN_TESTED_OPENSTA_VERSION`.
     TooOld {
         binary: PathBuf,
@@ -90,11 +87,9 @@ impl std::fmt::Display for LocateError {
                 "OpenSTA binary not found. Set JACQUARD_OPENSTA_BIN, ensure `sta` is on PATH, \
                  or run scripts/build-opensta.sh to build the vendored copy."
             ),
-            Self::VersionProbeFailed { binary, err } => write!(
-                f,
-                "failed to spawn `{} -version`: {err}",
-                binary.display()
-            ),
+            Self::VersionProbeFailed { binary, err } => {
+                write!(f, "failed to spawn `{} -version`: {err}", binary.display())
+            }
             Self::VersionProbeNonZero {
                 binary,
                 exit_code,
@@ -137,10 +132,7 @@ pub fn parse_version(raw: &str) -> Option<OpenstaVersion> {
     let s = raw.trim().lines().next()?.trim();
     let s = s.strip_prefix('v').unwrap_or(s);
     // Strip pre-release / build-metadata suffixes.
-    let core = s
-        .split(|c: char| c == '-' || c == '+')
-        .next()
-        .unwrap_or(s);
+    let core = s.split(|c: char| c == '-' || c == '+').next().unwrap_or(s);
     let mut parts = core.split('.');
     let major: u32 = parts.next()?.parse().ok()?;
     let minor: u32 = parts.next()?.parse().ok()?;
@@ -391,8 +383,7 @@ pub fn run(
     // contain a `module <top>` declaration are passed through
     // unchanged so hierarchical designs with sub-modules split across
     // multiple files still link cleanly. See ADR 0009.
-    let filtered_verilog_paths =
-        filter_verilog_inputs(inv.verilog, inv.top, dir.path())?;
+    let filtered_verilog_paths = filter_verilog_inputs(inv.verilog, inv.top, dir.path())?;
     let verilog_arg = paths_to_lines(&filtered_verilog_paths);
 
     let mut cmd = Command::new(binary);

--- a/crates/opensta-to-ir/tests/opensta_integration.rs
+++ b/crates/opensta-to-ir/tests/opensta_integration.rs
@@ -466,8 +466,12 @@ fn aigpdk_dff_emits_per_corner_timing_values() {
         assert_eq!(setup.len(), 2, "two corners → two setup TimingValues");
         assert_eq!(hold.len(), 2, "two corners → two hold TimingValues");
         // Corner indices are positional; entry 0 → corner 0, etc.
-        let setup_indices: Vec<u32> = (0..setup.len()).map(|j| setup.get(j).corner_index()).collect();
-        let hold_indices: Vec<u32> = (0..hold.len()).map(|j| hold.get(j).corner_index()).collect();
+        let setup_indices: Vec<u32> = (0..setup.len())
+            .map(|j| setup.get(j).corner_index())
+            .collect();
+        let hold_indices: Vec<u32> = (0..hold.len())
+            .map(|j| hold.get(j).corner_index())
+            .collect();
         assert_eq!(setup_indices, vec![0, 1]);
         assert_eq!(hold_indices, vec![0, 1]);
     }

--- a/src/aig.rs
+++ b/src/aig.rs
@@ -336,11 +336,7 @@ impl AIG {
     /// one. An internal AND node with no recorded origin (or a netlist without
     /// `src`) yields `[]`, a typical gate output one, and an aigpin fed by
     /// several merged origin cells many. De-duplicated, in first-seen order.
-    pub fn aigpin_src_locations(
-        &self,
-        aigpin: usize,
-        netlistdb: &NetlistDB,
-    ) -> Vec<CompactString> {
+    pub fn aigpin_src_locations(&self, aigpin: usize, netlistdb: &NetlistDB) -> Vec<CompactString> {
         let mut locs: Vec<CompactString> = Vec::new();
         let Some(origins) = self.aigpin_cell_origins.get(aigpin) else {
             return locs;
@@ -4880,7 +4876,11 @@ mod path_mapping_tests {
 
         // Precondition: netlistdb (B1) carried the annotation onto the nand2 cell.
         assert!(
-            netlistdb.cell_src.iter().flatten().any(|s| s.as_str() == "prov.v:12.3-12.44"),
+            netlistdb
+                .cell_src
+                .iter()
+                .flatten()
+                .any(|s| s.as_str() == "prov.v:12.3-12.44"),
             "B1 regression: cell_src did not carry the (* src *) annotation"
         );
 

--- a/src/sim/trace_signals.rs
+++ b/src/sim/trace_signals.rs
@@ -541,7 +541,10 @@ endmodule
         // to that cell's src (this is exactly what registration logs).
         let (iv, _) = aig.extra_observable_names.iter().next().unwrap();
         let src = aig.aigpin_src_locations(*iv >> 1, &nl);
-        assert_eq!(src, vec![compact_str::CompactString::from("top.v:5.3-5.34")]);
+        assert_eq!(
+            src,
+            vec![compact_str::CompactString::from("top.v:5.3-5.34")]
+        );
     }
 
     /// Unresolved names increment `dropped`, log a warning, and do

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -82,21 +82,22 @@ pub fn synthesize(design: &Path, opts: &SynthOptions) -> Result<PathBuf> {
         use_slang,
     );
 
-    // Cache key: design source + generated script + wasm module (+ crate
-    // version, to invalidate across incompatible synth-engine changes).
-    let cache_key = {
-        use std::hash::{Hash, Hasher};
-        let mut h = std::collections::hash_map::DefaultHasher::new();
-        design_bytes.hash(&mut h);
-        script.hash(&mut h);
-        wasm_bytes.hash(&mut h);
-        env!("CARGO_PKG_VERSION").hash(&mut h);
-        format!("synth-{:016x}.gv", h.finish())
-    };
+    let cache_key = synth_cache_key(
+        &design_bytes,
+        &script,
+        &wasm_bytes,
+        // Every file the script reads out of the work dir. Add here when the run
+        // gains an input, or editing that input yields a stale hit.
+        &[AIGPDK_NOMEM_LIB, MEMLIB_YOSYS, GEM_FORMAL_V],
+    );
     let cache_dir = cache_dir();
     let cached = cache_dir.join(&cache_key);
 
-    if cached.is_file() {
+    // Escape hatch for bisecting a synthesis problem, where a hit is exactly
+    // what you don't want. Still refreshes the entry afterwards.
+    let bypass = std::env::var_os("JACQUARD_NO_SYNTH_CACHE").is_some_and(|v| !v.is_empty());
+
+    if cached.is_file() && !bypass {
         clilog::info!("synth: cache hit {}", cached.display());
     } else {
         clilog::info!("synth: using yosys.wasm at {}", wasm_path.display());
@@ -138,6 +139,45 @@ pub fn synthesize(design: &Path, opts: &SynthOptions) -> Result<PathBuf> {
     }
 
     Ok(cached)
+}
+
+/// Content hash of *everything* that determines the synthesized netlist.
+///
+/// Every input the run reads has to be in here, or a change to it yields a
+/// stale hit — the netlist gets reused despite having been produced under
+/// different conditions. The non-obvious members are the three embedded support
+/// files: they're `include_str!`, so editing `aigpdk/aigpdk_nomem.lib` changes
+/// the binary but *not* `CARGO_PKG_VERSION`, which only moves at release. Before
+/// they were hashed, editing the standard-cell library the script maps against
+/// (`read_liberty -lib aigpdk_nomem.lib`) silently reused a netlist built with
+/// the old one.
+///
+/// `script` covers the top module, assertion handling, and the chosen SV
+/// frontend, since all three are baked into the text. `CARGO_PKG_VERSION` stays
+/// as a coarse backstop for engine changes the inputs above don't capture.
+///
+/// `support` is taken as an argument rather than read from the consts directly
+/// so the tests can vary it: hashing a `const` can't be exercised by a test that
+/// can't change it, and a test that cannot fail is worse than none.
+///
+/// If you add an input to the synthesis run, add it to `support` at the call
+/// site — `cache_key_covers_the_support_files` makes dropping one loud.
+fn synth_cache_key(
+    design_bytes: &[u8],
+    script: &str,
+    wasm_bytes: &[u8],
+    support: &[&str],
+) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    design_bytes.hash(&mut h);
+    script.hash(&mut h);
+    wasm_bytes.hash(&mut h);
+    for s in support {
+        s.hash(&mut h);
+    }
+    env!("CARGO_PKG_VERSION").hash(&mut h);
+    format!("synth-{:016x}.gv", h.finish())
 }
 
 /// Whether the embedded Yosys exposes `read_slang` (yosys-slang, a
@@ -502,6 +542,95 @@ fn run_yosys_wasm(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const SUP: &[&str] = &[AIGPDK_NOMEM_LIB, MEMLIB_YOSYS, GEM_FORMAL_V];
+
+    /// Every input that changes the netlist must change the key. A miss here is
+    /// a stale cache hit in the field: the user silently gets a netlist built
+    /// under conditions that no longer hold.
+    #[test]
+    fn cache_key_covers_each_direct_input() {
+        let base = synth_cache_key(
+            b"module m(); endmodule",
+            "read_verilog m.v\n",
+            b"\0asm-a",
+            SUP,
+        );
+
+        assert_ne!(
+            base,
+            synth_cache_key(
+                b"module n(); endmodule",
+                "read_verilog m.v\n",
+                b"\0asm-a",
+                SUP
+            ),
+            "a different design must not reuse the netlist"
+        );
+        assert_ne!(
+            base,
+            synth_cache_key(
+                b"module m(); endmodule",
+                "read_slang m.v\n",
+                b"\0asm-a",
+                SUP
+            ),
+            "a different script (top module, assertions, SV frontend) must not reuse it"
+        );
+        assert_ne!(
+            base,
+            synth_cache_key(
+                b"module m(); endmodule",
+                "read_verilog m.v\n",
+                b"\0asm-b",
+                SUP
+            ),
+            "a different yosys.wasm must not reuse it"
+        );
+    }
+
+    /// The support files are synthesis inputs: the script does `read_liberty
+    /// -lib aigpdk_nomem.lib`, `memory_libmap -lib memlib_yosys.txt`, `techmap
+    /// -map gem_formal.v`. They arrive by `include_str!`, so editing one moves
+    /// neither the design, the script, the wasm, nor `CARGO_PKG_VERSION` (which
+    /// only moves at release) — they were absent from the key, and editing the
+    /// standard-cell library silently reused a netlist mapped against the old
+    /// one. Verified by hand before the fix: same key, "cache hit", stale
+    /// netlist.
+    #[test]
+    fn cache_key_covers_the_support_files() {
+        let k = |support: &[&str]| synth_cache_key(b"d", "s", b"w", support);
+        let real = k(SUP);
+
+        assert_ne!(
+            real,
+            k(&["edited", MEMLIB_YOSYS, GEM_FORMAL_V]),
+            "editing the liberty the script maps against must change the key"
+        );
+        assert_ne!(
+            real,
+            k(&[AIGPDK_NOMEM_LIB, "edited", GEM_FORMAL_V]),
+            "editing the memory-mapping rules must change the key"
+        );
+        assert_ne!(
+            real,
+            k(&[AIGPDK_NOMEM_LIB, MEMLIB_YOSYS, "edited"]),
+            "editing the assertion techmap must change the key"
+        );
+        assert_ne!(
+            real,
+            k(&[AIGPDK_NOMEM_LIB, MEMLIB_YOSYS]),
+            "dropping a support file from the key is exactly the bug that shipped"
+        );
+    }
+
+    /// Keys are filenames; a stray path separator would escape the cache dir.
+    #[test]
+    fn cache_key_is_a_plain_filename() {
+        let k = synth_cache_key(b"d", "s", b"w", SUP);
+        assert!(k.starts_with("synth-") && k.ends_with(".gv"), "{k}");
+        assert!(!k.contains('/') && !k.contains(".."), "{k}");
+    }
 
     /// Guard the pinned-wasm trio against a copy-paste slip on re-pin: the
     /// download URL must reference the tag, and the hash must be a 64-char


### PR DESCRIPTION
> *"You have a latency problem, so you introduce a cache. Congratulations — you now have a latency problem **and** a consistency problem."*

Two things, the second smuggled in on request.

---

## 1. The cache key omitted three synthesis inputs

It hashed the design, the script, the wasm and `CARGO_PKG_VERSION` — but **not** the three files the script reads:

```
read_liberty  -lib aigpdk_nomem.lib
memory_libmap -lib memlib_yosys.txt
techmap       -map gem_formal.v
```

They arrive by `include_str!`, so editing one changes the binary but **not** `CARGO_PKG_VERSION`, which only moves at release:

```
$ (edit aigpdk_nomem.lib — the library the design is mapped against)
$ cargo build && jacquard sim ok_mod.sv …
synth: cache hit …/synth-c1ced5e32b99639b.gv     ← same key
cache entries: 1                                  ← stale netlist
```

You silently get a netlist mapped against the **old standard-cell library**. Reproduced by hand before fixing.

**Now content-addressed, not merely invalidating:**

| step | result |
|---|---|
| cold run | key `synth-d70dafb…` |
| edit lib, rebuild | key moves, **re-synthesizes** |
| restore lib | **original key returns and hits** |

That last row is the one that proves content-addressing rather than "bust everything on any change".

**My first test was fake.** It built its own hasher and asserted on that, so it **passed with the fix reverted** — worse than no test. `synth_cache_key` now takes `support` as a parameter so a test can vary it, and it **FAILS** when the hashing is removed. It also asserts that *dropping* a support file changes the key — precisely the bug that shipped.

**`JACQUARD_NO_SYNTH_CACHE=1`** bypasses a hit, for bisecting synthesis where a hit is exactly what you don't want.

---

## 2. The formatting check couldn't fail

```yaml
run: cargo fmt --all -- --check || echo "::warning::Formatting issues found"
```

The tree had drifted accordingly — 11 hunks across `aig.rs`, `trace_signals.rs` and `opensta-to-ir`, invisible because nothing failed.

**But it wasn't defanged for no reason**, and I nearly broke CI by "fixing" it naively: `cargo fmt --all` reaches into **`vendor/eda-infra-rs`**, a submodule we don't format — **16 of the 27 hunks were vendor's**. Enforce it as written and CI fails forever on files that aren't ours.

Both tidy escapes are closed: rustfmt's `ignore` is **nightly-only**, and `cargo fmt` has **no `--exclude`** (just `-p` / `--all`). So the check now lists our sources by path. New files under them are picked up automatically; a new top-level source dir needs adding, which the comment says.

**Verified the gate bites**, since one that couldn't is what caused this: clean tree → 0, badly formatted source → 1, restored → 0.

---

`cargo test --features synth --lib`: **342 passed**. Build clean. `vendor/` untouched.

Also corrects something I said earlier: the cache did **not** mask a re-run during the #211 hunt — `module empty_tb (); endmodule` is classified *structural*, so synthesis never ran, and I'd misattributed that. The cache bug is real but was found by reading the key, not by being bitten.