### PR TITLE
chore(gitignore): ignore .env and generated Metal test dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ crates/*/Cargo.lock
 /compile_commands.json
 .cache
 
+# Local environment / secrets — never commit
+.env
+
 # Python
 __pycache__/
 *.pyc
@@ -36,6 +39,11 @@ __pycache__/
 debug_trace.csv
 # Per-run CDC-jitter seed dump written next to the fixture goldens.
 run_params.json
+# Generated Metal test dumps — produced by the Metal test run and uploaded as
+# the `metal-outputs` CI artifact, never committed (see that step in
+# .github/workflows/test.yml). The .vcd outputs are already covered by *.vcd.
+/metal_*.txt
+timing_report_metal.json
 *_watchlist.json
 api_artifacts/
 tb_verify_sim


### PR DESCRIPTION
Closes three `.gitignore` gaps — files that were untracked-but-not-ignored, so a
careless `git add` could commit them:

- **`.env`** — local secrets, never commit.
- **`/metal_*.txt`** and **`timing_report_metal.json`** — generated by the Metal
  test run and uploaded as the `metal-outputs` CI artifact (see the upload step in
  `.github/workflows/test.yml`); not goldens.

Scoped precisely: the Metal `.vcd` outputs in that same artifact set are already
covered by the existing `*.vcd` rule (tracked goldens stay via the
`!…/expected/*.vcd` negations), and `run_params.json` was already ignored — so only
these three needed adding. Verified `git check-ignore` matches all three and does
**not** match any tracked golden (`inv_chain_stimulus.vcd`, `mcu_flash.vcd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
