### PR TITLE
ci: trim cosim edge counts to the minimum needed (mcu_soc + JTAG replay)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -592,10 +592,12 @@ jobs:
           # ground-truth GPU-execution time from Metal device timestamps
           # (GPUStartTime/GPUEndTime). Report-only — surfaced in the step
           # summary below; no perf gate. See docs/cosim-perf-report.md.
+          # The boot marker "nyaa" prints at ~edge 201k (measured); 250k caps it
+          # with headroom without running to completion the way 500k did.
           target/release/jacquard cosim \
             tests/mcu_soc/data/6_final.v \
             --config tests/mcu_soc/sim_config.json --top-module top \
-            --max-clock-edges 500000 \
+            --max-clock-edges 250000 \
             --cosim-perf-json cosim_perf.json \
             2>&1 | tee cosim_output.txt
 
@@ -606,7 +608,7 @@ jobs:
           # summary. Never fails the job (no regression gate — see
           # docs/cosim-perf-report.md for the rationale and follow-up gating).
           {
-            echo "## Cosim perf — mcu_soc (Metal, 500K edges)"
+            echo "## Cosim perf — mcu_soc (Metal, 250K edges)"
             echo '```json'
             cat cosim_perf.json 2>/dev/null || echo '{ "error": "no perf report produced" }'
             echo '```'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -770,6 +770,11 @@ jobs:
         timeout-minutes: 40
         run: |
           set -o pipefail
+          # The server blocks on the socket (advances the design clock only per
+          # bitbang command, not free-running), so it is as deterministic as the
+          # replay: same 11759-byte stream, CAFEBABE latched by ~110k edges
+          # (measured locally: passes at 100k and 150k). 150k, matching the
+          # replay job, rather than idling to 400k.
           ./target/release/jacquard cosim \
             tests/jtag_minimal/data/top.pnl.v \
             --config tests/jtag_minimal/sim_config.json \
@@ -778,7 +783,7 @@ jobs:
             --jtag-hold-cycles 8 \
             --trace-signals tests/jtag_minimal/trace_signals.txt \
             --output-vcd tests/jtag_minimal/data/cosim_server_trace.vcd \
-            --max-clock-edges 400000 \
+            --max-clock-edges 150000 \
             > jtag_minimal_server.log 2>&1 &
           SERVER_PID=$!
           python3 tests/jtag_minimal/scripts/bitbang_client.py \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -716,6 +716,9 @@ jobs:
         timeout-minutes: 40
         run: |
           set -o pipefail
+          # The 11759-byte replay feeds ~94k edges; data0_obs latches 0xCAFEBABE
+          # by ~110k (measured: passes at 120k, fails at 100k). 150k caps it with
+          # headroom rather than running to 400k idle.
           target/release/jacquard cosim \
             tests/jtag_minimal/data/top.pnl.v \
             --config tests/jtag_minimal/sim_config.json \
@@ -724,7 +727,7 @@ jobs:
             --jtag-hold-cycles 8 \
             --trace-signals tests/jtag_minimal/trace_signals.txt \
             --output-vcd tests/jtag_minimal/data/cosim_trace.vcd \
-            --max-clock-edges 400000 \
+            --max-clock-edges 150000 \
             2>&1 | tee jtag_minimal_cosim.log
       - name: Assert data0_obs == 0xCAFEBABE
         run: |


### PR DESCRIPTION
Several cosim jobs ran far more clock edges than their pass condition needs — all run to completion (no golden VCD, just an assertion/grep), so the excess was pure wall-clock. Each cap is set just above where the pass condition is actually met, measured locally on the metal binary.

| Job | Old | New | Pass condition met at |
|---|---|---|---|
| mcu-soc-metal | 500k | 250k | boot marker `nyaa` ~201k |
| jtag-minimal-cosim (replay) | 400k | 150k | `data0_obs`=0xCAFEBABE ~110k (fails 100k, passes 120k) |
| jtag-minimal-cosim-server | 400k | 150k | same stream over socket; passes 100k & 150k |

The `--jtag-server` blocks on socket reads (advances the clock only per bitbang command), so it is as deterministic as the replay — verified by running the live client/server locally.

Left as-is: `jtag-minimal-openocd` (8M) — its server is killed when real OpenOCD finishes, so the cap is a rarely-binding ceiling paced by OpenOCD's remote_bitbang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)