### PR TITLE
ci: sccache + nproc/2 build parallelism (de-flake mt-kahypar OOM, cache C++)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -26,3 +26,16 @@ self-hosted-runner:
     - amd
     - rocm
     - gfx1036
+
+# Suppress two shellcheck patterns in test.yml that are intentional, not bugs.
+# Scoped to this one file so every other workflow keeps full shellcheck coverage
+# (SC2086 in particular catches real unquoted-variable bugs elsewhere).
+#   SC2046: `make -j$(nproc)` — nproc emits a single integer, so the flagged
+#           word-splitting can't happen; this is the idiomatic parallel-make form.
+#   SC2086: unquoted `$TIMING_ARGS` — deliberately word-split so an empty value
+#           passes no args and a set value passes the flag+path as two args.
+paths:
+  .github/workflows/test.yml:
+    ignore:
+      - 'shellcheck reported issue in this script: SC2046'
+      - 'shellcheck reported issue in this script: SC2086'

--- a/.github/actions/setup-sccache/action.yml
+++ b/.github/actions/setup-sccache/action.yml
@@ -1,0 +1,44 @@
+name: Setup sccache
+description: >
+  Install sccache with the GitHub Actions cache backend and route rustc, cc-rs
+  C/C++, and nvcc through it, plus bound build parallelism to nproc/2.
+
+  One wrapper covers all three: cc-rs (>= 1.0.84, ours is 1.2.x) honours
+  RUSTC_WRAPPER for its C/C++ and nvcc invocations via rustc_wrapper_fallback,
+  so the heavy mt-kahypar/TBB/boost objects get cached on warm runs. The
+  nproc/2 job cap bounds peak memory of those parallel -O3 C++ TUs on *cold*
+  builds (a cache miss still compiles), which is what was OOM-killing runners.
+
+inputs:
+  multiarch:
+    description: >
+      Set SCCACHE_CACHE_MULTIARCH=1. Needed for multi-arch device code (the
+      all-major CUDA build) so nvcc objects still cache.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Installs the sccache binary, wires the GHA cache tokens, and prints
+    # `sccache --show-stats` in its post-run step (so cache hit-rates are
+    # visible without a manual step).
+    - uses: mozilla-actions/sccache-action@v0.0.10
+
+    - name: Configure sccache + build parallelism
+      shell: bash
+      run: |
+        set -euo pipefail
+        n=$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null \
+              || sysctl -n hw.ncpu 2>/dev/null || echo 2)
+        jobs=$(( n / 2 )); [ "$jobs" -lt 1 ] && jobs=1
+        {
+          echo "CARGO_BUILD_JOBS=$jobs"
+          echo "RUSTC_WRAPPER=sccache"
+          echo "SCCACHE_GHA_ENABLED=true"
+        } >> "$GITHUB_ENV"
+        echo "sccache enabled; CARGO_BUILD_JOBS=$jobs (of $n cpus)"
+        if [ "${{ inputs.multiarch }}" = "true" ]; then
+          echo "SCCACHE_CACHE_MULTIARCH=1" >> "$GITHUB_ENV"
+          echo "multi-arch device-code caching enabled"
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,18 +104,29 @@ jobs:
       - name: Cache cargo
         uses: actions/cache@v5
         with:
+          # Registry/git only — sccache (below) owns compiled artifacts, so
+          # caching target/ too would double-store and fight sccache for the
+          # 10 GB repo cache budget. Key bumped (-sccache) to start a fresh,
+          # target-less cache rather than restore an old target/-laden one.
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
           # Per-config key so the divergent dependency trees (wasmtime for synth,
           # cust for cuda, …) don't thrash a shared cache. LLVM_VERSION is only
           # set for the metal build; empty elsewhere.
