### PR TITLE
docs(dev): warn that a partial submodule init silently cripples the build

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -12,6 +12,19 @@ for the backend you're building. Nothing else.
 git submodule update --init --recursive
 ```
 
+> **The submodule init is load-bearing, not boilerplate — and its failure is
+> silent.** `build.rs` bakes the standard-cell pin tables into the binary by
+> reading the vendored PDK cell libraries (`vendor/sky130_fd_sc_hd`,
+> `vendor/gf180mcu_fd_sc_mcu7t5v0`, `vendor/gf180mcu_fd_sc_mcu9t5v0`). If one of
+> those submodules is absent, `build.rs` skips it and the build **succeeds** —
+> but the resulting binary carries an incomplete pin table and **panics at
+> runtime** on any netlist using an omitted cell (`Unknown SKY130 cell (no
+> pin-table entry for type '…')`), which looks like a Jacquard bug rather than a
+> missing checkout. So the `--recursive` above is required, and any script that
+> inits submodules *selectively* — a CI matrix that only needs
+> `vendor/eda-infra-rs`, or a historical-build / bisect harness — must also init
+> the PDK cell submodules, or it will silently produce a crippled binary.
+
 The GPU backend is a feature, and you pick exactly one:
 
 ```sh


### PR DESCRIPTION
Persists a learning from this week's perf-bisect so the next person (or the #218 perf harness) doesn't lose the time I did.

## The gotcha
`build.rs` bakes the standard-cell pin tables into the binary from the vendored PDK cell libraries (`vendor/sky130_fd_sc_hd`, `vendor/gf180mcu_fd_sc_mcu{7,9}t5v0`). If one of those submodules is **absent**, `build.rs` skips it and **the build succeeds** — but the binary carries an incomplete pin table and **panics at runtime**:

```
Unknown SKY130 cell (no pin-table entry for type 'clkinv'): ...
```

Which reads as a Jacquard bug, not a missing checkout.

## Why it's worth a note
It cost me three wrong conclusions in one session. Bisecting mcu_soc cosim performance across tags, I built each historical tag with only `vendor/eda-infra-rs` initialized — the pattern CI uses for speed, which I copied into the bisect harness. Every old binary panicked on the netlist, and I "concluded" no pre-cutover build could even map the design. It was nonsense: adding `vendor/sky130_fd_sc_hd` made v0.1.0 and v0.2.4 run first try, and the real answer (no regression) fell out immediately.

The `git submodule update --init --recursive` in the Build section already does the right thing for a fresh clone — the trap is **selective** init: a CI matrix, or a bisect/historical-build harness. The note points that out right where it matters.

Verified: doc-link checker passes. Docs-only.