### PR TITLE
ci: make CI merge-queue-ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ on:
   # No base-branch filter: run CI on every PR regardless of its base, so stacked
   # PRs (based on other feature branches) get CI automatically.
   pull_request:
+  # Required for the merge queue: the queue validates each entry by firing
+  # `merge_group`, and every check `main` requires must run here or an entry sits
+  # in the queue forever waiting for a status that can never arrive.
+  merge_group:
   workflow_dispatch:
 
 permissions:
@@ -28,7 +32,11 @@ permissions:
 # up on the billed GPU + macOS runners.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never cancel a merge-queue run. The queue is blocking on these checks, and a
+  # cancelled check reports as failed — which evicts the PR from the queue rather
+  # than merely delaying it. PR and push runs stay cancellable: superseding them
+  # is the point.
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -42,12 +50,17 @@ jobs:
     name: Detect code changes
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      # A merge-queue entry is a candidate `main`, and the filter has no
+      # meaningful base to diff against there. Run everything rather than trust
+      # it: the failure mode of over-running is wasted CI, while a mis-based
+      # filter would *skip tests on the commit about to become main*.
+      code: ${{ github.event_name == 'merge_group' && 'true' || steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: false
       - uses: dorny/paths-filter@v3
+        if: github.event_name != 'merge_group'
         id: filter
         with:
           # `every`: a changed file counts toward `code` only if it matches ALL


### PR DESCRIPTION
Prep only — enabling the queue is a branch-protection change, and **this must land first** or every PR would hang in it.

## Why
We hit the same wall repeatedly. `main` has **`strict: true`** (require up to date) and we **rebase-merge**, so N ready PRs land strictly serially: rebase → wait for CI → merge → *everything else goes BEHIND again*. Five PRs are queued behind this right now.

It's cost us before: the #202/#204 stack — deleting #202's branch **auto-closed #204**, and GitHub refuses to reopen *or* retarget a closed PR, so it had to be re-filed as #205. And stacking couldn't have helped anyway: rebase-merge rewrites the parent's SHAs, so a stacked child always sits on commits that no longer exist.

## Enabling the queue today would hang every PR
Three things break, all silent:

1. **No `merge_group` trigger.** The queue validates entries by firing `merge_group`. Without it, none of the **seven required checks** (`Lint`, `Unit Tests`, `Metal Tests`, `CUDA Tests`, `HIP Tests`, `Benchmarks`, `MCU SoC Metal Simulation`) ever run — entries wait forever for statuses that cannot arrive.

2. **`cancel-in-progress: true` would evict PRs.** Cancelling is right for PR/push runs — superseding is the point. But a cancelled check reports as **failed**, and a failed check *removes the PR from the queue* rather than delaying it. Now `cancel-in-progress: ${{ github.event_name != 'merge_group' }}`.

3. **The path filter has no base in a `merge_group`.** Forced `code=true` there: over-running wastes CI, whereas a mis-based filter would **skip tests on the very commit about to become `main`**. Same wrong-but-loud reasoning as the denylist it sits beside.

## Audited the rest for event assumptions
- **Docs deploy + version-list refresh** are gated on `push && refs/heads/main` → a queue entry correctly won't publish. ✅
- **Metal runner selection** keys off `github.ref == 'refs/heads/main'` or a PR label; in a `merge_group` neither holds, so entries land on the self-hosted **`macos-runner-1`** rather than `macos-latest-xlarge`. Works, but it's a latency/cost call — flagged, not changed, since it spends money.

## After this lands
Enable **Require merge queue** on `main`. Two things worth deciding then:
- **Drop `strict` (require up-to-date)** — the queue does that job properly, and keeping both is redundant.
- **Runner cost**: the queue re-runs the full required suite per entry, on top of each PR's own run. On contended self-hosted runners that's the main risk, and the Metal-runner question above feeds into it.

The first queued PR is the real test — I can't exercise a merge queue without one.