-          key: ${{ runner.os }}-cargo-build-${{ matrix.config }}-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-build-sccache-${{ matrix.config }}-llvm${{ env.LLVM_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-build-${{ matrix.config }}-
+            ${{ runner.os }}-cargo-build-sccache-${{ matrix.config }}-
+
+      # sccache caches rustc + the heavy mt-kahypar/TBB/boost C++ (cc-rs) and
+      # nvcc; the nproc/2 cap bounds cold-build C++ memory. multiarch for the
+      # all-major CUDA device code so nvcc objects still cache.
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
+        with:
+          multiarch: ${{ matrix.config == 'cuda' }}
 
       - name: Build jacquard
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,15 +119,21 @@ jobs:
       - name: Cache cargo
         uses: actions/cache@v5
         with:
+          # Registry/git + the installed tool binaries (mdbook/d2 land in
+          # ~/.cargo/bin). sccache owns compiled artifacts, so target/ is not
+          # cached here — see setup-sccache.
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-docs-sccache-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-docs-
+            ${{ runner.os }}-cargo-docs-sccache-
+
+      # cargo doc compiles the dependency graph, including mt-kahypar's -O3 C++.
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
 
       - name: Build cargo docs
         run: cargo doc --no-deps --lib

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,15 +50,17 @@ jobs:
       - name: Cache cargo
         uses: actions/cache@v5
         with:
+          # Registry/git only — sccache owns compiled artifacts (see setup-sccache).
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-sccache-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-sccache-
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
       - name: Run library tests
         run: cargo test --lib
       # Lightweight sub-crates that carry dev-dependencies are not workspace
@@ -87,15 +89,17 @@ jobs:
       - name: Cache cargo
         uses: actions/cache@v5
         with:
+          # Registry/git only — sccache owns compiled artifacts (see setup-sccache).
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-synth-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-synth-sccache-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-synth-
+            ${{ runner.os }}-cargo-synth-sccache-
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
       - name: Build jacquard (synth on-ramp, no GPU)
         run: cargo build --release --features synth --bin jacquard
       - name: Input-classifier unit tests (synth feature)
@@ -218,6 +222,12 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      # clippy still compiles deps, and mt-kahypar's build.rs forces -O3 C++
+      # regardless of profile — so this job carries the same OOM/cache profile
+      # as a release build. rustfmt (next step) doesn't go through cargo, so the
+      # wrapper is a no-op there.
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
       - name: Check formatting
         # Enforced, not advisory — it used to end in `|| echo "::warning::"`, so it
         # could never fail and the tree drifted out of shape unnoticed.
@@ -259,15 +269,17 @@ jobs:
       - name: Cache cargo
         uses: actions/cache@v5
         with:
+          # Registry/git only — sccache owns compiled artifacts (see setup-sccache).
           path: |
             ~/.cargo/bin/
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-bench-sccache-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-bench-
+            ${{ runner.os }}-cargo-bench-sccache-
+      - name: Setup sccache
+        uses: ./.github/actions/setup-sccache
       - name: Run benchmarks
         run: |
           cargo bench --bench event_buffer -- --noplot 2>&1 | tee benchmark_results.txt


### PR DESCRIPTION
## What

Two changes to every from-source **compile** job (the `build.yml` matrix —
cpu/cuda/hip-rocm/metal — plus `test.yml`'s Unit/Synth-on-ramp/Lint/Benchmarks
and the docs `cargo doc`):

1. **`CARGO_BUILD_JOBS = nproc/2`** — bounds peak memory of `cc-rs`'s parallel
   `-O3` C++ compiles. `mt-kahypar`'s `build.rs` compiles hundreds of heavy TUs
   at `-O3` (hardcoded, so even `cargo test --lib` / `clippy` / `cargo doc` hit
   it), and at full `-j` the concurrent `cc1plus` processes intermittently
   OOM-kill the runner (bare *"compilation terminated"*, no diagnostic — the
   flake seen on PR #227). `cc-rs` caps its C++ parallelism at `NUM_JOBS`, which
   cargo derives from `-j`.

2. **sccache** (GitHub Actions cache backend) via a new
   `.github/actions/setup-sccache` composite. `RUSTC_WRAPPER=sccache` routes
   rustc, the `cc-rs` C/C++ (mt-kahypar/TBB/boost), **and** nvcc through sccache
   in one variable — `cc-rs` ≥ 1.0.84 (ours is 1.2.61) honours `RUSTC_WRAPPER`
   via `rustc_wrapper_fallback`. Warm runs skip the heavy C++ compile entirely,
   which also closes the cold-compile OOM window. `SCCACHE_CACHE_MULTIARCH=1`
   for the all-major CUDA build so nvcc objects still cache.

`target/` is dropped from the touched `actions/cache` blocks (keys bumped to
`-sccache-`): sccache owns compiled artifacts now, and double-storing `target/`
would fight sccache for the 10 GB repo cache budget. The cargo registry/git
cache stays. `.metal` shader compilation isn't cacheable (it's `xcrun metal`,
not `cc-rs`) — expected, small fraction.

Scope: GitHub-hosted compile jobs only. Self-hosted GPU runners just download
prebuilt artifacts, so they don't compile and aren't touched. `release.yml` is a
deliberate fast-follow.

## Validation

- **This run (cold cache):** should be green, and each job's `sccache
  --show-stats` (printed by the action's post-step) should show non-zero compile
  *requests* — proving sccache is engaged even before it's warm.
- **Warm run:** a second run should show non-zero cache **hits** and a faster,
  lower-memory C++ build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
